### PR TITLE
Temporarily add mariadb to CVE Whitelist

### DIFF
--- a/cve-whitelist.yaml
+++ b/cve-whitelist.yaml
@@ -1,4 +1,6 @@
 generalwhitelist:
+  CVE-2020-13249: mariadb
+
   CVE-2019-5482: curl
   CVE-2019-18224: libidn2
   CVE-2019-19603: sqlite3


### PR DESCRIPTION
https://security-tracker.debian.org/tracker/CVE-2020-13249 is not fixed yet. 

Temporarily adding it to CVE Whitelist 