### PR TITLE
Constraint version of Flask-Appbuilder to non-broken version

### DIFF
--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -9,3 +9,6 @@ papermill<2.0
 nteract-scrapbook<0.4
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.10/buster/include/pip-constraints.txt
+++ b/1.10.10/buster/include/pip-constraints.txt
@@ -3,3 +3,6 @@
 redis!=3.4.0
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -13,3 +13,6 @@ papermill<2.0
 nteract-scrapbook<0.4
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.5/buster/include/pip-constraints.txt
+++ b/1.10.5/buster/include/pip-constraints.txt
@@ -6,3 +6,6 @@ redis!=3.4.0
 Werkzeug < 1.0.0
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.5/rhel7/include/pip-constraints.txt
+++ b/1.10.5/rhel7/include/pip-constraints.txt
@@ -5,3 +5,6 @@ redis!=3.4.0
 Werkzeug < 1.0.0
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.6/alpine3.10/include/pip-constraints.txt
+++ b/1.10.6/alpine3.10/include/pip-constraints.txt
@@ -13,3 +13,6 @@ papermill<2.0
 nteract-scrapbook<0.4
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.6/buster/include/pip-constraints.txt
+++ b/1.10.6/buster/include/pip-constraints.txt
@@ -5,3 +5,6 @@ redis!=3.4.0
 Werkzeug < 1.0.0
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -10,3 +10,6 @@ papermill<2.0
 nteract-scrapbook<0.4
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3

--- a/1.10.7/buster/include/pip-constraints.txt
+++ b/1.10.7/buster/include/pip-constraints.txt
@@ -4,3 +4,6 @@ redis!=3.4.0
 Werkzeug < 1.0.0
 
 WTforms<2.3.0
+
+# Details: https://github.com/apache/airflow/issues/8599
+flask-appbuilder<2.3.3


### PR DESCRIPTION
Details:

- https://github.com/apache/airflow/issues/8599
- https://github.com/apache/airflow/issues/8613

We need this before we 1.10.7-9 Docker images are published