### PR TITLE
Replace installing apache-airflow with astronomer_certified for 1.10.7

### DIFF
--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -23,9 +23,9 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.7"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7+astro.7"
+ARG VERSION="1.10.7-7"
 ARG SUBMODULES="all, statsd, elasticsearch"
-ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==1!$VERSION"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
 
 ENV AIRFLOW_HOME="/usr/local/airflow"

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,9 +105,9 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7+astro.6"
+ARG VERSION="1.10.7-7"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
-ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==1!$VERSION"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.


### PR DESCRIPTION
**What this PR does / why we need it**:
We have published a wheel package for AC Airflow 1.10.7: 
https://pip.astronomer.io/simple/astronomer-certified/astronomer_certified-1.10.7.post7-py2.py3-none-any.whl

This PR replaces installing apache-airflow package with astronomer_certified for 1.10.7


