### PR TITLE
Fix RHEL7 Airflow Image

### DIFF
--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -55,16 +55,16 @@ RUN chmod 750 ./install-python && \
 #    cp /usr/share/zoneinfo/UTC /etc/localtime && \
 
 RUN pip3.6 install --no-cache-dir cryptography  \
-     &&  pip3.6 install --no-cache-dir  pymssql==2.1.4 \
-     &&  pip3.6 install --no-cache-dir --upgrade pip==19.3.1 \
-     &&  pip3.6 install --no-cache-dir --upgrade setuptools==41.0.1 \
-     &&  pip3.6 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
-     &&  pip3.6 install --no-cache-dir "${AIRFLOW_MODULE}" \
-     &&  pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl" \
-     &&  pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
-     &&  cd /usr/local/lib/python3.6/site-packages/airflow/www_rbac \
-     &&  /node-v12.13.1-linux-x64/bin/npm install \
-     &&  /node-v12.13.1-linux-x64/bin/npm run build \
+     && pip3.6 install --no-cache-dir  pymssql==2.1.4 \
+     && pip3.6 install --no-cache-dir --upgrade pip==19.3.1 \
+     && pip3.6 install --no-cache-dir --upgrade setuptools==41.0.1 \
+     && pip3.6 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
+     && pip3.6 install --no-cache-dir "${AIRFLOW_MODULE}" \
+     && pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl" \
+     && pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
+     && cd /usr/local/lib/python3.6/site-packages/airflow/www_rbac \
+     && /node-v12.13.1-linux-x64/bin/npm install \
+     && /node-v12.13.1-linux-x64/bin/npm run build \
      && update-alternatives --install /usr/bin/python3 python3 $(which python3.6) 0
 
 # Create logs directory so we can own it when we mount volumes

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -43,8 +43,45 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     rpm -ivh http://dev.mysql.com/get/mysql-community-release-el7-5.noarch.rpm
 
 
-RUN yum install -y epel-release cyrus-sasl-devel krb5-libs python-devel mysql-devel make tini build-base git krb5-dev openssl-devel libffi-dev linux-headers nodejs nodejs-npm python3-dev tzdata  wget libaio  zlib-devel libcurl-devel python-setuptools python-virtualenv bzip2-devel openssl-devel ncurses-devel  libxml2-devel libxslt-devel  sqlite sqlite-devel gcc sharutils unzip bash tar gcc-c++ nmap-ncat && \
-    yum groupinstall -y "Development Tools"
+RUN yum install -y \
+      epel-release \
+      cyrus-sasl-devel \
+      krb5-libs \
+      python-devel \
+      mysql-devel \
+      make \
+      tini \
+      build-base \
+      git \
+      krb5-dev \
+      openssl-devel \
+      libffi-dev \
+      linux-headers \
+      nodejs \
+      nodejs-npm \
+      python3-dev \
+      tzdata  \
+      wget \
+      libaio  \
+      zlib-devel \
+      libcurl-devel \
+      python-setuptools \
+      python-virtualenv \
+      bzip2-devel \
+      openssl-devel \
+      ncurses-devel  \
+      libxml2-devel \
+      libxslt-devel  \
+      sqlite \
+      sqlite-devel \
+      gcc \
+      sharutils \
+      unzip \
+      bash \
+      tar \
+      gcc-c++ \
+      nmap-ncat \
+    && yum groupinstall -y "Development Tools"
 
 RUN wget https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz && \
     tar -xvf /node-v12.13.1-linux-x64.tar.xz

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -62,7 +62,7 @@ RUN yum install -y \
       python3-dev \
       tzdata  \
       wget \
-      libaio  \
+      libaio \
       zlib-devel \
       libcurl-devel \
       python-setuptools \

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -27,7 +27,7 @@ ARG ASTRONOMER_GROUP="astro"
 ENV ASTRONOMER_USER=${ASTRONOMER_USER}
 ENV ASTRONOMER_GROUP=${ASTRONOMER_GROUP}
 
-RUN useradd  ${ASTRONOMER_USER}
+RUN useradd  ${ASTRONOMER_USER} -u 100
 RUN usermod -g ${ASTRONOMER_GROUP} ${ASTRONOMER_USER}
 
 ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
@@ -43,7 +43,7 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
     rpm -ivh http://dev.mysql.com/get/mysql-community-release-el7-5.noarch.rpm
 
 
-RUN yum install -y epel-release cyrus-sasl-devel krb5-libs python-devel mysql-devel make tini build-base git krb5-dev openssl-devel libffi-dev linux-headers nodejs nodejs-npm python3-dev tzdata  wget libaio  zlib-devel libcurl-devel python-setuptools python-virtualenv bzip2-devel openssl-devel ncurses-devel  libxml2-devel libxslt-devel  sqlite sqlite-devel gcc sharutils unzip bash tar gcc-c++ && \
+RUN yum install -y epel-release cyrus-sasl-devel krb5-libs python-devel mysql-devel make tini build-base git krb5-dev openssl-devel libffi-dev linux-headers nodejs nodejs-npm python3-dev tzdata  wget libaio  zlib-devel libcurl-devel python-setuptools python-virtualenv bzip2-devel openssl-devel ncurses-devel  libxml2-devel libxslt-devel  sqlite sqlite-devel gcc sharutils unzip bash tar gcc-c++ nmap-ncat && \
     yum groupinstall -y "Development Tools"
 
 RUN wget https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz && \

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -60,7 +60,7 @@ RUN yum install -y \
       nodejs \
       nodejs-npm \
       python3-dev \
-      tzdata  \
+      tzdata \
       wget \
       libaio \
       zlib-devel \
@@ -69,9 +69,9 @@ RUN yum install -y \
       python-virtualenv \
       bzip2-devel \
       openssl-devel \
-      ncurses-devel  \
+      ncurses-devel \
       libxml2-devel \
-      libxslt-devel  \
+      libxslt-devel \
       sqlite \
       sqlite-devel \
       gcc \

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -64,7 +64,8 @@ RUN pip3.6 install --no-cache-dir cryptography  \
      &&  pip3.6 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
      &&  cd /usr/local/lib/python3.6/site-packages/airflow/www_rbac \
      &&  /node-v12.13.1-linux-x64/bin/npm install \
-     &&  /node-v12.13.1-linux-x64/bin/npm run build
+     &&  /node-v12.13.1-linux-x64/bin/npm run build \
+     && update-alternatives --install /usr/bin/python3 python3 $(which python3.6) 0
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.5/rhel7/onbuild/Dockerfile
+++ b/1.10.5/rhel7/onbuild/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ianstanton/ap-airflow:rhel7-v10
+FROM astronomerinc/ap-airflow:1.10.5-rhel7
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 LABEL io.astronomer.docker=true

--- a/1.10.5/rhel7/onbuild/Dockerfile
+++ b/1.10.5/rhel7/onbuild/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ianstanton/ap-airflow:rhel7-v9
+FROM ianstanton/ap-airflow:rhel7-v10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 LABEL io.astronomer.docker=true

--- a/1.10.5/rhel7/onbuild/Dockerfile
+++ b/1.10.5/rhel7/onbuild/Dockerfile
@@ -13,9 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM astronomerinc/ap-airflow:1.10.5-rhel7
+FROM ianstanton/ap-airflow:rhel7-v9
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.airflow.onbuild=true
 
+# Install RHEL packages
+ONBUILD COPY packages.txt .
+ONBUILD RUN if [[ -s packages.txt ]]; then \
+    yum update -y && cat packages.txt | xargs yum install -y; \
+  fi
+
+# Install python packages
+ONBUILD COPY requirements.txt .
+ONBUILD RUN pip install --no-cache-dir -q -r requirements.txt
+
+# Copy entire project directory
+ONBUILD COPY . .

--- a/1.10.5/rhel7/onbuild/Dockerfile
+++ b/1.10.5/rhel7/onbuild/Dockerfile
@@ -27,7 +27,9 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN pip install --no-cache-dir -q -r requirements.txt
+ONBUILD RUN if [[ -s requirements.txt ]]; then \
+    pip install --no-cache-dir -q -r requirements.txt; \
+  fi
 
 # Copy entire project directory
 ONBUILD COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
The RHEL7 Airflow image that we have was not functional. The following has been fixed:
- Create user with UID 100. Without this we see permission errors.
- Include missing dependency `npm-ncat`.
- Include proper steps in `onbuild`
- Create symbolic link for `python3`

Related to https://github.com/astronomer/issues/issues/735

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow verison is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow verison is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
