### PR TITLE
Constrain version of azure-storage

### DIFF
--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -12,3 +12,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.10/buster/include/pip-constraints.txt
+++ b/1.10.10/buster/include/pip-constraints.txt
@@ -6,3 +6,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -16,3 +16,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.5/buster/include/pip-constraints.txt
+++ b/1.10.5/buster/include/pip-constraints.txt
@@ -9,3 +9,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.5/rhel7/include/pip-constraints.txt
+++ b/1.10.5/rhel7/include/pip-constraints.txt
@@ -8,3 +8,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.6/alpine3.10/include/pip-constraints.txt
+++ b/1.10.6/alpine3.10/include/pip-constraints.txt
@@ -16,3 +16,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.6/buster/include/pip-constraints.txt
+++ b/1.10.6/buster/include/pip-constraints.txt
@@ -8,3 +8,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -13,3 +13,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.7/buster/include/pip-constraints.txt
+++ b/1.10.7/buster/include/pip-constraints.txt
@@ -7,3 +7,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0


### PR DESCRIPTION
2020.05.12 release of the azure-storage is not installable any more
(it is deprecated). For now, we should switch to the latest working
version

