### PR TITLE
Fix openssl CVE

### DIFF
--- a/1.10.10.dev/alpine3.10/Dockerfile
+++ b/1.10.10.dev/alpine3.10/Dockerfile
@@ -86,6 +86,8 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-typed-ast \
 		python3 \
 		tini \
+	&& apk add --upgrade \
+		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
 	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \

--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -88,6 +88,8 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-typed-ast \
 		python3 \
 		tini \
+	&& apk add --upgrade \
+		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
 	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \

--- a/1.10.6/alpine3.10/Dockerfile
+++ b/1.10.6/alpine3.10/Dockerfile
@@ -67,7 +67,6 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		python3-dev \
 		tzdata \
 	&& apk add --no-cache \
-		openssl \
 		bash \
 		ca-certificates \
 		cyrus-sasl \

--- a/1.10.6/alpine3.10/Dockerfile
+++ b/1.10.6/alpine3.10/Dockerfile
@@ -67,6 +67,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		python3-dev \
 		tzdata \
 	&& apk add --no-cache \
+		openssl \
 		bash \
 		ca-certificates \
 		cyrus-sasl \
@@ -88,6 +89,8 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-typed-ast \
 		python3 \
 		tini \
+	&& apk add --upgrade \
+		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
 	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -84,6 +84,8 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-typed-ast \
 		python3 \
 		tini \
+	&& apk add --upgrade \
+		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
 	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \


### PR DESCRIPTION
Upgrade OpenSSL to fix the following CVE:

* https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967


