### PR TITLE
Correctly publish onbuild images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,8 @@ workflows:
             - build-1.10.5-alpine3.10
       - publish:
           name: publish-1.10.5-alpine3.10
-          airflow_version: 1.10.5
-          distribution_name: alpine3.10
-          comma_separated_tags: "1.10.5-alpine3.10,1.10.5-alpine3.10-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.5-alpine3.10"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-alpine3.10
             - test-1.10.5-alpine3.10
@@ -48,9 +47,8 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.5-alpine3.10-onbuild
-          airflow_version: 1.10.5
-          distribution_name: alpine3.10
-          comma_separated_tags: "1.10.5-alpine3.10-onbuild,1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.5-alpine3.10-onbuild"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - test-1.10.5-alpine3.10-onbuild
@@ -88,9 +86,8 @@ workflows:
             - build-1.10.5-buster
       - publish:
           name: publish-1.10.5-buster
-          airflow_version: 1.10.5
-          distribution_name: buster
-          comma_separated_tags: "1.10.5-buster,1.10.5-buster-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.5-buster"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-buster
             - test-1.10.5-buster
@@ -99,9 +96,8 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.5-buster-onbuild
-          airflow_version: 1.10.5
-          distribution_name: buster
-          comma_separated_tags: "1.10.5-buster-onbuild,1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.5-buster-onbuild"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-buster-onbuild
             - test-1.10.5-buster-onbuild
@@ -139,9 +135,8 @@ workflows:
             - build-1.10.5-rhel7
       - publish:
           name: publish-1.10.5-rhel7
-          airflow_version: 1.10.5
-          distribution_name: rhel7
-          comma_separated_tags: "1.10.5-rhel7,1.10.5-rhel7-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.5-rhel7"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-rhel7
             - test-1.10.5-rhel7
@@ -150,9 +145,8 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.5-rhel7-onbuild
-          airflow_version: 1.10.5
-          distribution_name: rhel7
-          comma_separated_tags: "1.10.5-rhel7-onbuild,1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.5-rhel7-onbuild"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - test-1.10.5-rhel7-onbuild
@@ -192,9 +186,8 @@ workflows:
             - build-1.10.6-alpine3.10
       - publish:
           name: publish-1.10.6-alpine3.10
-          airflow_version: 1.10.6
-          distribution_name: alpine3.10
-          comma_separated_tags: "1.10.6-alpine3.10,1.10.6-alpine3.10-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.6-alpine3.10"
+          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-alpine3.10
             - test-1.10.6-alpine3.10
@@ -203,9 +196,8 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.6-alpine3.10-onbuild
-          airflow_version: 1.10.6
-          distribution_name: alpine3.10
-          comma_separated_tags: "1.10.6-alpine3.10-onbuild,1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.6-alpine3.10-onbuild"
+          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - test-1.10.6-alpine3.10-onbuild
@@ -243,9 +235,8 @@ workflows:
             - build-1.10.6-buster
       - publish:
           name: publish-1.10.6-buster
-          airflow_version: 1.10.6
-          distribution_name: buster
-          comma_separated_tags: "1.10.6-buster,1.10.6-buster-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.6-buster"
+          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-buster
             - test-1.10.6-buster
@@ -254,9 +245,8 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.6-buster-onbuild
-          airflow_version: 1.10.6
-          distribution_name: buster
-          comma_separated_tags: "1.10.6-buster-onbuild,1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          tag: "1.10.6-buster-onbuild"
+          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-buster-onbuild
             - test-1.10.6-buster-onbuild
@@ -272,11 +262,9 @@ jobs:
     parameters:
       airflow_version:
         description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
         type: string
       distribution_name:
         description: "The base distribution of the container"
-        default: "alpine"
         type: string
     steps:
       - docker-build-base-and-onbuild:
@@ -288,56 +276,44 @@ jobs:
     parameters:
       airflow_version:
         description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
         type: string
       distribution_name:
         description: "The base distribution of the container"
-        default: "alpine"
         type: string
     steps:
       - airflow-image-test:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
   scan:
     executor: clair-scanner/default
     description: Test Airflow images
     parameters:
       airflow_version:
         description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
         type: string
       distribution_name:
         description: "The base distribution of the container"
-        default: "alpine"
         type: string
     steps:
       - clair-scan:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
   publish:
     executor: docker-executor
     description: Publish Airflow images
     parameters:
-      airflow_version:
-        description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
+      tag:
         type: string
-      distribution_name:
-        description: "The base distribution of the container"
-        default: "alpine"
+      extra_tags:
         type: string
-      comma_separated_tags:
-        default: "alpine"
-        type: string
+        default: ""
     steps:
       - push:
-          comma_separated_tags: "<< parameters.comma_separated_tags >>"
-          image_name_load: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
-          image_repo: ap-airflow
+          extra_tags: "<< parameters.extra_tags >>"
+          tag: "<< parameters.tag >>"
+          image_name: "astronomerinc/ap-airflow"
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:
-    environment:
-      GIT_ORG: astronomerinc
     docker:
       - image: circleci/python:3
 commands:
@@ -356,15 +332,15 @@ commands:
       - setup_remote_docker:
           docker_layer_caching: true
       - docker-build:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
           path: "<< parameters.airflow_version >>/<< parameters.distribution_name >>"
-      - run:
-          name: "Tag image"
-          command: |
-            docker tag ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >> ${GIT_ORG}/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>
       - docker-build:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>-onbuild"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>-onbuild"
           path: "<< parameters.airflow_version >>/<< parameters.distribution_name >>/onbuild"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - saved-images/
   docker-build:
     description: "Build a Docker image"
     parameters:
@@ -382,13 +358,9 @@ commands:
           name: Build the Docker image
           command: |
             set -xe
-            image_name="<< parameters.image_name >>"
-            docker build -t $image_name --file << parameters.path>>/<< parameters.dockerfile >> --build-arg BUILD_NUMBER=${CIRCLE_BUILD_NUM} --build-arg REPO_BRANCH=${CIRCLE_BRANCH} << parameters.path >>
-            docker save -o << parameters.image_name >>.tar $image_name
-      - persist_to_workspace:
-          root: .
-          paths:
-            - './*.tar'
+            mkdir -p saved-images/"$(dirname "<< parameters.image_name >>")"
+            docker build -t "<< parameters.image_name >>" --file << parameters.path>>/<< parameters.dockerfile >> --build-arg BUILD_NUMBER=${CIRCLE_BUILD_NUM} --build-arg REPO_BRANCH=${CIRCLE_BRANCH} << parameters.path >>
+            docker save -o saved-images/<< parameters.image_name >>.tar << parameters.image_name >>
   airflow-image-test:
     description: Test an Airflow image
     parameters:
@@ -402,7 +374,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Load archived Airflow Docker image
-          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
       - run:
           name: Set up test environment
           command: |
@@ -426,25 +398,20 @@ commands:
   push:
     description: "Push a Docker image to DockerHub"
     parameters:
-      comma_separated_tags:
+      extra_tags:
         type: string
-        default: latest
-      organization:
+        default: ""
+      tag:
         type: string
-        default: $GIT_ORG
-      image_name_load:
+      image_name:
         type: string
-        default: $CIRCLE_PROJECT_REPONAME
-      image_repo:
-        type: string
-        default: $CIRCLE_PROJECT_REPONAME
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/<< parameters.image_name_load >>.tar
+          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
@@ -452,11 +419,15 @@ commands:
           name: Push Docker image(s)
           command: |
             set -e
-            for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
+            image="<< parameters.image_name >>:<< parameters.tag >>"
+            set -x
+            docker push "$image"
+            set +x
+            for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              docker tag << parameters.image_name_load >> << parameters.organization >>/<< parameters.image_repo >>:${tag}
-              docker push << parameters.organization >>/<< parameters.image_repo >>:${tag}
+              docker tag "$image" "<< parameters.image_name >>:${tag}"
+              docker push "<< parameters.image_name >>:${tag}"
               set +x
             done
   clair-scan:
@@ -475,7 +446,7 @@ commands:
           at: /tmp/workspace
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
       - modified-orb:
           whitelist: "<< parameters.whitelist >>"
           image: "<< parameters.image_name >>"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -35,9 +35,8 @@ workflows:
             - build-{{ airflow_version }}-{{ distribution }}
       - publish:
           name: publish-{{ airflow_version }}-{{ distribution }}
-          airflow_version: {{ airflow_version }}
-          distribution_name: {{ distribution }}
-          comma_separated_tags: "{{ airflow_version }}-{{ distribution }},{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
+          tag: "{{ airflow_version }}-{{ distribution }}"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}
             - test-{{ airflow_version }}-{{ distribution }}
@@ -46,9 +45,8 @@ workflows:
               only: master
       - publish:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
-          airflow_version: {{ airflow_version }}
-          distribution_name: {{ distribution }}
-          comma_separated_tags: "{{ airflow_version }}-{{ distribution }}-onbuild,{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
+          tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -64,11 +62,9 @@ jobs:
     parameters:
       airflow_version:
         description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
         type: string
       distribution_name:
         description: "The base distribution of the container"
-        default: "alpine"
         type: string
     steps:
       - docker-build-base-and-onbuild:
@@ -80,56 +76,44 @@ jobs:
     parameters:
       airflow_version:
         description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
         type: string
       distribution_name:
         description: "The base distribution of the container"
-        default: "alpine"
         type: string
     steps:
       - airflow-image-test:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
   scan:
     executor: clair-scanner/default
     description: Test Airflow images
     parameters:
       airflow_version:
         description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
         type: string
       distribution_name:
         description: "The base distribution of the container"
-        default: "alpine"
         type: string
     steps:
       - clair-scan:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
   publish:
     executor: docker-executor
     description: Publish Airflow images
     parameters:
-      airflow_version:
-        description: "The Airflow version, for example '1.10.5'"
-        default: "1.10.5"
+      tag:
         type: string
-      distribution_name:
-        description: "The base distribution of the container"
-        default: "alpine"
+      extra_tags:
         type: string
-      comma_separated_tags:
-        default: "alpine"
-        type: string
+        default: ""
     steps:
       - push:
-          comma_separated_tags: "<< parameters.comma_separated_tags >>"
-          image_name_load: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
-          image_repo: ap-airflow
+          extra_tags: "<< parameters.extra_tags >>"
+          tag: "<< parameters.tag >>"
+          image_name: "astronomerinc/ap-airflow"
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:
-    environment:
-      GIT_ORG: astronomerinc
     docker:
       - image: circleci/python:3
 commands:
@@ -148,15 +132,15 @@ commands:
       - setup_remote_docker:
           docker_layer_caching: true
       - docker-build:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>"
           path: "<< parameters.airflow_version >>/<< parameters.distribution_name >>"
-      - run:
-          name: "Tag image"
-          command: |
-            docker tag ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >> ${GIT_ORG}/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>
       - docker-build:
-          image_name: "ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>-onbuild"
+          image_name: "astronomerinc/ap-airflow:<< parameters.airflow_version >>-<< parameters.distribution_name >>-onbuild"
           path: "<< parameters.airflow_version >>/<< parameters.distribution_name >>/onbuild"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - saved-images/
   docker-build:
     description: "Build a Docker image"
     parameters:
@@ -174,13 +158,9 @@ commands:
           name: Build the Docker image
           command: |
             set -xe
-            image_name="<< parameters.image_name >>"
-            docker build -t $image_name --file << parameters.path>>/<< parameters.dockerfile >> --build-arg BUILD_NUMBER=${CIRCLE_BUILD_NUM} --build-arg REPO_BRANCH=${CIRCLE_BRANCH} << parameters.path >>
-            docker save -o << parameters.image_name >>.tar $image_name
-      - persist_to_workspace:
-          root: .
-          paths:
-            - './*.tar'
+            mkdir -p saved-images/"$(dirname "<< parameters.image_name >>")"
+            docker build -t "<< parameters.image_name >>" --file << parameters.path>>/<< parameters.dockerfile >> --build-arg BUILD_NUMBER=${CIRCLE_BUILD_NUM} --build-arg REPO_BRANCH=${CIRCLE_BRANCH} << parameters.path >>
+            docker save -o saved-images/<< parameters.image_name >>.tar << parameters.image_name >>
   airflow-image-test:
     description: Test an Airflow image
     parameters:
@@ -194,7 +174,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Load archived Airflow Docker image
-          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
       - run:
           name: Set up test environment
           command: |
@@ -218,25 +198,20 @@ commands:
   push:
     description: "Push a Docker image to DockerHub"
     parameters:
-      comma_separated_tags:
+      extra_tags:
         type: string
-        default: latest
-      organization:
+        default: ""
+      tag:
         type: string
-        default: $GIT_ORG
-      image_name_load:
+      image_name:
         type: string
-        default: $CIRCLE_PROJECT_REPONAME
-      image_repo:
-        type: string
-        default: $CIRCLE_PROJECT_REPONAME
     steps:
       - attach_workspace:
           at: /tmp/workspace
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/<< parameters.image_name_load >>.tar
+          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
@@ -244,11 +219,15 @@ commands:
           name: Push Docker image(s)
           command: |
             set -e
-            for tag in $(echo "<< parameters.comma_separated_tags >>" | sed "s/,/ /g");
+            image="<< parameters.image_name >>:<< parameters.tag >>"
+            set -x
+            docker push "$image"
+            set +x
+            for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              docker tag << parameters.image_name_load >> << parameters.organization >>/<< parameters.image_repo >>:${tag}
-              docker push << parameters.organization >>/<< parameters.image_repo >>:${tag}
+              docker tag "$image" "<< parameters.image_name >>:${tag}"
+              docker push "<< parameters.image_name >>:${tag}"
               set +x
             done
   clair-scan:
@@ -267,7 +246,7 @@ commands:
           at: /tmp/workspace
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/<< parameters.image_name >>.tar
+          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
       - modified-orb:
           whitelist: "<< parameters.whitelist >>"
           image: "<< parameters.image_name >>"


### PR DESCRIPTION
Don't re-tag the image before pushing, instead build with the right tag
that we are going to push and test/scan that throughout.

This is a bit of a bigger change I _needed_ to make, but rather than re-tagging at the end I made it push the image, and then only change the tag (but never the image) -- hopefully this makes it less error prone?

**What this PR does / why we need it**:

Fixes astronomer/issues#680

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] If a new distribution or Airflow verison is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow verison is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
