### PR TITLE
Papermill 2.0 includes PyArrow, which is hard to install on Alpine

### DIFF
--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -4,3 +4,4 @@ pymssql<3.0
 kombu>=4.6.7, <5.0
 redis!=3.4.0
 Werkzeug < 1.0.0
+papermill<2.0

--- a/1.10.6/alpine3.10/include/pip-constraints.txt
+++ b/1.10.6/alpine3.10/include/pip-constraints.txt
@@ -4,3 +4,4 @@ pymssql<3.0
 kombu>=4.6.7, <5.0
 redis!=3.4.0
 Werkzeug < 1.0.0
+papermill<2.0

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -1,3 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 redis!=3.4.0
 Werkzeug < 1.0.0
+papermill<2.0


### PR DESCRIPTION
To avoid this, we just restrict papermill to <2 only for Alpine images.


**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py