### PR TITLE
Pin Kombu version for Airflow 1.10.5 & 1.10.6

### DIFF
--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -1,3 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 azure-storage-blob<12.0
 pymssql<3.0
+kombu>=4.6.7, <5.0

--- a/1.10.6/alpine3.10/include/pip-constraints.txt
+++ b/1.10.6/alpine3.10/include/pip-constraints.txt
@@ -1,3 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 azure-storage-blob<12.0
 pymssql<3.0
+kombu>=4.6.7, <5.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Pins Kombu version for Airflow 1.10.5 & 1.10.6

We don't need to pin it on 1.10.7 because of https://github.com/apache/airflow/blob/1.10.7/setup.py#L178

