### PR TITLE
Bump Airflow 1.10.5 and 1.10.7 images

### DIFF
--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-3"
+ARG VERSION="1.10.5-4"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.5-3"
+ARG VERSION="1.10.5-4"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 

--- a/1.10.5/buster/include/pip-constraints.txt
+++ b/1.10.5/buster/include/pip-constraints.txt
@@ -1,3 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 azure-storage-blob<12.0
+elasticsearch>=5.5.3,<6.0.0
 pymssql<3.0

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-3"
+ARG VERSION="1.10.5-4"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.7"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-2"
+ARG VERSION="1.10.7-3"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-2"
+ARG VERSION="1.10.7-3"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 

--- a/cve-whitelist.yaml
+++ b/cve-whitelist.yaml
@@ -2,6 +2,7 @@ generalwhitelist:
   CVE-2019-5482: curl
   CVE-2019-18224: libidn2
   CVE-2019-19603: sqlite3
+  CVE-2019-20218: sqlite3
 
   # These kernel vulnerabilities aren't a problem in a docker image, as they
   # don't use this kernel; but the hosts' kernel


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated tags for 1.10.5 and 1.10.7 

- https://github.com/astronomer/airflow/releases/tag/1.10.7-3
- https://github.com/astronomer/airflow/releases/tag/1.10.5-4

Contains config for airflow_local_settings.py so that we can use pod_mutation_hook

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow verison is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow verison is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
