### PR TITLE
Don't re-publish Tags for point releases (#62)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,8 +837,12 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              docker tag "$image" "<< parameters.image_name >>:${tag}"
-              docker push "<< parameters.image_name >>:${tag}"
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null 2>&1; then
+                echo "Image with Tag ($image:$tag) already exists"
+              else
+                docker tag "$image" "<< parameters.image_name >>:${tag}"
+                docker push "<< parameters.image_name >>:${tag}"
+              fi
               set +x
             done
   clair-scan:


### PR DESCRIPTION
Forgot to generate `.circleci/config.yml` file from template in https://github.com/astronomer/ap-airflow/pull/62
