### PR TITLE
Push images with Build Number to DEV Docker Repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
           name: publish-1.10.5-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-7-alpine3.10"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -53,7 +53,7 @@ workflows:
           name: publish-1.10.5-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-7-alpine3.10-onbuild"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10-onbuild"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -95,7 +95,7 @@ workflows:
           name: publish-1.10.5-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-7-buster"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-7-buster"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -107,7 +107,7 @@ workflows:
           name: publish-1.10.5-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-7-buster-onbuild"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-buster-onbuild"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -149,7 +149,7 @@ workflows:
           name: publish-1.10.5-rhel7
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-7-rhel7"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -161,7 +161,7 @@ workflows:
           name: publish-1.10.5-rhel7-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-7-rhel7-onbuild"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7-onbuild"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -205,7 +205,7 @@ workflows:
           name: publish-1.10.6-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10"
-          extra_tags: "1.10.6-3-alpine3.10"
+          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-3-alpine3.10"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -217,7 +217,7 @@ workflows:
           name: publish-1.10.6-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10-onbuild"
-          extra_tags: "1.10.6-3-alpine3.10-onbuild"
+          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-3-alpine3.10-onbuild"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -259,7 +259,7 @@ workflows:
           name: publish-1.10.6-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster"
-          extra_tags: "1.10.6-3-buster"
+          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-3-buster"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -271,7 +271,7 @@ workflows:
           name: publish-1.10.6-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster-onbuild"
-          extra_tags: "1.10.6-3-buster-onbuild"
+          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-3-buster-onbuild"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -315,7 +315,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-10-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -327,7 +327,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-10-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -369,7 +369,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-10-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-10-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -381,7 +381,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-10-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -425,7 +425,7 @@ workflows:
           name: publish-1.10.10-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-1-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -437,7 +437,7 @@ workflows:
           name: publish-1.10.10-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-1-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10-onbuild"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -479,7 +479,7 @@ workflows:
           name: publish-1.10.10-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster"
-          extra_tags: "1.10.10-1-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-1-buster"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -491,7 +491,7 @@ workflows:
           name: publish-1.10.10-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-1-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-buster-onbuild"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,11 +623,16 @@ jobs:
       docker_repo:
         description: "The docker repo to publish the image, for example 'astronomerinc/ap-airflow'"
         type: string
+      dev_docker_repo:
+        description: "The docker repo to publish the image, for example 'astronomerinc/ap-airflow'"
+        default: "astronomerio/ap-airflow"
+        type: string
     steps:
       - push:
           extra_tags: "<< parameters.extra_tags >>"
           tag: "<< parameters.tag >>"
-          image_name: "<< parameters.docker_repo >>"
+          prod_docker_repo: "<< parameters.docker_repo >>"
+          dev_docker_repo: "<< parameters.dev_docker_repo >>"
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
@@ -727,7 +732,10 @@ commands:
         default: ""
       tag:
         type: string
-      image_name:
+      prod_docker_repo:
+        type: string
+      dev_docker_repo:
+        default: "astronomerio/ap-airflow"
         type: string
     steps:
       - attach_workspace:
@@ -735,7 +743,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i '/tmp/workspace/saved-images/<< parameters.image_name >>:<< parameters.tag >>.tar'
+          command: docker load -i '/tmp/workspace/saved-images/<< parameters.prod_docker_repo >>:<< parameters.tag >>.tar'
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
@@ -743,17 +751,21 @@ commands:
           name: Push Docker image(s)
           command: |
             set -e
-            image="<< parameters.image_name >>:<< parameters.tag >>"
+            image="<< parameters.prod_docker_repo >>:<< parameters.tag >>"
             set -x
             export NEW_POINT_RELEASE=true
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null 2>&1; then
-                echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.prod_docker_repo >>:$tag >/dev/null 2>&1; then
+                echo "Image with Tag (<< parameters.prod_docker_repo >>:$tag) already exists"
                 export NEW_POINT_RELEASE=false
+              elif [[ "$tag" == "<< parameters.tag >>-$CIRCLE_BUILD_NUM" ]]; then
+                echo "Pushing Image with << parameters.tag >>-$CIRCLE_BUILD_NUM tag to << parameters.dev_docker_repo >>"
+                docker tag "$image" "<< parameters.dev_docker_repo >>:${tag}"
+                docker push "<< parameters.dev_docker_repo >>:${tag}"
               else
-                docker tag "$image" "<< parameters.image_name >>:${tag}"
-                docker push "<< parameters.image_name >>:${tag}"
+                docker tag "$image" "<< parameters.prod_docker_repo >>:${tag}"
+                docker push "<< parameters.prod_docker_repo >>:${tag}"
               fi
             done
             if $NEW_POINT_RELEASE ; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
           name: publish-1.10.5-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10"
+          extra_tags: "1.10.5-7-alpine3.10"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -53,7 +53,7 @@ workflows:
           name: publish-1.10.5-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10-onbuild"
+          extra_tags: "1.10.5-7-alpine3.10-onbuild"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -95,7 +95,7 @@ workflows:
           name: publish-1.10.5-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-7-buster"
+          extra_tags: "1.10.5-7-buster"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -107,7 +107,7 @@ workflows:
           name: publish-1.10.5-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-buster-onbuild"
+          extra_tags: "1.10.5-7-buster-onbuild"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -149,7 +149,7 @@ workflows:
           name: publish-1.10.5-rhel7
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7"
+          extra_tags: "1.10.5-7-rhel7"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -161,7 +161,7 @@ workflows:
           name: publish-1.10.5-rhel7-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7-onbuild"
+          extra_tags: "1.10.5-7-rhel7-onbuild"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -205,7 +205,7 @@ workflows:
           name: publish-1.10.6-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10"
-          extra_tags: "1.10.6-alpine3.10-${CIRCLE_BUILD_NUM},1.10.6-3-alpine3.10"
+          extra_tags: "1.10.6-3-alpine3.10"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -217,7 +217,7 @@ workflows:
           name: publish-1.10.6-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-alpine3.10-onbuild"
-          extra_tags: "1.10.6-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.6-3-alpine3.10-onbuild"
+          extra_tags: "1.10.6-3-alpine3.10-onbuild"
           requires:
             - scan-1.10.6-alpine3.10-onbuild
             - scan-trivy-1.10.6-alpine3.10-onbuild
@@ -259,7 +259,7 @@ workflows:
           name: publish-1.10.6-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster"
-          extra_tags: "1.10.6-buster-${CIRCLE_BUILD_NUM},1.10.6-3-buster"
+          extra_tags: "1.10.6-3-buster"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -271,7 +271,7 @@ workflows:
           name: publish-1.10.6-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.6-buster-onbuild"
-          extra_tags: "1.10.6-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.6-3-buster-onbuild"
+          extra_tags: "1.10.6-3-buster-onbuild"
           requires:
             - scan-1.10.6-buster-onbuild
             - scan-trivy-1.10.6-buster-onbuild
@@ -315,7 +315,7 @@ workflows:
           name: publish-1.10.7-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10"
+          extra_tags: "1.10.7-10-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -327,7 +327,7 @@ workflows:
           name: publish-1.10.7-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10-onbuild"
+          extra_tags: "1.10.7-10-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -369,7 +369,7 @@ workflows:
           name: publish-1.10.7-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-10-buster"
+          extra_tags: "1.10.7-10-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -381,7 +381,7 @@ workflows:
           name: publish-1.10.7-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-buster-onbuild"
+          extra_tags: "1.10.7-10-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -425,7 +425,7 @@ workflows:
           name: publish-1.10.10-alpine3.10
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10"
+          extra_tags: "1.10.10-1-alpine3.10"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -437,7 +437,7 @@ workflows:
           name: publish-1.10.10-alpine3.10-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10-onbuild"
+          extra_tags: "1.10.10-1-alpine3.10-onbuild"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -479,7 +479,7 @@ workflows:
           name: publish-1.10.10-buster
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-1-buster"
+          extra_tags: "1.10.10-1-buster"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -491,7 +491,7 @@ workflows:
           name: publish-1.10.10-buster-onbuild
           docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-buster-onbuild"
+          extra_tags: "1.10.10-1-buster-onbuild"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -44,8 +44,10 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}"
-          {%- if "dev" not in airflow_version %}
-          extra_tags: "{{ ac_version }}-{{ distribution }}"
+          {%- if "dev" in airflow_version %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
+          {%- else %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
           {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -58,8 +60,10 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
-          {%- if "dev" not in airflow_version %}
-          extra_tags: "{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- if "dev" in airflow_version %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
+          {%- else %}
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
           {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -264,11 +264,16 @@ jobs:
       docker_repo:
         description: "The docker repo to publish the image, for example 'astronomerinc/ap-airflow'"
         type: string
+      dev_docker_repo:
+        description: "The docker repo to publish the image, for example 'astronomerinc/ap-airflow'"
+        default: "astronomerio/ap-airflow"
+        type: string
     steps:
       - push:
           extra_tags: "<< parameters.extra_tags >>"
           tag: "<< parameters.tag >>"
-          image_name: "<< parameters.docker_repo >>"
+          prod_docker_repo: "<< parameters.docker_repo >>"
+          dev_docker_repo: "<< parameters.dev_docker_repo >>"
 orbs:
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
@@ -368,7 +373,10 @@ commands:
         default: ""
       tag:
         type: string
-      image_name:
+      prod_docker_repo:
+        type: string
+      dev_docker_repo:
+        default: "astronomerio/ap-airflow"
         type: string
     steps:
       - attach_workspace:
@@ -376,7 +384,7 @@ commands:
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i '/tmp/workspace/saved-images/<< parameters.image_name >>:<< parameters.tag >>.tar'
+          command: docker load -i '/tmp/workspace/saved-images/<< parameters.prod_docker_repo >>:<< parameters.tag >>.tar'
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
@@ -384,17 +392,21 @@ commands:
           name: Push Docker image(s)
           command: |
             set -e
-            image="<< parameters.image_name >>:<< parameters.tag >>"
+            image="<< parameters.prod_docker_repo >>:<< parameters.tag >>"
             set -x
             export NEW_POINT_RELEASE=true
             for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
             do
-              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.image_name >>:$tag >/dev/null 2>&1; then
-                echo "Image with Tag (<< parameters.image_name >>:$tag) already exists"
+              if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect << parameters.prod_docker_repo >>:$tag >/dev/null 2>&1; then
+                echo "Image with Tag (<< parameters.prod_docker_repo >>:$tag) already exists"
                 export NEW_POINT_RELEASE=false
+              elif [[ "$tag" == "<< parameters.tag >>-$CIRCLE_BUILD_NUM" ]]; then
+                echo "Pushing Image with << parameters.tag >>-$CIRCLE_BUILD_NUM tag to << parameters.dev_docker_repo >>"
+                docker tag "$image" "<< parameters.dev_docker_repo >>:${tag}"
+                docker push "<< parameters.dev_docker_repo >>:${tag}"
               else
-                docker tag "$image" "<< parameters.image_name >>:${tag}"
-                docker push "<< parameters.image_name >>:${tag}"
+                docker tag "$image" "<< parameters.prod_docker_repo >>:${tag}"
+                docker push "<< parameters.prod_docker_repo >>:${tag}"
               fi
             done
             if $NEW_POINT_RELEASE ; then

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -44,10 +44,8 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}"
-          {%- if "dev" in airflow_version %}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
-          {%- else %}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
+          {%- if "dev" not in airflow_version %}
+          extra_tags: "{{ ac_version }}-{{ distribution }}"
           {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -60,10 +58,8 @@ workflows:
           name: publish-{{ airflow_version }}-{{ distribution }}-onbuild
           docker_repo: {{ docker_repo }}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
-          {%- if "dev" in airflow_version %}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM}"
-          {%- else %}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- if "dev" not in airflow_version %}
+          extra_tags: "{{ ac_version }}-{{ distribution }}-onbuild"
           {%- endif %}
           requires:
             - scan-{{ airflow_version }}-{{ distribution }}-onbuild


### PR DESCRIPTION
I don't see a reason why we should publish images like `astronomerinc/ap-airflow:1.10.5-rhel7-onbuild-11056`

Let me know if there is a use-case for this, in which case I will add logic to push them to `astronomerio` repo 