### PR TITLE
Only Publish images on New point release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,19 +715,23 @@ commands:
             set -e
             image="<< parameters.image_name >>:<< parameters.tag >>"
             set -x
-            docker push "$image"
-            set +x
+            export NEW_POINT_RELEASE=true
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
-              set -x
               if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null 2>&1; then
                 echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
+                export NEW_POINT_RELEASE=false
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"
                 docker push "<< parameters.image_name >>:${tag}"
               fi
-              set +x
             done
+            if $NEW_POINT_RELEASE ; then
+              docker push "$image"
+            else
+              echo "Image with Tag ($image) not pushed as it is not a new point release"
+            fi
+            set +x
   clair-scan:
     description: "Vulnerability scan a Docker image"
     parameters:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -372,19 +372,23 @@ commands:
             set -e
             image="<< parameters.image_name >>:<< parameters.tag >>"
             set -x
-            docker push "$image"
-            set +x
+            export NEW_POINT_RELEASE=true
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
-              set -x
               if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null 2>&1; then
                 echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
+                export NEW_POINT_RELEASE=false
               else
                 docker tag "$image" "<< parameters.image_name >>:${tag}"
                 docker push "<< parameters.image_name >>:${tag}"
               fi
-              set +x
             done
+            if $NEW_POINT_RELEASE ; then
+              docker push "$image"
+            else
+              echo "Image with Tag ($image) not pushed as it is not a new point release"
+            fi
+            set +x
   clair-scan:
     description: "Vulnerability scan a Docker image"
     parameters:

--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -12,3 +12,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.10/buster/include/pip-constraints.txt
+++ b/1.10.10/buster/include/pip-constraints.txt
@@ -6,3 +6,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -16,3 +16,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.5/buster/include/pip-constraints.txt
+++ b/1.10.5/buster/include/pip-constraints.txt
@@ -9,3 +9,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.5/rhel7/include/pip-constraints.txt
+++ b/1.10.5/rhel7/include/pip-constraints.txt
@@ -8,3 +8,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.6/alpine3.10/include/pip-constraints.txt
+++ b/1.10.6/alpine3.10/include/pip-constraints.txt
@@ -16,3 +16,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.6/buster/include/pip-constraints.txt
+++ b/1.10.6/buster/include/pip-constraints.txt
@@ -8,3 +8,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -13,3 +13,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0

--- a/1.10.7/buster/include/pip-constraints.txt
+++ b/1.10.7/buster/include/pip-constraints.txt
@@ -7,3 +7,6 @@ WTforms<2.3.0
 
 # Details: https://github.com/apache/airflow/issues/8599
 flask-appbuilder<2.3.3
+
+# Details: https://github.com/apache/airflow/pull/8833
+azure-storage<0.37.0


### PR DESCRIPTION
Github Issue: https://github.com/astronomer/issues/issues/1247

Note this does not fully address https://github.com/astronomer/issues/issues/1247

This PR only stop republishing of `astronomerinc/ap-airflow:1.10.7-buster` kind of images.
The CI will still publish images like `astronomerinc/ap-airflow:1.10.7-buster-onbuild-9373`.

Following are the things I still want to do and this PR does not solve them:

- [ ] Stop building & testing all the images when a single version is released. For example, releasing `1.10.7-10` would still build, test & scan `1.10.5-2` but won't publish it.
- [ ] If publishing new image without release, push it to astronomerio instead of astronomerinc
