### PR TITLE
Bump Airflow 1.10.5 and 1.10.7 images (#30)

### DIFF
--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-4"
+ARG VERSION="1.10.5-5"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.5-4"
+ARG VERSION="1.10.5-5"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-4"
+ARG VERSION="1.10.5-5"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.7"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-3"
+ARG VERSION="1.10.7-4"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-3"
+ARG VERSION="1.10.7-4"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Contains bugfix for https://issues.apache.org/jira/browse/AIRFLOW-6516

https://github.com/astronomer/airflow/commit/b97165d9012cc001159a61e737e2d740e0de20bd

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow verison is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow verison is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
