### PR TITLE
Circle image tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - docker-build:
-        image_name: ap-airflow-buster
-        path: 1.10.5/buster
+          image_name: ap-airflow-buster
+          path: 1.10.5/buster
       - run:
           name: "Tag image"
           command: docker tag ap-airflow-buster astronomerinc/ap-airflow:1.10.5-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,9 @@ workflows:
       - scan-alpine:
           requires:
             - build-alpine
-      - publish-dev-alpine:
-          requires:
-            - scan-alpine
+      # - publish-dev-alpine:
+      #     requires:
+      #       - scan-alpine
       - publish-prod-alpine:
           requires:
             - scan-alpine
@@ -93,9 +93,9 @@ workflows:
       - scan-buster:
           requires:
             - build-buster
-      - publish-dev-buster:
-          requires:
-            - scan-buster
+      # - publish-dev-buster:
+      #     requires:
+      #       - scan-buster
       - publish-prod-buster:
           requires:
             - scan-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,14 @@ jobs:
   build-alpine:
     executor: docker-executor
     steps:
+      - checkout
+      - setup_remote_docker
       - docker-build:
           image_name: ap-airflow-alpine
           path: 1.10.5/alpine3.10
+      - run:
+          name: "Tag image"
+          command: docker tag ap-airflow-alpine astronomerinc/ap-airflow:1.10.5-alpine3.10
       - docker-build:
           image_name: ap-airflow-alpine-onbuild
           path: 1.10.5/alpine3.10/onbuild
@@ -17,13 +22,11 @@ jobs:
     steps:
       - clair-scan:
           image_name: ap-airflow-alpine
-  # publish-dev-alpine:
-  #   executor: docker-executor
-  #   steps:
-  #     - push:
-  #         comma_separated_tags: "1.10.5-alpine3.10-$CIRCLE_SHA1"
-  #         image_name_load: ap-airflow-alpine
-  #         image_name_publish: ap-airflow
+  scan-alpine-onbuild:
+    executor: clair-scanner/default
+    steps:
+      - clair-scan:
+          image_name: ap-airflow-alpine-onbuild
   publish-prod-alpine:
     executor: docker-executor
     steps:
@@ -31,20 +34,27 @@ jobs:
           comma_separated_tags: "1.10.5-alpine,1.10.5-alpine3.10"
           image_name_load: ap-airflow-alpine
           image_name_publish: ap-airflow
+  publish-prod-alpine-onbuild:
+    executor: docker-executor
+    steps:
       - push:
           comma_separated_tags: "1.10.5-alpine-onbuild,1.10.5-alpine3.10-onbuild"
           image_name_load: ap-airflow-alpine-onbuild
           image_name_publish: ap-airflow
-
   #
   # Debian
   #
   build-buster:
     executor: docker-executor
     steps:
+      - checkout
+      - setup_remote_docker
       - docker-build:
           image_name: ap-airflow-buster
           path: 1.10.5/buster
+      - run:
+          name: "Tag image"
+          command: docker tag ap-airflow-alpine astronomerinc/ap-airflow:1.10.5-buster
       - docker-build:
           image_name: ap-airflow-buster-onbuild
           path: 1.10.5/buster/onbuild
@@ -53,13 +63,11 @@ jobs:
     steps:
       - clair-scan:
           image_name: ap-airflow-buster
-  # publish-dev-buster:
-  #   executor: docker-executor
-  #   steps:
-  #     - push:
-  #         comma_separated_tags: "1.10.5-buster-$CIRCLE_SHA1"
-  #         image_name_load: ap-airflow-buster
-  #         image_name_publish: ap-airflow
+  scan-buster-onbuild:
+    executor: clair-scanner/default
+    steps:
+      - clair-scan:
+          image_name: ap-airflow-buster-onbuild
   publish-prod-buster:
     executor: docker-executor
     steps:
@@ -67,6 +75,9 @@ jobs:
           comma_separated_tags: "1.10.5-buster"
           image_name_load: ap-airflow-buster
           image_name_publish: ap-airflow
+  publish-prod-buster-onbuild:
+    executor: docker-executor
+    steps:
       - push:
           comma_separated_tags: "1.10.5-buster-onbuild"
           image_name_load: ap-airflow-buster-onbuild
@@ -80,12 +91,20 @@ workflows:
       - scan-alpine:
           requires:
             - build-alpine
-      # - publish-dev-alpine:
-      #     requires:
-      #       - scan-alpine
+      - scan-alpine-onbuild:
+          requires:
+            - build-alpine
       - publish-prod-alpine:
           requires:
             - scan-alpine
+            - scan-alpine-onbuild
+          filters:
+            branches:
+              only: master
+      - publish-prod-alpine-onbuild:
+          requires:
+            - scan-alpine
+            - scan-alpine-onbuild
           filters:
             branches:
               only: master
@@ -93,12 +112,20 @@ workflows:
       - scan-buster:
           requires:
             - build-buster
-      # - publish-dev-buster:
-      #     requires:
-      #       - scan-buster
+      - scan-buster-onbuild:
+          requires:
+            - build-buster
       - publish-prod-buster:
           requires:
             - scan-buster
+            - scan-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish-prod-buster-onbuild:
+          requires:
+            - scan-buster
+            - scan-buster-onbuild
           filters:
             branches:
               only: master
@@ -124,8 +151,6 @@ commands:
         type: string
         default: $CIRCLE_PROJECT_REPONAME
     steps:
-      - checkout
-      - setup_remote_docker
       - run:
           name: Build the Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - docker-build:
           image_name: ap-airflow-alpine
           path: 1.10.5/alpine3.10
-      - docker-build-onbuild:
+      - docker-build:
           image_name: ap-airflow-alpine-onbuild
           path: 1.10.5/alpine3.10/onbuild
   scan-alpine:
@@ -45,7 +45,7 @@ jobs:
       - docker-build:
           image_name: ap-airflow-buster
           path: 1.10.5/buster
-      - docker-build-onbuild:
+      - docker-build:
           image_name: ap-airflow-buster-onbuild
           path: 1.10.5/buster/onbuild
   scan-buster:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ jobs:
     executor: docker-executor
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - docker-build:
           image_name: ap-airflow-alpine
           path: 1.10.5/alpine3.10
@@ -48,7 +49,8 @@ jobs:
     executor: docker-executor
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
       - docker-build:
           image_name: ap-airflow-buster
           path: 1.10.5/buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,54 +1,75 @@
 version: 2.1
 jobs:
+  #
+  # Alpine
+  #
   build-alpine:
     executor: docker-executor
     steps:
       - docker-build:
           image_name: ap-airflow-alpine
           path: 1.10.5/alpine3.10
+      - docker-build-onbuild:
+          image_name: ap-airflow-alpine-onbuild
+          path: 1.10.5/alpine3.10/onbuild
   scan-alpine:
     executor: clair-scanner/default
     steps:
       - clair-scan:
           image_name: ap-airflow-alpine
-  publish-dev-alpine:
-    executor: docker-executor
-    steps:
-      - push:
-          comma_separated_tags: "1.10.5-alpine3.10-$CIRCLE_SHA1,1.10.5-alpine3.10-$CIRCLE_BUILD_NUM"
-          image_name_load: ap-airflow-alpine
-          image_name_publish: ap-airflow
+  # publish-dev-alpine:
+  #   executor: docker-executor
+  #   steps:
+  #     - push:
+  #         comma_separated_tags: "1.10.5-alpine3.10-$CIRCLE_SHA1"
+  #         image_name_load: ap-airflow-alpine
+  #         image_name_publish: ap-airflow
   publish-prod-alpine:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "1.10.5-alpine,1.10.5-alpine3.10,1.10.5-alpine-onbuild,1.10.5-alpine3.10-onbuild"
+          comma_separated_tags: "1.10.5-alpine,1.10.5-alpine3.10"
           image_name_load: ap-airflow-alpine
           image_name_publish: ap-airflow
+      - push:
+          comma_separated_tags: "1.10.5-alpine-onbuild,1.10.5-alpine3.10-onbuild"
+          image_name_load: ap-airflow-alpine-onbuild
+          image_name_publish: ap-airflow
+
+  #
+  # Debian
+  #
   build-buster:
     executor: docker-executor
     steps:
       - docker-build:
           image_name: ap-airflow-buster
           path: 1.10.5/buster
+      - docker-build-onbuild:
+          image_name: ap-airflow-buster-onbuild
+          path: 1.10.5/buster/onbuild
   scan-buster:
     executor: clair-scanner/default
     steps:
       - clair-scan:
           image_name: ap-airflow-buster
-  publish-dev-buster:
-    executor: docker-executor
-    steps:
-      - push:
-          comma_separated_tags: "1.10.5-buster-$CIRCLE_SHA1,1.10.5-buster-$CIRCLE_BUILD_NUMBER"
-          image_name_load: ap-airflow-buster
-          image_name_publish: ap-airflow
+  # publish-dev-buster:
+  #   executor: docker-executor
+  #   steps:
+  #     - push:
+  #         comma_separated_tags: "1.10.5-buster-$CIRCLE_SHA1"
+  #         image_name_load: ap-airflow-buster
+  #         image_name_publish: ap-airflow
   publish-prod-buster:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "1.10.5-buster,1.10.5-buster-onbuild"
-          image_name_load: ap-airflow-alpine
+          comma_separated_tags: "1.10.5-buster"
+          image_name_load: ap-airflow-buster
+          image_name_publish: ap-airflow
+      - push:
+          comma_separated_tags: "1.10.5-buster-onbuild"
+          image_name_load: ap-airflow-buster-onbuild
           image_name_publish: ap-airflow
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   #
   # Alpine
   #
+
+  # Build Alpine Images
   build-alpine:
     executor: docker-executor
     steps:
@@ -18,6 +20,8 @@ jobs:
       - docker-build:
           image_name: ap-airflow-alpine-onbuild
           path: 1.10.5/alpine3.10/onbuild
+
+  # Scan Alpine Images
   scan-alpine:
     executor: clair-scanner/default
     steps:
@@ -28,23 +32,28 @@ jobs:
     steps:
       - clair-scan:
           image_name: ap-airflow-alpine-onbuild
+
+  # Publish Alpine Images
   publish-prod-alpine:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "1.10.5-alpine,1.10.5-alpine3.10"
+          comma_separated_tags: "1.10.5-alpine3.10,1.10.5-alpine"
           image_name_load: ap-airflow-alpine
-          image_name_publish: ap-airflow
+          image_repo: ap-airflow
   publish-prod-alpine-onbuild:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "1.10.5-alpine-onbuild,1.10.5-alpine3.10-onbuild"
+          comma_separated_tags: "1.10.5-alpine3.10-onbuild,1.10.5-alpine-onbuild"
           image_name_load: ap-airflow-alpine-onbuild
-          image_name_publish: ap-airflow
+          image_repo: ap-airflow
+
   #
   # Debian
   #
+  
+  # Build Debian Images
   build-buster:
     executor: docker-executor
     steps:
@@ -52,7 +61,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - docker-build:
-          image_name: ap-airflow-buster
+        image_name: ap-airflow-buster
           path: 1.10.5/buster
       - run:
           name: "Tag image"
@@ -60,6 +69,8 @@ jobs:
       - docker-build:
           image_name: ap-airflow-buster-onbuild
           path: 1.10.5/buster/onbuild
+
+  # Scan Debian Images
   scan-buster:
     executor: clair-scanner/default
     steps:
@@ -70,20 +81,22 @@ jobs:
     steps:
       - clair-scan:
           image_name: ap-airflow-buster-onbuild
+
+  # Publish Debian Images
   publish-prod-buster:
     executor: docker-executor
     steps:
       - push:
           comma_separated_tags: "1.10.5-buster"
           image_name_load: ap-airflow-buster
-          image_name_publish: ap-airflow
+          image_repo: ap-airflow
   publish-prod-buster-onbuild:
     executor: docker-executor
     steps:
       - push:
           comma_separated_tags: "1.10.5-buster-onbuild"
           image_name_load: ap-airflow-buster-onbuild
-          image_name_publish: ap-airflow
+          image_repo: ap-airflow
 
 workflows:
   version: 2.1
@@ -190,7 +203,7 @@ commands:
       image_name_load:
         type: string
         default: $CIRCLE_PROJECT_REPONAME
-      image_name_publish:
+      image_repo:
         type: string
         default: $CIRCLE_PROJECT_REPONAME
     steps:
@@ -210,7 +223,7 @@ commands:
             for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
             do
               set -x
-              docker tag << parameters.image_name_load >> << parameters.organization >>/<< parameters.image_name_publish >>:${tag}
-              docker push << parameters.organization >>/<< parameters.image_name_publish >>:${tag}
+              docker tag << parameters.image_name_load >> << parameters.organization >>/<< parameters.image_repo >>:${tag}
+              docker push << parameters.organization >>/<< parameters.image_repo >>:${tag}
               set +x
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           docker_layer_caching: true
       - docker-build:
         image_name: ap-airflow-buster
-          path: 1.10.5/buster
+        path: 1.10.5/buster
       - run:
           name: "Tag image"
           command: docker tag ap-airflow-buster astronomerinc/ap-airflow:1.10.5-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           path: 1.10.5/buster
       - run:
           name: "Tag image"
-          command: docker tag ap-airflow-alpine astronomerinc/ap-airflow:1.10.5-buster
+          command: docker tag ap-airflow-buster astronomerinc/ap-airflow:1.10.5-buster
       - docker-build:
           image_name: ap-airflow-buster-onbuild
           path: 1.10.5/buster/onbuild


### PR DESCRIPTION
@sjmiller609 commenting out the dev ones for now. It kind of clutters up the repo. I want to think about those some more.

Also, the `onbuild` images are actually separate images, not additional tags on the original images. I've made some changes, but am hitting an issue with these builds. Trying to run the `onbuild` step right after the base image is built in both distros. For some reason its failing.