### PR TITLE
[astronomer/issues#1042] Add appropriate '-number' tags to Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           name: publish-1.10.5-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -50,7 +50,7 @@ workflows:
           name: publish-1.10.5-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10-onbuild"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -90,7 +90,7 @@ workflows:
           name: publish-1.10.5-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-6-buster"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -102,7 +102,7 @@ workflows:
           name: publish-1.10.5-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-buster-onbuild"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -142,7 +142,7 @@ workflows:
           name: publish-1.10.5-rhel7
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -154,7 +154,7 @@ workflows:
           name: publish-1.10.5-rhel7-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7-onbuild"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -196,7 +196,7 @@ workflows:
           name: publish-1.10.6-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10"
-          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -208,7 +208,7 @@ workflows:
           name: publish-1.10.6-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10-onbuild"
-          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10-onbuild"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -248,7 +248,7 @@ workflows:
           name: publish-1.10.6-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster"
-          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-2-buster"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -260,7 +260,7 @@ workflows:
           name: publish-1.10.6-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster-onbuild"
-          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-buster-onbuild"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -302,7 +302,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -314,7 +314,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -354,7 +354,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-7-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -366,7 +366,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -834,19 +834,6 @@ commands:
             set -x
             docker push "$image"
             set +x
-            # Tag AC Version for non-dev images
-            if [[ "<< parameters.image_name >>" != *"dev"* ]]; then
-                ac_version=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.ac.version"}}')
-                distro=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.distro"}}')
-                on_build=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.airflow.onbuild"}}')
-
-                if [[ "$on_build" == "true" ]]; then
-                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}-onbuild"
-                else
-                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}"
-                fi
-                docker push "<< parameters.image_name >>:${ac_version}"
-            fi
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           name: publish-1.10.5-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -50,7 +50,7 @@ workflows:
           name: publish-1.10.5-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10-onbuild"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -90,7 +90,7 @@ workflows:
           name: publish-1.10.5-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-6-buster"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -102,7 +102,7 @@ workflows:
           name: publish-1.10.5-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-buster-onbuild"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -142,7 +142,7 @@ workflows:
           name: publish-1.10.5-rhel7
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -154,7 +154,7 @@ workflows:
           name: publish-1.10.5-rhel7-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7-onbuild"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -196,7 +196,7 @@ workflows:
           name: publish-1.10.6-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10"
-          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -208,7 +208,7 @@ workflows:
           name: publish-1.10.6-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10-onbuild"
-          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10-onbuild"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -248,7 +248,7 @@ workflows:
           name: publish-1.10.6-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster"
-          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-2-buster"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -260,7 +260,7 @@ workflows:
           name: publish-1.10.6-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster-onbuild"
-          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-buster-onbuild"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -302,7 +302,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -314,7 +314,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -354,7 +354,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-7-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -366,7 +366,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           name: publish-1.10.5-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -50,7 +50,7 @@ workflows:
           name: publish-1.10.5-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10-onbuild"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -90,7 +90,7 @@ workflows:
           name: publish-1.10.5-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-6-buster"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -102,7 +102,7 @@ workflows:
           name: publish-1.10.5-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-buster-onbuild"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -142,7 +142,7 @@ workflows:
           name: publish-1.10.5-rhel7
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -154,7 +154,7 @@ workflows:
           name: publish-1.10.5-rhel7-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7-onbuild"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -196,7 +196,7 @@ workflows:
           name: publish-1.10.6-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10"
-          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10"
+          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -208,7 +208,7 @@ workflows:
           name: publish-1.10.6-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10-onbuild"
-          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10-onbuild"
+          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -248,7 +248,7 @@ workflows:
           name: publish-1.10.6-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster"
-          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-2-buster"
+          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -260,7 +260,7 @@ workflows:
           name: publish-1.10.6-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster-onbuild"
-          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-buster-onbuild"
+          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -302,7 +302,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -314,7 +314,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -354,7 +354,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-7-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -366,7 +366,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM}"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -834,6 +834,19 @@ commands:
             set -x
             docker push "$image"
             set +x
+            # Tag AC Version for non-dev images
+            if [[ "<< parameters.image_name >>" != *"dev"* ]]; then
+                ac_version=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.ac.version"}}')
+                distro=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.distro"}}')
+                on_build=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.airflow.onbuild"}}')
+
+                if [[ "$on_build" == "true" ]]; then
+                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}-onbuild"
+                else
+                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}"
+                fi
+                docker push "<< parameters.image_name >>:${ac_version}"
+            fi
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -41,11 +41,7 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}"
-          {%- if "dev" in airflow_version %}
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
-          {%- else %}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
-          {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -57,11 +53,7 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
-          {%- if "dev" in airflow_version %}
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
-          {%- else %}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
-          {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -374,6 +366,22 @@ commands:
             set -x
             docker push "$image"
             set +x
+
+            {%- raw %}
+            # Tag AC Version for non-dev images
+            if [[ "<< parameters.image_name >>" != *"dev"* ]]; then
+                ac_version=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.ac.version"}}')
+                distro=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.distro"}}')
+                on_build=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.airflow.onbuild"}}')
+
+                if [[ "$on_build" == "true" ]]; then
+                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}-onbuild"
+                else
+                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}"
+                fi
+                docker push "<< parameters.image_name >>:${ac_version}"
+            fi
+            {%- endraw %}
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -3,7 +3,8 @@ workflows:
   version: 2.1
   certified-airflow:
     jobs:
-{% for airflow_version, distributions in image_map.items() %}
+{% for ac_version, distributions in image_map.items() %}
+{% set airflow_version = ac_version.split('-')[0] -%}
 {% set docker_repo = "astronomerio/ap-airflow" if "dev" in airflow_version else "astronomerinc/ap-airflow" -%}
 {% for distribution in distributions %}
       - build:
@@ -40,7 +41,11 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}"
+          {%- if "dev" in airflow_version %}
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
+          {%- else %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
+          {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -52,7 +57,11 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          {%- if "dev" in airflow_version %}
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
+          {%- else %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -41,7 +41,11 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}"
+          {%- if "dev" in airflow_version %}
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
+          {%- else %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
+          {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -53,7 +57,11 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          {%- if "dev" in airflow_version %}
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
+          {%- else %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -366,22 +374,6 @@ commands:
             set -x
             docker push "$image"
             set +x
-
-            {%- raw %}
-            # Tag AC Version for non-dev images
-            if [[ "<< parameters.image_name >>" != *"dev"* ]]; then
-                ac_version=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.ac.version"}}')
-                distro=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.distro"}}')
-                on_build=$(docker image inspect $image -f '{{index .Config.Labels "io.astronomer.docker.airflow.onbuild"}}')
-
-                if [[ "$on_build" == "true" ]]; then
-                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}-onbuild"
-                else
-                    docker tag "$image" "<< parameters.image_name >>:${ac_version}-${distro}"
-                fi
-                docker push "<< parameters.image_name >>:${ac_version}"
-            fi
-            {%- endraw %}
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,9 +9,9 @@ import os
 from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
-    ("1.10.5", ["alpine3.10", "buster", "rhel7"]),
-    ("1.10.6", ["alpine3.10", "buster"]),
-    ("1.10.7", ["alpine3.10", "buster"]),
+    ("1.10.5-6", ["alpine3.10", "buster", "rhel7"]),
+    ("1.10.6-2", ["alpine3.10", "buster"]),
+    ("1.10.7-7", ["alpine3.10", "buster"]),
     ("1.10.10.dev", ["alpine3.10", "buster"]),
 ])
 

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -6,6 +6,8 @@ so that we can stay DRY.
 
 import collections
 import os
+import re
+
 from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
@@ -22,8 +24,12 @@ def dev_releases(all_releases):
 
 
 def main():
-    """ Render the Jinja2 template file
     """
+    Render the Jinja2 template file
+    """
+
+    replace_version_info()
+
     circle_directory = os.path.dirname(os.path.realpath(__file__))
     config_path = os.path.join(circle_directory, "config.yml")
 
@@ -39,6 +45,31 @@ def main():
     with open(config_path, "w") as circle_ci_config_file:
         circle_ci_config_file.write(warning_header)
         circle_ci_config_file.write(config)
+
+
+def replace_version_info():
+    """
+    Replace the VERSION in all the Dockerfiles with the corresponding VERSION in IMAGE_MAP
+    """
+
+    for ac_version, distros in IMAGE_MAP.items():
+        airflow_version = ac_version.split('-')[0]
+        for distro in distros:
+            file_name = os.path.join("..", airflow_version, distro, "Dockerfile")
+
+            if "dev" in ac_version:
+                ac_version = ac_version.replace("dev", "*")
+
+            with open(file_name) as f:
+                file_contents = f.read()
+
+                new_text = re.sub(
+                    r'ARG VERSION=(.*)', f'ARG VERSION="{ac_version}"', file_contents,
+                    flags=re.MULTILINE
+                )
+
+            with open(file_name, "w") as f:
+                f.write(new_text)
 
 
 if __name__ == "__main__":

--- a/1.10.10.dev/alpine3.10/Dockerfile
+++ b/1.10.10.dev/alpine3.10/Dockerfile
@@ -16,17 +16,18 @@
 FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
-LABEL io.astronomer.docker=true
-LABEL io.astronomer.docker.distro="alpine"
-LABEL io.astronomer.docker.module="airflow"
-LABEL io.astronomer.docker.component="airflow"
-LABEL io.astronomer.docker.airflow.version="1.10.10.dev"
-
 ARG ORG="astronomer"
 ARG VERSION="1.10.10.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
+
+LABEL io.astronomer.docker=true
+LABEL io.astronomer.docker.distro="alpine"
+LABEL io.astronomer.docker.module="airflow"
+LABEL io.astronomer.docker.component="airflow"
+LABEL io.astronomer.docker.airflow.version="1.10.10.dev"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_HOME="/usr/local/airflow"
 ENV PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}${AIRFLOW_HOME}

--- a/1.10.10.dev/buster/Dockerfile
+++ b/1.10.10.dev/buster/Dockerfile
@@ -123,6 +123,7 @@ RUN pip install "${AIRFLOW_MODULE}" --pre \
 FROM ${APT_DEPS_IMAGE} as main
 
 LABEL io.astronomer.docker.airflow.version="1.10.10.dev"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -16,17 +16,18 @@
 FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
-LABEL io.astronomer.docker=true
-LABEL io.astronomer.docker.distro="alpine"
-LABEL io.astronomer.docker.module="airflow"
-LABEL io.astronomer.docker.component="airflow"
-LABEL io.astronomer.docker.airflow.version="1.10.7"
-
 ARG ORG="astronomer"
 ARG VERSION="1.10.7-7"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
+
+LABEL io.astronomer.docker=true
+LABEL io.astronomer.docker.distro="alpine"
+LABEL io.astronomer.docker.module="airflow"
+LABEL io.astronomer.docker.component="airflow"
+LABEL io.astronomer.docker.airflow.version="1.10.7"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_HOME="/usr/local/airflow"
 ENV PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}${AIRFLOW_HOME}

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -125,6 +125,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 LABEL io.astronomer.docker.airflow.version="1.10.7"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
Add the -number to the end of our docker tags, for example `1.10.7-7` for the `astro.7`

Closes https://github.com/astronomer/issues/issues/1042

