### PR TITLE
Fix airflow worker grace period on Buster-based images

### DIFF
--- a/1.10.10.dev/buster/Dockerfile
+++ b/1.10.10.dev/buster/Dockerfile
@@ -142,14 +142,17 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \
     && install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}/logs"
 
-COPY include/sudoers /etc/sudoers.d/astro
-RUN visudo --check --file=/etc/sudoers.d/astro
-
 # Copy entrypoint to root
 COPY include/entrypoint /
 
 # Copy "cron" scripts
 COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
+# Set it up so that _apt/UID 100 can `gosu`, but no other users can
+RUN groupadd gosuers \
+    && usermod --append --groups gosuers _apt \
+    && chgrp gosuers /usr/sbin/gosu \
+    && chmod u+s,g+sx,o-rx /usr/sbin/gosu
 
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
@@ -159,5 +162,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["tini", "--", "/entrypoint"]
+ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.10.dev/buster/include/entrypoint
+++ b/1.10.10.dev/buster/include/entrypoint
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-# Sudo _explicitly_ filters out PYTHONPATH, even when env_reset is disabled. but we want it
-[[ $UID == ${ASTRONOMER_UID:-1000} ]] || exec sudo -H -u ${ASTRONOMER_USER} PYTHONPATH=$PYTHONPATH "$0" "$@"
-# Make sure logs folder is writable by the right user.
-[ -O "$AIRFLOW_HOME/logs" ] || sudo chown $ASTRONOMER_USER "$AIRFLOW_HOME/logs"
+if [[ $UID == "${ASTRONOMER_UID:-1000}" ]]; then
+  # Since we need to support running tini as another user, we can't put tini in
+  # the ENTRYPOINT command, we have to run it here, if we haven't already
+  if [[ -z "$__TINIFIED" ]]; then
+    __TINIFIED=1 exec tini -- "$0" "$@"
+  fi
+else
+  __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
+fi
+
+if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
+  # Support for puckle style of defining configs
+  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
+fi
 
 # Airflow subcommand
 CMD=$2

--- a/1.10.10.dev/buster/include/sudoers
+++ b/1.10.10.dev/buster/include/sudoers
@@ -1,6 +1,0 @@
-# Our astro platform currentl forces RunAs uid 100. As a temporary workaround
-# we give that user (`_apt`) permission to switch to astro.
-astro ALL=(ALL) NOPASSWD: ALL
-_apt ALL=(astro) SETENV:NOPASSWD: /entrypoint *
-
-Defaults>astro !env_reset

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -152,14 +152,17 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \
     && install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}/logs"
 
-COPY include/sudoers /etc/sudoers.d/astro
-RUN visudo --check --file=/etc/sudoers.d/astro
-
 # Copy entrypoint to root
 COPY include/entrypoint /
 
 # Copy "cron" scripts
 COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
+# Set it up so that _apt/UID 100 can `gosu`, but no other users can
+RUN groupadd gosuers \
+    && usermod --append --groups gosuers _apt \
+    && chgrp gosuers /usr/sbin/gosu \
+    && chmod u+s,g+sx,o-rx /usr/sbin/gosu
 
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
@@ -169,5 +172,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["tini", "--", "/entrypoint"]
+ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.5/buster/include/entrypoint
+++ b/1.10.5/buster/include/entrypoint
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-# Sudo _explicitly_ filters out PYTHONPATH, even when env_reset is disabled. but we want it
-[[ $UID == ${ASTRONOMER_UID:-1000} ]] || exec sudo -H -u ${ASTRONOMER_USER} PYTHONPATH=$PYTHONPATH "$0" "$@"
-# Make sure logs folder is writable by the right user.
-[ -O "$AIRFLOW_HOME/logs" ] || sudo chown $ASTRONOMER_USER "$AIRFLOW_HOME/logs"
+if [[ $UID == "${ASTRONOMER_UID:-1000}" ]]; then
+  # Since we need to support running tini as another user, we can't put tini in
+  # the ENTRYPOINT command, we have to run it here, if we haven't already
+  if [[ -z "$__TINIFIED" ]]; then
+    __TINIFIED=1 exec tini -- "$0" "$@"
+  fi
+else
+  __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
+fi
+
+if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
+  # Support for puckle style of defining configs
+  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
+fi
 
 # Airflow subcommand
 CMD=$2

--- a/1.10.5/buster/include/sudoers
+++ b/1.10.5/buster/include/sudoers
@@ -1,6 +1,0 @@
-# Our astro platform currentl forces RunAs uid 100. As a temporary workaround
-# we give that user (`_apt`) permission to switch to astro.
-astro ALL=(ALL) NOPASSWD: ALL
-_apt ALL=(astro) SETENV:NOPASSWD: /entrypoint *
-
-Defaults>astro !env_reset

--- a/1.10.6/buster/Dockerfile
+++ b/1.10.6/buster/Dockerfile
@@ -152,14 +152,17 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \
     && install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}/logs"
 
-COPY include/sudoers /etc/sudoers.d/astro
-RUN visudo --check --file=/etc/sudoers.d/astro
-
 # Copy entrypoint to root
 COPY include/entrypoint /
 
 # Copy "cron" scripts
 COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
+# Set it up so that _apt/UID 100 can `gosu`, but no other users can
+RUN groupadd gosuers \
+    && usermod --append --groups gosuers _apt \
+    && chgrp gosuers /usr/sbin/gosu \
+    && chmod u+s,g+sx,o-rx /usr/sbin/gosu
 
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
@@ -169,5 +172,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["tini", "--", "/entrypoint"]
+ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.6/buster/include/entrypoint
+++ b/1.10.6/buster/include/entrypoint
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-# Sudo _explicitly_ filters out PYTHONPATH, even when env_reset is disabled. but we want it
-[[ $UID == ${ASTRONOMER_UID:-1000} ]] || exec sudo -H -u ${ASTRONOMER_USER} PYTHONPATH=$PYTHONPATH "$0" "$@"
-# Make sure logs folder is writable by the right user.
-[ -O "$AIRFLOW_HOME/logs" ] || sudo chown $ASTRONOMER_USER "$AIRFLOW_HOME/logs"
+if [[ $UID == "${ASTRONOMER_UID:-1000}" ]]; then
+  # Since we need to support running tini as another user, we can't put tini in
+  # the ENTRYPOINT command, we have to run it here, if we haven't already
+  if [[ -z "$__TINIFIED" ]]; then
+    __TINIFIED=1 exec tini -- "$0" "$@"
+  fi
+else
+  __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
+fi
+
+if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
+  # Support for puckle style of defining configs
+  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
+fi
 
 # Airflow subcommand
 CMD=$2

--- a/1.10.6/buster/include/sudoers
+++ b/1.10.6/buster/include/sudoers
@@ -1,6 +1,0 @@
-# Our astro platform currentl forces RunAs uid 100. As a temporary workaround
-# we give that user (`_apt`) permission to switch to astro.
-astro ALL=(ALL) NOPASSWD: ALL
-_apt ALL=(astro) SETENV:NOPASSWD: /entrypoint *
-
-Defaults>astro !env_reset

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -144,14 +144,17 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \
     && install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}/logs"
 
-COPY include/sudoers /etc/sudoers.d/astro
-RUN visudo --check --file=/etc/sudoers.d/astro
-
 # Copy entrypoint to root
 COPY include/entrypoint /
 
 # Copy "cron" scripts
 COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
+# Set it up so that _apt/UID 100 can `gosu`, but no other users can
+RUN groupadd gosuers \
+    && usermod --append --groups gosuers _apt \
+    && chgrp gosuers /usr/sbin/gosu \
+    && chmod u+s,g+sx,o-rx /usr/sbin/gosu
 
 # Though this is set here we currently override this in the helm template, so
 # this _might_ not have any effect once deployed. The /entrypoint script copes
@@ -161,5 +164,5 @@ USER ${ASTRONOMER_USER}
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
 
-ENTRYPOINT ["tini", "--", "/entrypoint"]
+ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/1.10.7/buster/include/entrypoint
+++ b/1.10.7/buster/include/entrypoint
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
-# Sudo _explicitly_ filters out PYTHONPATH, even when env_reset is disabled. but we want it
-[[ $UID == ${ASTRONOMER_UID:-1000} ]] || exec sudo -H -u ${ASTRONOMER_USER} PYTHONPATH=$PYTHONPATH "$0" "$@"
-# Make sure logs folder is writable by the right user.
-[ -O "$AIRFLOW_HOME/logs" ] || sudo chown $ASTRONOMER_USER "$AIRFLOW_HOME/logs"
+if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
+  # Support for puckle style of defining configs
+  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
+fi
+
+if [[ $UID == "${ASTRONOMER_UID:-1000}" ]]; then
+  # Since we need to support running tini as another user, we can't put tini in
+  # the ENTRYPOINT command, we have to run it here, if we haven't already
+  if [[ -z "$__TINIFIED" ]]; then
+    __TINIFIED=1 exec tini -- "$0" "$@"
+  fi
+else
+  __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
+fi
 
 # Airflow subcommand
 CMD=$2

--- a/1.10.7/buster/include/sudoers
+++ b/1.10.7/buster/include/sudoers
@@ -1,6 +1,0 @@
-# Our astro platform currentl forces RunAs uid 100. As a temporary workaround
-# we give that user (`_apt`) permission to switch to astro.
-astro ALL=(ALL) NOPASSWD: ALL
-_apt ALL=(astro) SETENV:NOPASSWD: /entrypoint *
-
-Defaults>astro !env_reset

--- a/common/Dockerfile.onbuild-buster
+++ b/common/Dockerfile.onbuild-buster
@@ -35,4 +35,4 @@ ONBUILD RUN pip install --no-cache-dir -q -r requirements.txt
 ONBUILD USER astro
 
 # Copy entire project directory
-ONBUILD COPY . .
+ONBUILD COPY --chown=astro:astro . .


### PR DESCRIPTION
**What this PR does / why we need it**:

The problem was that PID1 (the tini process) was run as what ever the "default" user was, which when run on our platform is currently hard-coded to UID=100. We'd put in steps to switch to the other user to run airflow (via sudo) but unfortunately this meant when we tried to "gracefully shut down the celery worker" it would send the signal to tini, which would try to forward it on to sudo, but this would fail with:

    [FATAL tini (1)] Unexpected error when forwarding signal: 'Operation not permitted'

So the fix foe this is to make sure what ever is PID1 is running as the right user.

The way we achieve this is:

1. Switch to `gosu` (it was already installed) as this doesn't leave a "sudo" process in the middle. If we kept sudo we would have sudo as PID1 which would handle signals properly (PID1 is special)
2. gosu doesn't have a config file -- you need to be root to be able to run it. To work around this we make it a sticky/SUID executable, so that anyone who can run it (via normal file permissions) will run it "as root"
3. To "limit the blast radius" of gosu, we only let root and members of the new "gosuers" group be able to execute the binary.

The end result of this: `tini` is PID1, and running as the "correct"
astro user, even the container was launched as UID 100, and signals
correctly propagate where needed

Fixes astronomer/issues#718

/cc @kaxil You'll need to update this in your PR that adds 1.10.9 too. (We really need to sort out duplication of all these dockerfiles/scripts!)