### PR TITLE
Don't re-publish Tags for point releases

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -377,8 +377,12 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              docker tag "$image" "<< parameters.image_name >>:${tag}"
-              docker push "<< parameters.image_name >>:${tag}"
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null; then
+                echo "Image with Tag ($image:$tag) already exists"
+              else
+                docker tag "$image" "<< parameters.image_name >>:${tag}"
+                docker push "<< parameters.image_name >>:${tag}"
+              fi
               set +x
             done
   clair-scan:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -377,7 +377,7 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null; then
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null 2>&1; then
                 echo "Image with Tag ($image:$tag) already exists"
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"


### PR DESCRIPTION
We don't want to push Images with same tags for point releases.

Note: This only stop republishing of point release (with `-number` format, eg.ap-airflow:1.10.5-6-alpine3.10-onbuild) and not `ap-airflow:1.10.5-alpine3.10-onbuild`

