### PR TITLE
Release Astro Certified 1.10.6-3 and 1.10.5-7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ workflows:
           name: publish-1.10.6-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10"
-          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10"
+          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-3-alpine3.10"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -208,7 +208,7 @@ workflows:
           name: publish-1.10.6-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10-onbuild"
-          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-alpine3.10-onbuild"
+          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-3-alpine3.10-onbuild"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -248,7 +248,7 @@ workflows:
           name: publish-1.10.6-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster"
-          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-2-buster"
+          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-3-buster"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -260,7 +260,7 @@ workflows:
           name: publish-1.10.6-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster-onbuild"
-          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-2-buster-onbuild"
+          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-3-buster-onbuild"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ workflows:
           name: publish-1.10.5-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -50,7 +50,7 @@ workflows:
           name: publish-1.10.5-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-alpine3.10-onbuild"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10-onbuild"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -90,7 +90,7 @@ workflows:
           name: publish-1.10.5-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-6-buster"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-7-buster"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -102,7 +102,7 @@ workflows:
           name: publish-1.10.5-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-buster-onbuild"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-buster-onbuild"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -142,7 +142,7 @@ workflows:
           name: publish-1.10.5-rhel7
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -154,7 +154,7 @@ workflows:
           name: publish-1.10.5-rhel7-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-6-rhel7-onbuild"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7-onbuild"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -12,7 +12,7 @@ from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-6", ["alpine3.10", "buster", "rhel7"]),
-    ("1.10.6-2", ["alpine3.10", "buster"]),
+    ("1.10.6-3", ["alpine3.10", "buster"]),
     ("1.10.7-8", ["alpine3.10", "buster"]),
     ("1.10.10-1", ["alpine3.10", "buster"]),
 ])

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,7 +11,7 @@ import re
 from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
-    ("1.10.5-6", ["alpine3.10", "buster", "rhel7"]),
+    ("1.10.5-7", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-3", ["alpine3.10", "buster"]),
     ("1.10.7-8", ["alpine3.10", "buster"]),
     ("1.10.10-1", ["alpine3.10", "buster"]),

--- a/1.10.5/CHANGELOG.md
+++ b/1.10.5/CHANGELOG.md
@@ -7,8 +7,8 @@ No changes in `astronomer/airflow` repo.
 
 Dockerfile changes are:
 
-- Upgrade sqlite3 packages for Alpine 3.10  ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
-- Fix OpenSSL CVE ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
+- Upgrade sqlite3 packages for Alpine 3.10 [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967) ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
+- Upgrade OpenSSL to mitigate [CVE-2019-16168](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2019-16168) ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
 - Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
 - JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))
 

--- a/1.10.5/CHANGELOG.md
+++ b/1.10.5/CHANGELOG.md
@@ -7,7 +7,7 @@ No changes in `astronomer/airflow` repo.
 
 Dockerfile changes are:
 
-- Upgrade sqlite3 packages for Alpine 3.10 [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967) ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
+- Upgrade sqlite3 packages for Alpine 3.10 to mitigate [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967) ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
 - Upgrade OpenSSL to mitigate [CVE-2019-16168](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2019-16168) ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
 - Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
 - JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))

--- a/1.10.5/CHANGELOG.md
+++ b/1.10.5/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+Astronomer Certified 1.10.5-7, 2020-04-27
+--------------------------------------------
+
+No changes in `astronomer/airflow` repo.
+
+Dockerfile changes are:
+
+- Upgrade sqlite3 packages for Alpine 3.10  ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
+- Fix OpenSSL CVE ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
+- Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
+- JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))
+
+
 Astronomer Certified 1.10.5-6, 2020-03-30
 -----------------------------------------------
 

--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-6"
+ARG VERSION="1.10.5-7"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.5-6"
+ARG VERSION="1.10.5-7"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-6"
+ARG VERSION="1.10.5-7"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.6/CHANGELOG.md
+++ b/1.10.6/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+Astronomer Certified 1.10.6-3, 2020-04-27
+--------------------------------------------
+
+No changes in `astronomer/airflow` repo.
+
+Dockerfile changes are:
+
+- Upgrade sqlite3 packages for Alpine 3.10  ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
+- Fix OpenSSL CVE ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
+- Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
+- JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))

--- a/1.10.6/CHANGELOG.md
+++ b/1.10.6/CHANGELOG.md
@@ -7,7 +7,7 @@ No changes in `astronomer/airflow` repo.
 
 Dockerfile changes are:
 
-- Upgrade sqlite3 packages for Alpine 3.10 [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967) ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
+- Upgrade sqlite3 packages for Alpine 3.10 to mitigate [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967) ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
 - Upgrade OpenSSL to mitigate [CVE-2019-16168](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2019-16168) ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
 - Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
 - JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))

--- a/1.10.6/CHANGELOG.md
+++ b/1.10.6/CHANGELOG.md
@@ -7,7 +7,7 @@ No changes in `astronomer/airflow` repo.
 
 Dockerfile changes are:
 
-- Upgrade sqlite3 packages for Alpine 3.10  ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
-- Fix OpenSSL CVE ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
+- Upgrade sqlite3 packages for Alpine 3.10 [CVE-2020-1967](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2020-1967) ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
+- Upgrade OpenSSL to mitigate [CVE-2019-16168](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2019-16168) ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
 - Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
 - JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))

--- a/1.10.6/alpine3.10/Dockerfile
+++ b/1.10.6/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.6"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.6-2"
+ARG VERSION="1.10.6-3"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.6/buster/Dockerfile
+++ b/1.10.6/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.6-2"
+ARG VERSION="1.10.6-3"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 


### PR DESCRIPTION
1.10.6-3 tag: https://github.com/astronomer/airflow/releases/tag/1.10.6-3

### Changelog for both

No changes in `astronomer/airflow` repo.

Dockerfile changes are:

- Upgrade sqlite3 packages for Alpine 3.10  ([commit](https://github.com/astronomer/ap-airflow/commit/2f29d493259cddd487bcc306b829a4ec4a74f35e))
- Fix OpenSSL CVE ([commit](https://github.com/astronomer/ap-airflow/commit/6de11c2c87e78b7a3171d8fb222c7278fcb673c9))
- Constraint version of WTForms to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/3cd34236f8a7214434dc313af525160133520bcb))
- JPype1 0.7.3 no longer installs on Alpline/musl-libc ([commit](https://github.com/astronomer/ap-airflow/commit/44164ba40cd1878cabeec5edc32fe0a7bb7a8e0d))

