### PR TITLE
Include the pip constraint file in the final output image

### DIFF
--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -144,6 +144,9 @@ RUN apt-get update \
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
 COPY --from=devel /usr/local/bin /usr/local/bin
 
+# Force pip to install these specific versions when ever it installs a module
+ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
+COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Create logs directory, so we can own it when we mount volumes
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \


### PR DESCRIPTION
We want these constraints to apply to anything installed via the
`ONBUILD` images.

Fixes astronomer/issues#640

I don't quite get why the `ENV` was copied across from the "wrong" multi-stage build but.... we want this file anyway, so lets just copy it in to the final image too.
