### PR TITLE
Fix entrypoints to correctly wait for DB/broker when no password

### DIFF
--- a/1.10.10.dev/alpine3.10/include/entrypoint
+++ b/1.10.10.dev/alpine3.10/include/entrypoint
@@ -10,11 +10,14 @@ fi
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -23,8 +26,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.10.dev/buster/include/entrypoint
+++ b/1.10.10.dev/buster/include/entrypoint
@@ -9,11 +9,14 @@ set -e
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -22,8 +25,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.5/alpine3.10/include/entrypoint
+++ b/1.10.5/alpine3.10/include/entrypoint
@@ -10,11 +10,14 @@ fi
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -23,8 +26,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.5/buster/include/entrypoint
+++ b/1.10.5/buster/include/entrypoint
@@ -9,11 +9,14 @@ set -e
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -22,8 +25,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.6/alpine3.10/include/entrypoint
+++ b/1.10.6/alpine3.10/include/entrypoint
@@ -10,11 +10,14 @@ fi
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -23,8 +26,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.6/buster/include/entrypoint
+++ b/1.10.6/buster/include/entrypoint
@@ -9,11 +9,14 @@ set -e
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -22,8 +25,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.7/alpine3.10/include/entrypoint
+++ b/1.10.7/alpine3.10/include/entrypoint
@@ -10,11 +10,14 @@ fi
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -23,8 +26,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001

--- a/1.10.7/buster/include/entrypoint
+++ b/1.10.7/buster/include/entrypoint
@@ -9,11 +9,14 @@ set -e
 # Airflow subcommand
 CMD=$2
 
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
 # Wait for postgres then init the db
 if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
@@ -22,8 +25,9 @@ fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
   # Wait for database port to open up
-  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
-  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
   echo "Waiting for host: ${HOST} ${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001


### PR DESCRIPTION
If you specify the celery broker URL as `redis://host:6379/0` it would
fail to correctly extract the host/port and would end up in a loop never actually run.

The problem was the awk pipeline required a username/password. So
instead replace it with a regex. Hopefully now we don't have two problems

**What this PR does / why we need it**:

Running these image with `AIRFLOW__CELERY__BROKER_URL=redis://redis:6379/0` wasn't possible.

(I'm starting to hate the amount of duplication we have with all these entrypoints being _almost_ identical. All the alpine ones should be the same, and all the buster ones, but there are differences from alpine to buster -- alpine has an `airflow sync_perm` that buster doesn't.)

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
