### PR TITLE
Add testing for Airflow images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,16 @@ jobs:
       - docker-build:
           image_name: ap-airflow-alpine-onbuild
           path: 1.10.5/alpine3.10/onbuild
+  test-alpine:
+    executor: docker-executor
+    steps:
+      - airflow-image-test:
+          image_name: ap-airflow-alpine
+  test-alpine-onbuild:
+    executor: docker-executor
+    steps:
+      - airflow-image-test:
+          image_name: ap-airflow-alpine-onbuild
   scan-alpine:
     executor: clair-scanner/default
     steps:
@@ -60,6 +70,16 @@ jobs:
       - docker-build:
           image_name: ap-airflow-buster-onbuild
           path: 1.10.5/buster/onbuild
+  test-buster:
+    executor: docker-executor
+    steps:
+      - airflow-image-test:
+          image_name: ap-airflow-buster
+  test-buster-onbuild:
+    executor: docker-executor
+    steps:
+      - airflow-image-test:
+          image_name: ap-airflow-buster-onbuild
   scan-buster:
     executor: clair-scanner/default
     steps:
@@ -96,10 +116,18 @@ workflows:
       - scan-alpine-onbuild:
           requires:
             - build-alpine
+      - test-alpine:
+          requires:
+            - build-alpine
+      - test-alpine-onbuild:
+          requires:
+            - build-alpine
       - publish-prod-alpine:
           requires:
             - scan-alpine
             - scan-alpine-onbuild
+            - test-alpine
+            - test-alpine-onbuild
           filters:
             branches:
               only: master
@@ -107,10 +135,18 @@ workflows:
           requires:
             - scan-alpine
             - scan-alpine-onbuild
+            - test-alpine
+            - test-alpine-onbuild
           filters:
             branches:
               only: master
       - build-buster
+      - test-buster:
+          requires:
+            - build-buster
+      - test-buster-onbuild:
+          requires:
+            - build-buster
       - scan-buster:
           requires:
             - build-buster
@@ -121,6 +157,8 @@ workflows:
           requires:
             - scan-buster
             - scan-buster-onbuild
+            - test-buster
+            - test-buster-onbuild
           filters:
             branches:
               only: master
@@ -128,6 +166,8 @@ workflows:
           requires:
             - scan-buster
             - scan-buster-onbuild
+            - test-buster
+            - test-buster-onbuild
           filters:
             branches:
               only: master
@@ -178,6 +218,40 @@ commands:
           command: mkdir /tmp/tarballs && mv /tmp/workspace/<< parameters.image_name >>.tar /tmp/tarballs/
       - clair-scanner/scan:
           docker_tar_dir: /tmp/tarballs
+  airflow-image-test:
+    description: Test an Airflow image
+    parameters:
+      image_name:
+        type: string
+        default: $CIRCLE_PROJECT_REPONAME
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Airflow Docker image
+          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+      - run:
+          name: Set up test environment
+          command: |
+            set -xe
+            pip install virtualenv
+            virtualenv --python=python3 ./venv
+            source ./venv/bin/activate
+            pip install -r .circleci/test-requirements.txt
+      - run:
+          name: Test Airflow Docker image
+          command: |
+            set -xe
+            source ./venv/bin/activate
+            export AIRFLOW_IMAGE='<< parameters.image_name >>'
+            mkdir -p test-reports
+            pytest .circle-ci/test-airflow-image.py --junitxml=test-reports/airflow-test-<< parameters.image_name >>.xml
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
   push:
     description: "Push a Docker image to DockerHub"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
   #
   # Debian
   #
-  
+
   # Build Debian Images
   build-buster:
     executor: docker-executor
@@ -189,7 +189,7 @@ executors:
     environment:
       GIT_ORG: astronomerinc
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: circleci/python:3
 commands:
   docker-build:
     description: "Build a Docker image"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ commands:
             source ./venv/bin/activate
             export AIRFLOW_IMAGE='<< parameters.image_name >>'
             mkdir -p test-reports
-            pytest .circle-ci/test-airflow-image.py --junitxml=test-reports/airflow-test-<< parameters.image_name >>.xml
+            pytest .circleci/test-airflow-image.py --junitxml=test-reports/airflow-test-<< parameters.image_name >>.xml
       - store_test_results:
           path: test-reports
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
   #
   # Debian
   #
-
   # Build Debian Images
   build-buster:
     executor: docker-executor

--- a/.circleci/test-airflow-image.py
+++ b/.circleci/test-airflow-image.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import pytest
+import subprocess
+import testinfra
+import docker
+
+from time import sleep, time
+from packaging.version import parse as semantic_version
+
+def get_image_name():
+    try:
+        return os.environ['AIRFLOW_IMAGE']
+    except KeyError:
+        raise Exception("Please provide docker image name to pytest using environment variable AIRFLOW_IMAGE")
+
+def get_label(client, label):
+    image_name = get_image_name()
+    image = client.images.get(image_name)
+    try:
+        return image.labels[label]
+    except KeyError:
+        raise Exception(f"Image should have a label '{label}'")
+
+def start_postgres():
+    docker_client = docker.from_env()
+    try:
+        postgres = docker_client.containers.get('postgres')
+    except docker.errors.NotFound:
+        return subprocess.check_output(
+            ['docker', 'run',
+             '--name', 'postgres',
+             '-e', 'POSTGRES_PASSWORD=notsecretpassword',
+             '-d', 'postgres:9.6.15']
+        ).decode().strip()
+    return postgres.short_id
+
+def get_ip_from_id(_id):
+    return subprocess.check_output(
+        ['docker', 'inspect',
+         '-f', '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
+         _id]
+    ).decode().strip()
+
+@pytest.fixture(scope='session')
+def webserver(request):
+
+    docker_id_db = start_postgres()
+    db_connection_string = f"postgres://postgres:notsecretpassword@{get_ip_from_id(docker_id_db)}:5432"
+    docker_id = subprocess.check_output(
+        ['docker', 'run',
+         '--name', 'webserver',
+         '-e', f"AIRFLOW__CORE__SQL_ALCHEMY_CONN={db_connection_string}",
+         '-d', get_image_name(), 'airflow', 'webserver']).decode().strip()
+
+    yield testinfra.get_host("docker://" + docker_id)
+
+    subprocess.check_call(['docker', 'rm', '-f', docker_id, docker_id_db])
+
+@pytest.fixture(scope='session')
+def docker_client(request):
+    client = docker.from_env()
+    yield client
+    client.close()
+
+def test_airflow_in_path(webserver):
+    assert webserver.exists('airflow'), \
+        "Expected 'airflow' to be in PATH"
+
+def test_maintainer(webserver, docker_client):
+    maintainer  = get_label(docker_client, 'maintainer')
+    assert maintainer  == "Astronomer <humans@astronomer.io>", \
+        "'maintainer' label should be 'Astronomer <humans@astronomer.io>'"
+
+def test_version(webserver, docker_client):
+    airflow_version = get_label(docker_client, 'io.astronomer.docker.airflow.version')
+    version_output = webserver.check_output('airflow version')
+    assert airflow_version in version_output
+
+def test_elasticsearch_version(webserver):
+    try:
+        elasticsearch_module = webserver.pip_package.get_packages()['elasticsearch']
+    except KeyError:
+        raise Exception("elasticsearch pip module is not installed")
+    version = elasticsearch_module['version']
+    assert semantic_version(version) >= semantic_version('5.5.3'), \
+        "elasticsearch module must be version 5.5.3 or greater"

--- a/.circleci/test-airflow-image.py
+++ b/.circleci/test-airflow-image.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+"""
+This file is for configuration testing Airflow images.
+The Airflow image is started in Docker, configured to access an
+instance of postgres, which is also running in Docker.
+
+Testinfra is used to configuration test the image. In effect,
+testinfra simplifies and provides syntactic sugar for doing
+execs into a running container.
+"""
 
 import os
 import sys
@@ -12,12 +21,17 @@ from time import sleep, time
 from packaging.version import parse as semantic_version
 
 def get_image_name():
+    """ Fetch image name from an environment variable
+    and inform the user if they are not using it right
+    """
     try:
         return os.environ['AIRFLOW_IMAGE']
     except KeyError:
         raise Exception("Please provide docker image name to pytest using environment variable AIRFLOW_IMAGE")
 
 def get_label(client, label):
+    """ Fetch the value of a label from the image
+    """
     image_name = get_image_name()
     image = client.images.get(image_name)
     try:
@@ -26,6 +40,8 @@ def get_label(client, label):
         raise Exception(f"Image should have a label '{label}'")
 
 def start_postgres():
+    """ Idempotently start a Postgres database
+    """
     docker_client = docker.from_env()
     try:
         postgres = docker_client.containers.get('postgres')
@@ -39,6 +55,8 @@ def start_postgres():
     return postgres.short_id
 
 def get_ip_from_id(_id):
+    """ Return the Docker private network IP of a given Docker container ID
+    """
     return subprocess.check_output(
         ['docker', 'inspect',
          '-f', '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
@@ -47,7 +65,10 @@ def get_ip_from_id(_id):
 
 @pytest.fixture(scope='session')
 def webserver(request):
-
+    """ This is the host fixture for testinfra. To read more, please see
+    the testinfra documentation:
+    https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
+    """
     docker_id_db = start_postgres()
     db_connection_string = f"postgres://postgres:notsecretpassword@{get_ip_from_id(docker_id_db)}:5432"
     docker_id = subprocess.check_output(
@@ -62,25 +83,37 @@ def webserver(request):
 
 @pytest.fixture(scope='session')
 def docker_client(request):
+    """ This is a text fixture for the docker client,
+    should it be needed in a test
+    """
     client = docker.from_env()
     yield client
     client.close()
 
 def test_airflow_in_path(webserver):
+    """ Ensure Airflow is in PATH
+    """
     assert webserver.exists('airflow'), \
         "Expected 'airflow' to be in PATH"
 
 def test_maintainer(webserver, docker_client):
+    """ Ensure the Docker image label 'maintainer' is set correctly
+    """
     maintainer  = get_label(docker_client, 'maintainer')
     assert maintainer  == "Astronomer <humans@astronomer.io>", \
         "'maintainer' label should be 'Astronomer <humans@astronomer.io>'"
 
 def test_version(webserver, docker_client):
+    """ Ensure the version of Airflow matches the Docker image label
+    """
     airflow_version = get_label(docker_client, 'io.astronomer.docker.airflow.version')
     version_output = webserver.check_output('airflow version')
     assert airflow_version in version_output
 
 def test_elasticsearch_version(webserver):
+    """ Astronomer runs a version of ElasticSearch that requires
+    our users to run the client code of version 5.5.3 or greater
+    """
     try:
         elasticsearch_module = webserver.pip_package.get_packages()['elasticsearch']
     except KeyError:

--- a/.circleci/test-requirements.txt
+++ b/.circleci/test-requirements.txt
@@ -1,0 +1,2 @@
+testinfra==3.2.1
+docker==4.1.0

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+**What this PR does / why we need it**:
+
+**Special notes for your reviewer**:
+
+#### Checklist
+[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
+- [ ] No new image, or image added to .circleci/config.yml jobs and workflow
+- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Astronomer Certified Airflow Docker Images
 
+[![CircleCI](https://circleci.com/gh/astronomer/ap-airflow/tree/master.svg?style=svg)](https://circleci.com/gh/astronomer/ap-airflow/tree/master)
+
 Astronomer makes it easy to run, monitor, and scale [Apache Airflow](https://github.com/apache/airflow) deployments in our cloud or yours. Source code is made available for the benefit of customers.
 
 If you'd like to see the platform in action, [start a free trial on our SaaS service, Astronomer Cloud](https://astronomer.io/trial) and run through our [getting started guide](https://www.astronomer.io/docs/getting-started/). This is a good first step, even if you're ultimately interested in running Astronomer in your own Kubernetes cluster.


### PR DESCRIPTION
Adding testing for Airflow images. These will run at the same time as the clair scan.

It uses the following tooling:
- pytest
- docker
- testinfra

it does so like this:
- start postgres and airflow webserver (from image) using docker
- use pytest to run tests against the live, running container
- use testinfra for utility functions and syntactic sugar
example: 
the utility functions for configuration testing are provided by testinfra
```
def test_airflow_in_path(webserver):
    assert webserver.exists('airflow'), \
        "Expected 'airflow' to be in PATH"
```