### PR TITLE
Release Astro Certified 1.10.7-8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-8-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -314,7 +314,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-8-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -354,7 +354,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-7-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-8-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -366,7 +366,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-7-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-8-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-6", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-2", ["alpine3.10", "buster"]),
-    ("1.10.7-7", ["alpine3.10", "buster"]),
+    ("1.10.7-8", ["alpine3.10", "buster"]),
     ("1.10.10.dev", ["alpine3.10", "buster"]),
 ])
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+Astronomer Certified 1.10.7-8, 2020-04-11
+-----------------------------------------------
+
+### Bug Fixes
+
+- Fix issue with SQLAlchemy 1.3.16 ([commit](https://github.com/astronomer/airflow/commit/3b6cf61e0f2de3fe3be98c8ff5809060d6e42ba4)) 
+- [AIRFLOW-7113] Fix gantt render error ([commit](https://github.com/astronomer/airflow/commit/dc015a0f3a836fe519f97acc75a26873a226695a))
+- Add prestop hook to prevent logging issue ([commit](https://github.com/astronomer/airflow/commit/328705f5f74e49be0ab251705172be45c19635f3))
+- [AIRFLOW-6584] Pin cassandra driver ([commit](https://github.com/astronomer/airflow/commit/21fd6fb56ee23c0a287874ed094e42fb22385916))
+
 Astronomer Certified 1.10.7-7, 2020-03-13
 -----------------------------------------------
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-7"
+ARG VERSION="1.10.7-8"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-7"
+ARG VERSION="1.10.7-8"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
https://github.com/astronomer/airflow/commits/v1.10.7%2Bastro.8

**What this PR does / why we need it**:
This PR adds support for AC 1.10.7-8 that fixes 2 issues (Gantt chart & EKS Log issue)

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [x] If changing an image, add applicable test in .circleci/test-airflow-image.py

