### PR TITLE
Build & Publish Dev releases daily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,18 +496,18 @@ workflows:
           name: build-1.10.10.dev-alpine3.10
           airflow_version: 1.10.10.dev
           distribution_name: alpine3.10
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
       - scan:
           name: scan-1.10.10.dev-alpine3.10-onbuild
           airflow_version: 1.10.10.dev
           distribution_name: alpine3.10-onbuild
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           requires:
             - build-1.10.10.dev-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.10.dev-alpine3.10-onbuild
           airflow_version: 1.10.10.dev
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -515,13 +515,13 @@ workflows:
       - test:
           name: test-1.10.10.dev-alpine3.10-onbuild
           airflow_version: 1.10.10.dev
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           distribution_name: alpine3.10
           requires:
             - build-1.10.10.dev-alpine3.10
       - publish:
           name: publish-1.10.10.dev-alpine3.10
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           tag: "1.10.10.dev-alpine3.10"
           extra_tags: "1.10.10.dev-alpine3.10-${CIRCLE_BUILD_NUM}"
           requires:
@@ -533,7 +533,7 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10.dev-alpine3.10-onbuild
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           tag: "1.10.10.dev-alpine3.10-onbuild"
           extra_tags: "1.10.10.dev-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
@@ -547,18 +547,18 @@ workflows:
           name: build-1.10.10.dev-buster
           airflow_version: 1.10.10.dev
           distribution_name: buster
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
       - scan:
           name: scan-1.10.10.dev-buster-onbuild
           airflow_version: 1.10.10.dev
           distribution_name: buster-onbuild
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           requires:
             - build-1.10.10.dev-buster
       - scan-trivy:
           name: scan-trivy-1.10.10.dev-buster-onbuild
           airflow_version: 1.10.10.dev
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -566,13 +566,13 @@ workflows:
       - test:
           name: test-1.10.10.dev-buster-onbuild
           airflow_version: 1.10.10.dev
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           distribution_name: buster
           requires:
             - build-1.10.10.dev-buster
       - publish:
           name: publish-1.10.10.dev-buster
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           tag: "1.10.10.dev-buster"
           extra_tags: "1.10.10.dev-buster-${CIRCLE_BUILD_NUM}"
           requires:
@@ -584,7 +584,7 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10.dev-buster-onbuild
-          docker_repo: 
+          docker_repo: "astronomerio/ap-airflow"
           tag: "1.10.10.dev-buster-onbuild"
           extra_tags: "1.10.10.dev-buster-onbuild-${CIRCLE_BUILD_NUM}"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,120 @@ workflows:
               only: master
 
 
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          name: build-1.10.10.dev-alpine3.10
+          airflow_version: 1.10.10.dev
+          distribution_name: alpine3.10
+          docker_repo: 
+      - scan:
+          name: scan-1.10.10.dev-alpine3.10-onbuild
+          airflow_version: 1.10.10.dev
+          distribution_name: alpine3.10-onbuild
+          docker_repo: 
+          requires:
+            - build-1.10.10.dev-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.10.dev-alpine3.10-onbuild
+          airflow_version: 1.10.10.dev
+          docker_repo: 
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.10.dev-alpine3.10
+      - test:
+          name: test-1.10.10.dev-alpine3.10-onbuild
+          airflow_version: 1.10.10.dev
+          docker_repo: 
+          distribution_name: alpine3.10
+          requires:
+            - build-1.10.10.dev-alpine3.10
+      - publish:
+          name: publish-1.10.10.dev-alpine3.10
+          docker_repo: 
+          tag: "1.10.10.dev-alpine3.10"
+          extra_tags: "1.10.10.dev-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10.dev-alpine3.10-onbuild
+            - scan-trivy-1.10.10.dev-alpine3.10-onbuild
+            - test-1.10.10.dev-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.10.dev-alpine3.10-onbuild
+          docker_repo: 
+          tag: "1.10.10.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.10.dev-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10.dev-alpine3.10-onbuild
+            - scan-trivy-1.10.10.dev-alpine3.10-onbuild
+            - test-1.10.10.dev-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.10.dev-buster
+          airflow_version: 1.10.10.dev
+          distribution_name: buster
+          docker_repo: 
+      - scan:
+          name: scan-1.10.10.dev-buster-onbuild
+          airflow_version: 1.10.10.dev
+          distribution_name: buster-onbuild
+          docker_repo: 
+          requires:
+            - build-1.10.10.dev-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.10.dev-buster-onbuild
+          airflow_version: 1.10.10.dev
+          docker_repo: 
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.10.dev-buster
+      - test:
+          name: test-1.10.10.dev-buster-onbuild
+          airflow_version: 1.10.10.dev
+          docker_repo: 
+          distribution_name: buster
+          requires:
+            - build-1.10.10.dev-buster
+      - publish:
+          name: publish-1.10.10.dev-buster
+          docker_repo: 
+          tag: "1.10.10.dev-buster"
+          extra_tags: "1.10.10.dev-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10.dev-buster-onbuild
+            - scan-trivy-1.10.10.dev-buster-onbuild
+            - test-1.10.10.dev-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.10.dev-buster-onbuild
+          docker_repo: 
+          tag: "1.10.10.dev-buster-onbuild"
+          extra_tags: "1.10.10.dev-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10.dev-buster-onbuild
+            - scan-trivy-1.10.10.dev-buster-onbuild
+            - test-1.10.10.dev-buster-onbuild
+          filters:
+            branches:
+              only: master
+
+
 jobs:
   build:
     executor: docker-executor

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -76,18 +76,18 @@ workflows:
           name: build-{{ airflow_version }}-{{ distribution }}
           airflow_version: {{ airflow_version }}
           distribution_name: {{ distribution }}
-          docker_repo: {{ docker_repo }}
+          docker_repo: "astronomerio/ap-airflow"
       - scan:
           name: scan-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}
           distribution_name: {{ distribution }}-onbuild
-          docker_repo: {{ docker_repo }}
+          docker_repo: "astronomerio/ap-airflow"
           requires:
             - build-{{ airflow_version }}-{{ distribution }}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}
-          docker_repo: {{ docker_repo }}
+          docker_repo: "astronomerio/ap-airflow"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
           requires:
@@ -95,13 +95,13 @@ workflows:
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}
-          docker_repo: {{ docker_repo }}
+          docker_repo: "astronomerio/ap-airflow"
           distribution_name: {{ distribution }}
           requires:
             - build-{{ airflow_version }}-{{ distribution }}
       - publish:
           name: publish-{{ airflow_version }}-{{ distribution }}
-          docker_repo: {{ docker_repo }}
+          docker_repo: "astronomerio/ap-airflow"
           tag: "{{ airflow_version }}-{{ distribution }}"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
           requires:
@@ -113,7 +113,7 @@ workflows:
               only: master
       - publish:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
-          docker_repo: {{ docker_repo }}
+          docker_repo: "astronomerio/ap-airflow"
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -59,6 +59,74 @@ workflows:
               only: master
 {% endfor %}
 {% endfor %}
+{% if image_map.keys() | dev_releases | length > 0 %}
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+{%- for airflow_version, distributions in image_map.items() -%}
+{% if "dev" in airflow_version %}
+{%- for distribution in distributions %}
+      - build:
+          name: build-{{ airflow_version }}-{{ distribution }}
+          airflow_version: {{ airflow_version }}
+          distribution_name: {{ distribution }}
+          docker_repo: {{ docker_repo }}
+      - scan:
+          name: scan-{{ airflow_version }}-{{ distribution }}-onbuild
+          airflow_version: {{ airflow_version }}
+          distribution_name: {{ distribution }}-onbuild
+          docker_repo: {{ docker_repo }}
+          requires:
+            - build-{{ airflow_version }}-{{ distribution }}
+      - scan-trivy:
+          name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
+          airflow_version: {{ airflow_version }}
+          docker_repo: {{ docker_repo }}
+          distribution: {{ distribution }}
+          distribution_name: {{ distribution }}-onbuild
+          requires:
+            - build-{{ airflow_version }}-{{ distribution }}
+      - test:
+          name: test-{{ airflow_version }}-{{ distribution }}-onbuild
+          airflow_version: {{ airflow_version }}
+          docker_repo: {{ docker_repo }}
+          distribution_name: {{ distribution }}
+          requires:
+            - build-{{ airflow_version }}-{{ distribution }}
+      - publish:
+          name: publish-{{ airflow_version }}-{{ distribution }}
+          docker_repo: {{ docker_repo }}
+          tag: "{{ airflow_version }}-{{ distribution }}"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-{{ airflow_version }}-{{ distribution }}-onbuild
+            - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
+            - test-{{ airflow_version }}-{{ distribution }}-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
+          docker_repo: {{ docker_repo }}
+          tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-{{ airflow_version }}-{{ distribution }}-onbuild
+            - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
+            - test-{{ airflow_version }}-{{ distribution }}-onbuild
+          filters:
+            branches:
+              only: master
+{%- endfor %}
+{% endif %}
+{%- endfor %}
+{% endif %}
 jobs:
   build:
     executor: docker-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -6,7 +6,7 @@ so that we can stay DRY.
 
 import collections
 import os
-from jinja2 import Template
+from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5", ["alpine3.10", "buster", "rhel7"]),
@@ -16,16 +16,21 @@ IMAGE_MAP = collections.OrderedDict([
 ])
 
 
+def dev_releases(all_releases):
+    """Find dev releases from a list of releases"""
+    return [release for release in all_releases if "dev" in release]
+
+
 def main():
     """ Render the Jinja2 template file
     """
     circle_directory = os.path.dirname(os.path.realpath(__file__))
-    config_template_path = os.path.join(circle_directory, "config.yml.j2")
     config_path = os.path.join(circle_directory, "config.yml")
 
-    with open(config_template_path, "r") as circle_ci_config_template:
-        templated_file_content = circle_ci_config_template.read()
-    template = Template(templated_file_content)
+    template_env = Environment(loader=FileSystemLoader(searchpath="./"), autoescape=True)
+    template_env.filters['dev_releases'] = dev_releases
+    template = template_env.get_template("config.yml.j2")
+
     config = template.render(
         image_map=IMAGE_MAP
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to build all our Dev release (current only 1.10.10.dev) daily so that it builds new Docker images based on the latest dev release.

I have added conditions in our Jinja templated file to add a Circle job to **a schedule** only if it is a dev release.
