### PR TITLE
Add common tags to publish list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,14 @@ jobs:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "1.10.5-alpine3.10,1.10.5-alpine"
+          comma_separated_tags: "1.10.5-alpine3.10,1.10.5-alpine,1.10.5,latest"
           image_name_load: ap-airflow-alpine
           image_repo: ap-airflow
   publish-prod-alpine-onbuild:
     executor: docker-executor
     steps:
       - push:
-          comma_separated_tags: "1.10.5-alpine3.10-onbuild,1.10.5-alpine-onbuild"
+          comma_separated_tags: "1.10.5-alpine3.10-onbuild,1.10.5-alpine-onbuild,1.10.5-onbuild,latest-onbuild"
           image_name_load: ap-airflow-alpine-onbuild
           image_repo: ap-airflow
 


### PR DESCRIPTION
This PR adds more common tags to our publish list for alpine. The addition of https://github.com/astronomer/houston-api/pull/177, gives us a way to control the airflow version at the platform level and expose it to the CLI for `astro dev init`.

This new `latest-onbuild` tag can serve as a fallback tag in the event of an error or before the user is connected to a cluster.

These should only be used in this fallback situation, or for convenience if you know what you are doing. These will not be used in any normal workflow.

Related to https://github.com/astronomer/issues/issues/596