### PR TITLE
Wait for pgbouncer for initdb/upgradedb

### DIFF
--- a/1.10.5/alpine3.10/include/entrypoint
+++ b/1.10.5/alpine3.10/include/entrypoint
@@ -11,7 +11,7 @@ fi
 CMD=$2
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run)$ ]]; then
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run|initdb|upgradedb)$ ]]; then
   # Wait for database port to open up
   HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
   PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')

--- a/1.10.5/buster/include/entrypoint
+++ b/1.10.5/buster/include/entrypoint
@@ -10,7 +10,7 @@ set -e
 CMD=$2
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run)$ ]]; then
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run|initdb|upgradedb)$ ]]; then
   # Wait for database port to open up
   HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
   PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')

--- a/1.10.5/rhel7/include/entrypoint
+++ b/1.10.5/rhel7/include/entrypoint
@@ -11,7 +11,7 @@ fi
 CMD=$2
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run)$ ]]; then
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker|run|initdb|upgradedb)$ ]]; then
   # Wait for database port to open up
   HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
   PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')


### PR DESCRIPTION
Saw some pgbouncer connection issues in the logs of the schedulers init container before actually running the migrations. This will allow the schedulers migration init container to wait until pgbouncer is up like the other commands.

New init container here:
https://github.com/astronomer/helm.astronomer.io/blob/master/charts/airflow/templates/scheduler/scheduler-deployment.yaml#L75