### PR TITLE
Copy missing clean-airflow-logs script in buster images

### DIFF
--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -158,6 +158,9 @@ RUN visudo --check --file=/etc/sudoers.d/astro
 # Copy entrypoint to root
 COPY include/entrypoint /
 
+# Copy "cron" scripts
+COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
 # with this

--- a/1.10.6/buster/Dockerfile
+++ b/1.10.6/buster/Dockerfile
@@ -158,6 +158,9 @@ RUN visudo --check --file=/etc/sudoers.d/astro
 # Copy entrypoint to root
 COPY include/entrypoint /
 
+# Copy "cron" scripts
+COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
 # with this

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -159,6 +159,9 @@ RUN visudo --check --file=/etc/sudoers.d/astro
 # Copy entrypoint to root
 COPY include/entrypoint /
 
+# Copy "cron" scripts
+COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
 # with this


### PR DESCRIPTION
**What this PR does / why we need it**:
Our buster images have missing `clean-airflow-logs` cron script causing the following error:

```
/entrypoint: line 34: /usr/local/bin/clean-airflow-logs: No such file or directory
```



**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow verison is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow verison is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
