### PR TITLE
Wait for db on airflow run commands

### DIFF
--- a/1.10.5/alpine3.10/include/entrypoint
+++ b/1.10.5/alpine3.10/include/entrypoint
@@ -11,7 +11,7 @@ fi
 CMD=$2
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker)$ ]]; then
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run)$ ]]; then
   # Wait for database port to open up
   HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
   PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')

--- a/1.10.5/buster/include/entrypoint
+++ b/1.10.5/buster/include/entrypoint
@@ -10,7 +10,7 @@ set -e
 CMD=$2
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker)$ ]]; then
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run)$ ]]; then
   # Wait for database port to open up
   HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
   PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')


### PR DESCRIPTION
Should help fix https://github.com/astronomer/issues/issues/578 for the `KubernetesExecutor`. This will wait until the pod can reach pgbouncer, ensuring that the istio-proxy is up and running.