### PR TITLE
Install dependencies for using psycopg2-binary in Alpine image

### DIFF
--- a/1.10.10.dev/alpine3.10/Dockerfile
+++ b/1.10.10.dev/alpine3.10/Dockerfile
@@ -60,6 +60,8 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		libxslt-dev \
 		linux-headers \
 		python3-dev \
+		musl-dev \
+		postgresql-dev \
 		tzdata \
 	&& apk add --no-cache \
 		bash \


### PR DESCRIPTION
**What this PR does / why we need it**:

Airflow switched from using psycopg2 to psycopg2-binary. To be able to run that in Alpine image we need to install "musl-dev" and "postgresql-dev"


Note: This is required only for Airflow 1.10.10