### PR TITLE
Update astronomer-airflow-scripts to 0.0.3

### DIFF
--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -94,7 +94,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/1.10.5/alpi
 	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
-	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.2/astronomer_airflow_scripts-0.0.2-py3-none-any.whl" \
+	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.3/astronomer_airflow_scripts-0.0.3-py3-none-any.whl" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl" \
 	&& cd /usr/lib/python3.7/site-packages/airflow/www_rbac \
 	&& npm install \

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -116,7 +116,7 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
 RUN pip install "${AIRFLOW_MODULE}" \
-  && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.2/astronomer_airflow_scripts-0.0.2-py3-none-any.whl" \
+  && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.3/astronomer_airflow_scripts-0.0.3-py3-none-any.whl" \
   && pip install "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl"
 
 RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -59,6 +59,7 @@ RUN pip3.6 install --no-cache-dir cryptography  \
      &&	 pip3.6 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
      &&	 pip3.6 install --no-cache-dir "${AIRFLOW_MODULE}" \
      &&	 pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl" \
+     &&  pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.3/astronomer_airflow_scripts-0.0.3-py3-none-any.whl" \
      &&  cd /usr/local/lib/python3.6/site-packages/airflow/www_rbac \
      &&  /node-v12.13.1-linux-x64/bin/npm install \
      &&  /node-v12.13.1-linux-x64/bin/npm run build


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes the "migration spinner" script to cope with multiple Alembic
heads foundin Airflow 1.10.5


Fixes astronomer/issues#633

**Special notes for your reviewer**:

#### Checklist
- [x] No new image, or image added to .circleci/config.yml jobs and workflow