### PR TITLE
Release Astro Certified 1.10.7-10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-9-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -314,7 +314,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-9-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -354,7 +354,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-9-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-10-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -366,7 +366,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-9-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-7", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-3", ["alpine3.10", "buster"]),
-    ("1.10.7-9", ["alpine3.10", "buster"]),
+    ("1.10.7-10", ["alpine3.10", "buster"]),
     ("1.10.10-1", ["alpine3.10", "buster"]),
 ])
 

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -93,7 +93,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \
 	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
-	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" --pre \
+	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
 	&& pip3 install --no-cache-dir "astronomer-fab-security-manager~=1.2, >=1.2.2" \
 	&& apk del .build-deps py3-numpy-dev \

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -113,7 +113,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install --no-cache-dir "${AIRFLOW_MODULE}" \
+RUN pip install "${AIRFLOW_MODULE}" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.2, >=1.2.2"
 

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -113,7 +113,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" --pre \
+RUN pip install --no-cache-dir "${AIRFLOW_MODULE}" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.2, >=1.2.2"
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+Astronomer Certified 1.10.7-10, 2020-04-29
+--------------------------------------------
+
+### New Features
+
+- Allow setting Airflow Variable values to empty string ('') ([commit](https://github.com/astronomer/airflow/commit/d6d666c33)) 
+- Get Airflow Variables from AWS Systems Manager Parameter Store ([commit](https://github.com/astronomer/airflow/commit/6a7130f55)) 
+- Get Airflow Variables from GCP Secrets Manager ([commit](https://github.com/astronomer/airflow/commit/595ede548)) 
+- Get Airflow Variables from Hashicorp Vault ([commit](https://github.com/astronomer/airflow/commit/59435bb88)) 
+- Get Airflow Variables from Environment Variables ([commit](https://github.com/astronomer/airflow/commit/fe1a6a3bd)) 
+- [AIRFLOW-6987] Avoid creating default connections ([commit](https://github.com/astronomer/airflow/commit/89052690e)) 
+- Make BaseSecretsBackend.build_path generic ([commit](https://github.com/astronomer/airflow/commit/1623b80bc)) 
+- Fix CloudSecretsManagerBackend invalid connections_prefix ([commit](https://github.com/astronomer/airflow/commit/fe0a9d850)) 
+- Standardize SecretBackend class names ([commit](https://github.com/astronomer/airflow/commit/008cb6ebe)) 
+- [AIRFLOW-7105] Unify Secrets Backend method interfaces ([commit](https://github.com/astronomer/airflow/commit/5ddff01e8)) 
+- [AIRFLOW-7104] Add Secret backend for GCP Secrets Manager ([commit](https://github.com/astronomer/airflow/commit/19bcf781b)) 
+- [AIRFLOW-5705] Make AwsSsmSecretsBackend consistent with VaultBackend ([commit](https://github.com/astronomer/airflow/commit/cff559cbb)) 
+- [AIRFLOW-7076] Add support for HashiCorp Vault as Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/99bb2a7ef)) 
+- [AIRFLOW-5705] Fix bugs in AWS SSM Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/afae4b62b)) 
+- [AIRFLOW-5705] Fix bug in Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/29015f537)) 
+- [AIRFLOW-5705] Add secrets backend and support for AWS SSM ([commit](https://github.com/astronomer/airflow/commit/2a82f5365)) 
+
 Astronomer Certified 1.10.7-9, 2020-04-28
 --------------------------------------------
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -9,8 +9,7 @@ Astronomer Certified 1.10.7-10, 2020-04-29
 - Get Airflow Variables from AWS Systems Manager Parameter Store ([commit](https://github.com/astronomer/airflow/commit/6a7130f55)) 
 - Get Airflow Variables from GCP Secrets Manager ([commit](https://github.com/astronomer/airflow/commit/595ede548)) 
 - Get Airflow Variables from Hashicorp Vault ([commit](https://github.com/astronomer/airflow/commit/59435bb88)) 
-- Get Airflow Variables from Environment Variables ([commit](https://github.com/astronomer/airflow/commit/fe1a6a3bd)) 
-- [AIRFLOW-6987] Avoid creating default connections ([commit](https://github.com/astronomer/airflow/commit/89052690e)) 
+- Get Airflow Variables from Environment Variables ([commit](https://github.com/astronomer/airflow/commit/fe1a6a3bd))  
 - Make BaseSecretsBackend.build_path generic ([commit](https://github.com/astronomer/airflow/commit/1623b80bc)) 
 - Fix CloudSecretsManagerBackend invalid connections_prefix ([commit](https://github.com/astronomer/airflow/commit/fe0a9d850)) 
 - Standardize SecretBackend class names ([commit](https://github.com/astronomer/airflow/commit/008cb6ebe)) 
@@ -22,10 +21,16 @@ Astronomer Certified 1.10.7-10, 2020-04-29
 - [AIRFLOW-5705] Fix bug in Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/29015f537)) 
 - [AIRFLOW-5705] Add secrets backend and support for AWS SSM ([commit](https://github.com/astronomer/airflow/commit/2a82f5365)) 
 
+### Improvements
+
+- [AIRFLOW-5167] Update dependencies for GCP packages ([commit](https://github.com/astronomer/airflow/commit/6277fcd499)) 
+
 Astronomer Certified 1.10.7-9, 2020-04-28
 --------------------------------------------
 
-No user-facing changes in `astronomer/airflow` repo.
+### New Features
+
+- Require the AC version check plugin ([commit](https://github.com/astronomer/airflow/commit/3af238f))
 
 Dockerfile changes are:
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-9"
+ARG VERSION="1.10.7-10"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -115,7 +115,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" \
+RUN pip install --no-cache-dir "${AIRFLOW_MODULE}" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
 	&& pip install --no-cache-dir "astronomer-fab-security-manager~=1.2, >=1.2.2"
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-9"
+ARG VERSION="1.10.7-10"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -115,7 +115,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install --no-cache-dir "${AIRFLOW_MODULE}" \
+RUN pip install "${AIRFLOW_MODULE}" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
 	&& pip install --no-cache-dir "astronomer-fab-security-manager~=1.2, >=1.2.2"
 


### PR DESCRIPTION
AC Airflow Tag: https://github.com/astronomer/airflow/releases/tag/v1.10.7%2Bastro.10

**Summary**:

Allow Adding & Retrieving Airflow Connections & Variables from different Secret Backends. Backported from Airflow 1.10.10

### New Features

- Allow setting Airflow Variable values to empty string ('') ([commit](https://github.com/astronomer/airflow/commit/d6d666c33)) 
- Get Airflow Variables from AWS Systems Manager Parameter Store ([commit](https://github.com/astronomer/airflow/commit/6a7130f55)) 
- Get Airflow Variables from GCP Secrets Manager ([commit](https://github.com/astronomer/airflow/commit/595ede548)) 
- Get Airflow Variables from Hashicorp Vault ([commit](https://github.com/astronomer/airflow/commit/59435bb88)) 
- Get Airflow Variables from Environment Variables ([commit](https://github.com/astronomer/airflow/commit/fe1a6a3bd)) 
- [AIRFLOW-6987] Avoid creating default connections ([commit](https://github.com/astronomer/airflow/commit/89052690e)) 
- Make BaseSecretsBackend.build_path generic ([commit](https://github.com/astronomer/airflow/commit/1623b80bc)) 
- Fix CloudSecretsManagerBackend invalid connections_prefix ([commit](https://github.com/astronomer/airflow/commit/fe0a9d850)) 
- Standardize SecretBackend class names ([commit](https://github.com/astronomer/airflow/commit/008cb6ebe)) 
- [AIRFLOW-7105] Unify Secrets Backend method interfaces ([commit](https://github.com/astronomer/airflow/commit/5ddff01e8)) 
- [AIRFLOW-7104] Add Secret backend for GCP Secrets Manager ([commit](https://github.com/astronomer/airflow/commit/19bcf781b)) 
- [AIRFLOW-5705] Make AwsSsmSecretsBackend consistent with VaultBackend ([commit](https://github.com/astronomer/airflow/commit/cff559cbb)) 
- [AIRFLOW-7076] Add support for HashiCorp Vault as Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/99bb2a7ef)) 
- [AIRFLOW-5705] Fix bugs in AWS SSM Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/afae4b62b)) 
- [AIRFLOW-5705] Fix bug in Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/29015f537)) 
- [AIRFLOW-5705] Add secrets backend and support for AWS SSM ([commit](https://github.com/astronomer/airflow/commit/2a82f5365)) 

### Improvements

- [AIRFLOW-5167] Update dependencies for GCP packages ([commit](https://github.com/astronomer/airflow/commit/6277fcd499)) 