### PR TITLE
Add Changelog info to readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Docker images for deploying and running Astronomer Certified are currently avail
 * Source Code: <https://github.com/astronomer/ap-airflow>
 * Issue Tracker: <https://github.com/astronomer/ap-airflow/issues>
 
+## Changelog
+
+All changes applied to available point releases will be documented in the `CHANGELOG.md` files within each version folder:
+- [1.10.5 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)
+- [1.10.7 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)
+
 ### Local testing
 
 This testing will run automatically in CI, but it will save some time to try it out locally first.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Docker images for deploying and running Astronomer Certified are currently avail
 
 All changes applied to available point releases will be documented in the `CHANGELOG.md` files within each version folder:
 - [1.10.5 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)
+- [1.10.6 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.6/CHANGELOG.md)
 - [1.10.7 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)
+- [1.10.10 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)
 
 ### Local testing
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the (previously empty) top-level changelog in favor of changelogs at the version level. It also adds some info to our readme on where to find relevant changelogs.
