### PR TITLE
BugFix: Docker Image Push for point release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,8 +837,8 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null 2>&1; then
-                echo "Image with Tag ($image:$tag) already exists"
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null ; then
+                echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"
                 docker push "<< parameters.image_name >>:${tag}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,7 +837,7 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null ; then
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null 2>&1; then
                 echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -377,8 +377,8 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null ; then
-                echo "Image with Tag ($image:$tag) already exists"
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null ; then
+                echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"
                 docker push "<< parameters.image_name >>:${tag}"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -377,7 +377,7 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null ; then
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null 2>&1; then
                 echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -377,7 +377,7 @@ commands:
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
               set -x
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null 2>&1; then
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect $image:$tag >/dev/null ; then
                 echo "Image with Tag ($image:$tag) already exists"
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"


### PR DESCRIPTION
**Update**:
The following command was run previously:

```
docker manifest inspect astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild:1.10.7-8-alpine3.10-onbuild
```

Notice`1.10.7-alpine3.10-onbuild:1.10.7-8-alpine3.10-onbuild` which is incorrect and it was because the `$image` variable was already assigned the name and tag of non-point release.


**Old**:
Docker images for point releases are still being pushed after https://github.com/astronomer/ap-airflow/pull/63 and I am not sure why. 

CI: https://app.circleci.com/pipelines/github/astronomer/ap-airflow/341/workflows/6913cbc8-2754-423f-9257-781b040b189e/jobs/7856

I think `docker manifest inspect` command might be failing on CI so need to check it.

Works fine on my local machine so can't think of any other way to debug it.

```
❯ if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect astronomerinc/ap-airflow:1.10.7-8-alpine3.10-onbuild >/dev/null 2>&1; then
    echo "Image with Tag ($image:$tag) already exists"
else
    echo "Image doesn't exist"
fi
Image with Tag (:) already exists
```