### PR TITLE
Add 1.10.7-11.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,7 @@ workflows:
           airflow_version: 1.10.7
           distribution_name: alpine3.10
           docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan:
@@ -341,6 +342,7 @@ workflows:
           airflow_version: 1.10.7
           distribution_name: buster
           docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,20 +286,20 @@ workflows:
           name: build-1.10.7-alpine3.10
           airflow_version: 1.10.7
           distribution_name: alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.7-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -307,15 +307,15 @@ workflows:
       - test:
           name: test-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: alpine3.10
           requires:
             - build-1.10.7-alpine3.10
       - publish:
           name: publish-1.10.7-alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-11.dev-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -325,9 +325,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11.dev-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -340,20 +340,20 @@ workflows:
           name: build-1.10.7-buster
           airflow_version: 1.10.7
           distribution_name: buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-buster-onbuild
           airflow_version: 1.10.7
           distribution_name: buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.7-buster
       - scan-trivy:
           name: scan-trivy-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -361,15 +361,15 @@ workflows:
       - test:
           name: test-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: buster
           requires:
             - build-1.10.7-buster
       - publish:
           name: publish-1.10.7-buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-10-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-11.dev-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -379,9 +379,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-10-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11.dev-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -500,6 +500,121 @@ workflows:
             branches:
               only: master
 
+
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          name: build-1.10.7-11.dev-alpine3.10
+          airflow_version: 1.10.7-11.dev
+          distribution_name: alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7-11.build)"
+      - scan:
+          name: scan-1.10.7-11.dev-alpine3.10-onbuild
+          airflow_version: 1.10.7-11.dev
+          distribution_name: alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.7-11.dev-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.7-11.dev-alpine3.10-onbuild
+          airflow_version: 1.10.7-11.dev
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.7-11.dev-alpine3.10
+      - test:
+          name: test-1.10.7-11.dev-alpine3.10-onbuild
+          airflow_version: 1.10.7-11.dev
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: alpine3.10
+          requires:
+            - build-1.10.7-11.dev-alpine3.10
+      - publish:
+          name: publish-1.10.7-11.dev-alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-11.dev-alpine3.10"
+          extra_tags: "1.10.7-11.dev-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-11.dev-alpine3.10-onbuild
+            - scan-trivy-1.10.7-11.dev-alpine3.10-onbuild
+            - test-1.10.7-11.dev-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.7-11.dev-alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-11.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.7-11.dev-alpine3.10-onbuild-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-11.dev-alpine3.10-onbuild
+            - scan-trivy-1.10.7-11.dev-alpine3.10-onbuild
+            - test-1.10.7-11.dev-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.7-11.dev-buster
+          airflow_version: 1.10.7-11.dev
+          distribution_name: buster
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7-11.build)"
+      - scan:
+          name: scan-1.10.7-11.dev-buster-onbuild
+          airflow_version: 1.10.7-11.dev
+          distribution_name: buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.7-11.dev-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.7-11.dev-buster-onbuild
+          airflow_version: 1.10.7-11.dev
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.7-11.dev-buster
+      - test:
+          name: test-1.10.7-11.dev-buster-onbuild
+          airflow_version: 1.10.7-11.dev
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: buster
+          requires:
+            - build-1.10.7-11.dev-buster
+      - publish:
+          name: publish-1.10.7-11.dev-buster
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-11.dev-buster"
+          extra_tags: "1.10.7-11.dev-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-11.dev-buster-onbuild
+            - scan-trivy-1.10.7-11.dev-buster-onbuild
+            - test-1.10.7-11.dev-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.7-11.dev-buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-11.dev-buster-onbuild"
+          extra_tags: "1.10.7-11.dev-buster-onbuild-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-11.dev-buster-onbuild
+            - scan-trivy-1.10.7-11.dev-buster-onbuild
+            - test-1.10.7-11.dev-buster-onbuild
+          filters:
+            branches:
+              only: master
 
 
 jobs:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -6,7 +6,7 @@ workflows:
       - static-checks
 {% for ac_version, distributions in image_map.items() %}
 {% set airflow_version = ac_version.split('-')[0] -%}
-{% set docker_repo = "astronomerio/ap-airflow" if "dev" in airflow_version else "astronomerinc/ap-airflow" -%}
+{% set docker_repo = "astronomerio/ap-airflow" if "dev" in ac_version else "astronomerinc/ap-airflow" -%}
 {% for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -13,7 +13,7 @@ workflows:
           airflow_version: {{ airflow_version }}
           distribution_name: {{ distribution }}
           docker_repo: {{ docker_repo }}
-          {%- if "dev" in airflow_version %}
+          {%- if "dev" in ac_version %}
           extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)"
           {%- endif %}
           requires:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-7", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-3", ["alpine3.10", "buster"]),
-    ("1.10.7-10", ["alpine3.10", "buster"]),
+    ("1.10.7-11.dev", ["alpine3.10", "buster"]),
     ("1.10.10-1", ["alpine3.10", "buster"]),
 ])
 
@@ -55,7 +55,6 @@ def replace_version_info():
     """
     Replace the VERSION in all the Dockerfiles with the corresponding VERSION in IMAGE_MAP
     """
-    current_dir = os.path.dirname(os.path.abspath(__file__))
     for ac_version, distros in IMAGE_MAP.items():
         airflow_version = ac_version.split('-')[0]
         for distro in distros:

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,7 +1,20 @@
 # Changelog
 
+Astronomer Certified 1.10.7-11.dev [DEV Package]
+-------------------------------------------------
+
+### Bug Fixes
+
+- Pin Version of Azure Cosmos to <4 ([commit](https://github.com/astronomer/airflow/commit/ff74293))
+- Make loading plugins from entrypoint fault-tolerant - 1.10.* Backport ([commit](https://github.com/astronomer/airflow/commit/ae9d5b770d8))
+
+
 Astronomer Certified 1.10.7-10, 2020-04-29
 --------------------------------------------
+
+### Bug Fixes
+
+- Constraint version of Flask-Appbuilder to non-broken version ([commit](https://github.com/astronomer/ap-airflow/commit/33da5f5))
 
 ### New Features
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-10"
+ARG VERSION="1.10.7-11.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-10"
+ARG VERSION="1.10.7-11.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds 1.10.7-11.dev

### Bug Fixes

- Pin Version of Azure Cosmos to <4 ([commit](https://github.com/astronomer/airflow/commit/ff74293))
- Make loading plugins from entrypoint fault-tolerant - 1.10.* Backport ([commit](https://github.com/astronomer/airflow/commit/ae9d5b770d8))

### New Feature

- Add support for AWS Secrets Manager as Secrets Backend ([commit](https://github.com/astronomer/airflow/commit/0dc4736))
