### PR TITLE
CVE-2019-19603 (sqlite3) is safe for us

### DIFF
--- a/cve-whitelist.yaml
+++ b/cve-whitelist.yaml
@@ -1,3 +1,4 @@
 generalwhitelist:
   CVE-2019-5482: curl
   CVE-2019-18224: libidn2
+  CVE-2019-19603: sqlite3


### PR DESCRIPTION
It only leads to application crash, and sqlite3 isn't used outside of
testing anyway.
