### PR TITLE
Fix bug in image publish stage of CI pipeline

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -211,7 +211,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>.tar
+          command: docker load -i '/tmp/workspace/saved-images/<< parameters.image_name >>:<< parameters.tag >>.tar'
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin


### PR DESCRIPTION
Didn't quite get it right in #23, but it's hard to test this stage
except when it gets to master

Checked that this new filename is right by re-running the pipeline with SSH:

```
circleci@6baa61452582:~$ ls /tmp/workspace/saved-images/astronomerinc/
ap-airflow:1.10.6-buster-onbuild.tar  ap-airflow:1.10.6-buster.tar
```