### PR TITLE
Ensure tini present, ensure werkzeug version, fix tests

### DIFF
--- a/.circleci/test-airflow-image.py
+++ b/.circleci/test-airflow-image.py
@@ -96,6 +96,11 @@ def webserver(request):
     docker_id_db = start_postgres()
     wait_for_container(docker_id_db)
     db_connection_string = f"postgres://postgres:notsecretpassword@{get_ip_from_id(docker_id_db)}:5432"
+    db_initializer = subprocess.check_output(
+        ['docker', 'run', '--rm',
+         '--name', 'initdb',
+         '-e', f"AIRFLOW__CORE__SQL_ALCHEMY_CONN={db_connection_string}",
+         get_image_name(), 'airflow', 'initdb']).decode().strip()
     docker_id = subprocess.check_output(
         ['docker', 'run', '--rm',
          '--name', 'webserver',

--- a/.circleci/test-airflow-image.py
+++ b/.circleci/test-airflow-image.py
@@ -24,6 +24,17 @@ def test_airflow_in_path(webserver):
     assert webserver.exists('airflow'), \
         "Expected 'airflow' to be in PATH"
 
+def test_tini_in_path(webserver):
+    """ Ensure 'tini' is in PATH
+    """
+    assert webserver.exists('tini'), \
+        "Expected 'tini' to be in PATH"
+
+def test_entrypoint(webserver):
+    """ There should be a file '/entrypoint'
+    """
+    assert webserver.file("/entrypoint").exists, \
+        "Expected to find /entrypoint"
 
 def test_maintainer(webserver, docker_client):
     """ Ensure the Docker image label 'maintainer' is set correctly

--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -3,3 +3,4 @@ azure-storage-blob<12.0
 pymssql<3.0
 kombu>=4.6.7, <5.0
 redis!=3.4.0
+Werkzeug < 1.0.0

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update \
            rsync \
            sasl2-bin \
            sudo \
+           tini \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -169,5 +170,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
+ENTRYPOINT ["tini", "--", "/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -58,7 +58,6 @@ RUN apt-get update \
            apt-utils \
            curl \
            libmariadb3 \
-           dumb-init \
            freetds-bin \
            git \
            gosu \

--- a/1.10.5/buster/include/pip-constraints.txt
+++ b/1.10.5/buster/include/pip-constraints.txt
@@ -3,3 +3,4 @@ azure-storage-blob<12.0
 elasticsearch>=5.5.3,<6.0.0
 pymssql<3.0
 redis!=3.4.0
+Werkzeug < 1.0.0

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -35,7 +35,7 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+RUN chmod +x /tini && cp /tini /usr/local/sbin/
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
     rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 && \

--- a/1.10.5/rhel7/include/pip-constraints.txt
+++ b/1.10.5/rhel7/include/pip-constraints.txt
@@ -2,3 +2,4 @@
 azure-storage-blob<12.0
 pymssql<3.0
 redis!=3.4.0
+Werkzeug < 1.0.0

--- a/1.10.6/alpine3.10/include/pip-constraints.txt
+++ b/1.10.6/alpine3.10/include/pip-constraints.txt
@@ -3,3 +3,4 @@ azure-storage-blob<12.0
 pymssql<3.0
 kombu>=4.6.7, <5.0
 redis!=3.4.0
+Werkzeug < 1.0.0

--- a/1.10.6/buster/Dockerfile
+++ b/1.10.6/buster/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update \
            rsync \
            sasl2-bin \
            sudo \
+           tini \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -169,5 +170,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
+ENTRYPOINT ["tini", "--", "/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.6/buster/Dockerfile
+++ b/1.10.6/buster/Dockerfile
@@ -58,7 +58,6 @@ RUN apt-get update \
            apt-utils \
            curl \
            libmariadb3 \
-           dumb-init \
            freetds-bin \
            git \
            gosu \

--- a/1.10.6/buster/include/pip-constraints.txt
+++ b/1.10.6/buster/include/pip-constraints.txt
@@ -2,3 +2,4 @@
 azure-storage-blob<12.0
 pymssql<3.0
 redis!=3.4.0
+Werkzeug < 1.0.0

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -1,2 +1,3 @@
 # Constraint the version pip will install, if it ever needs to install a module
 redis!=3.4.0
+Werkzeug < 1.0.0

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -58,7 +58,6 @@ RUN apt-get update \
            apt-utils \
            curl \
            libmariadb3 \
-           dumb-init \
            freetds-bin \
            git \
            gosu \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update \
            rsync \
            sasl2-bin \
            sudo \
+           tini \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -170,5 +171,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
+ENTRYPOINT ["tini", "--", "/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.7/buster/include/pip-constraints.txt
+++ b/1.10.7/buster/include/pip-constraints.txt
@@ -1,3 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 
 redis!=3.4.0
+Werkzeug < 1.0.0


### PR DESCRIPTION
**What this PR does / why we need it**:

I am baking an assumption on the location of the entrypoint into Astronomer. This test serves to ensure the expected functionality is retained.

There is an [issue](https://github.com/astronomer/issues/issues/620) that the airflow scheduler overwrites the entrypoint in KPO and k8s executor workers. To solve that issue, I am modifying the pod mutation hook in airflow to make use of our entrypoint, which is invoked with 'tini'

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

N/A

- [ ] If a new distribution or Airflow verison is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow verison is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
