### PR TITLE
Bump Airflow 1.10.7 image to 1.10.7+astro.7

### DIFF
--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.7"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7+astro.6"
+ARG VERSION="1.10.7+astro.7"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==1!$VERSION"
 ARG REPO_BRANCH=master


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Airflow 1.10.7 image to [ 1.10.7+astro.7](https://github.com/astronomer/airflow/releases/tag/v1.10.7%2Bastro.7)



