### PR TITLE
Install apache-airflow from our pre-packaged wheel

### DIFF
--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -23,16 +23,13 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.7"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-5"
+ARG VERSION="1.10.7+astro.6"
 ARG SUBMODULES="all, statsd, elasticsearch"
+ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==1!$VERSION"
 ARG REPO_BRANCH=master
 
-ENV AIRFLOW_REPOSITORY="https://github.com/${ORG}/airflow"
-ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 ENV AIRFLOW_HOME="/usr/local/airflow"
-ENV PYMSSQL_BUILD_WITH_BUNDLED_FREETDS=1
 ENV PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}${AIRFLOW_HOME}
-ENV AIRFLOW_GPL_UNIDECODE="True"
 
 ARG ASTRONOMER_USER="astro"
 ARG ASTRONOMER_GROUP="astro"
@@ -44,8 +41,9 @@ RUN addgroup -S ${ASTRONOMER_GROUP} \
 
 COPY apks/keys/humans@astronomer.io.rsa.pub /etc/apk/keys
 
-# Force pip to install these specific versions when ever it installs a module
-ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
+# Make pip look at our pip repo too, and force it to install these specific
+# versions when ever it installs a module.
+COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Install packages
@@ -56,14 +54,11 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/1.10.7/alpi
 		cyrus-sasl-dev \
 		freetds-dev \
 		freetype-dev \
-		git \
 		krb5-dev \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		nodejs \
-		nodejs-npm \
 		python3-dev \
 		tzdata \
 	&& apk add --no-cache \
@@ -95,12 +90,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/1.10.7/alpi
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
-	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl" \
-	&& cd /usr/lib/python3.7/site-packages/airflow/www_rbac \
-	&& rm package-lock.json \
-	&& npm install \
-	&& npm run build \
-	&& rm -rf node_modules \
+	&& pip3 install --no-cache-dir "astronomer-fab-security-manager~=1.2, >=1.2.2" \
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \

--- a/1.10.7/alpine3.10/include/pip.conf
+++ b/1.10.7/alpine3.10/include/pip.conf
@@ -1,0 +1,3 @@
+[global]
+extra-index-url = https://pip.astronomer.io/simple/
+constraint = /usr/local/share/astronomer-pip-constraints.txt

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -59,7 +59,6 @@ RUN apt-get update \
            curl \
            libmariadb3 \
            freetds-bin \
-           git \
            gosu \
            libffi6 \
            libkrb5-3 \
@@ -102,33 +101,23 @@ RUN apt-get update \
         libpq-dev \
         libsasl2-dev \
         libssl-dev \
-        nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-5"
+ARG VERSION="1.10.7+astro.6"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
-ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
+ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==1!$VERSION"
 
-# Force pip to install these specific versions when ever it installs a module
-ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
+# Make pip look at our pip repo too, and force it to install these specific
+# versions when ever it installs a module.
+COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
 RUN pip install "${AIRFLOW_MODULE}" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
-  && pip install "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl"
+	&& pip install --no-cache-dir "astronomer-fab-security-manager~=1.2, >=1.2.2"
 
-RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
-  && rm package-lock.json \
-  && npm install \
-  && npm run prod \
-  && rm -rf node_modules
-
-
-################################
-# Installing node_node modules #
-################################
 
 ## move this to same layer as airflow because its from tag.
 
@@ -146,7 +135,7 @@ COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.
 COPY --from=devel /usr/local/bin /usr/local/bin
 
 # Force pip to install these specific versions when ever it installs a module
-ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
+COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Create logs directory, so we can own it when we mount volumes

--- a/1.10.7/buster/include/pip.conf
+++ b/1.10.7/buster/include/pip.conf
@@ -1,0 +1,3 @@
+[global]
+extra-index-url = https://pip.astronomer.io/simple/
+constraint = /usr/local/share/astronomer-pip-constraints.txt


### PR DESCRIPTION
**What this PR does / why we need it**:

This saves us having to install then remove nodejs. It also makes the docker image "the same" as the python install of CEA

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there is an 'onbuild' directory and Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py