### PR TITLE
Bump 1.10.7 images to use 1.10.7-5 tag

### DIFF
--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.7"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-4"
+ARG VERSION="1.10.7-5"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-4"
+ARG VERSION="1.10.7-5"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 


### PR DESCRIPTION
Based on https://github.com/astronomer/airflow/releases/tag/1.10.7-5

**What this PR does / why we need it**:

I have backported a fix for a recently discovered bug in Airflow 1.10.7

BugFix: https://github.com/astronomer/airflow/commit/4233c0d2791e52b9de5a129e6216095436b97ed0
