### PR TITLE
Release Astro Certified 1.10.7-11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,21 +286,20 @@ workflows:
           name: build-1.10.7-alpine3.10
           airflow_version: 1.10.7
           distribution_name: alpine3.10
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.7-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -308,15 +307,15 @@ workflows:
       - test:
           name: test-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution_name: alpine3.10
           requires:
             - build-1.10.7-alpine3.10
       - publish:
           name: publish-1.10.7-alpine3.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-11.dev-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-11-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -326,9 +325,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -341,21 +340,20 @@ workflows:
           name: build-1.10.7-buster
           airflow_version: 1.10.7
           distribution_name: buster
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-buster-onbuild
           airflow_version: 1.10.7
           distribution_name: buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.7-buster
       - scan-trivy:
           name: scan-trivy-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -363,15 +361,15 @@ workflows:
       - test:
           name: test-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution_name: buster
           requires:
             - build-1.10.7-buster
       - publish:
           name: publish-1.10.7-buster
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-11.dev-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-11-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -381,9 +379,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11.dev-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -502,121 +500,6 @@ workflows:
             branches:
               only: master
 
-
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          name: build-1.10.7-alpine3.10
-          airflow_version: 1.10.7
-          distribution_name: alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
-      - scan:
-          name: scan-1.10.7-alpine3.10-onbuild
-          airflow_version: 1.10.7
-          distribution_name: alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.7-alpine3.10
-      - scan-trivy:
-          name: scan-trivy-1.10.7-alpine3.10-onbuild
-          airflow_version: 1.10.7
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: alpine3.10
-          distribution_name: alpine3.10-onbuild
-          requires:
-            - build-1.10.7-alpine3.10
-      - test:
-          name: test-1.10.7-alpine3.10-onbuild
-          airflow_version: 1.10.7
-          docker_repo: "astronomerio/ap-airflow"
-          distribution_name: alpine3.10
-          requires:
-            - build-1.10.7-alpine3.10
-      - publish:
-          name: publish-1.10.7-alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.7-alpine3.10-onbuild
-            - scan-trivy-1.10.7-alpine3.10-onbuild
-            - test-1.10.7-alpine3.10-onbuild
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.7-alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11.dev-alpine3.10-onbuild"
-          requires:
-            - scan-1.10.7-alpine3.10-onbuild
-            - scan-trivy-1.10.7-alpine3.10-onbuild
-            - test-1.10.7-alpine3.10-onbuild
-          filters:
-            branches:
-              only: master
-      - build:
-          name: build-1.10.7-buster
-          airflow_version: 1.10.7
-          distribution_name: buster
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
-      - scan:
-          name: scan-1.10.7-buster-onbuild
-          airflow_version: 1.10.7
-          distribution_name: buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.7-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.7-buster-onbuild
-          airflow_version: 1.10.7
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.7-buster
-      - test:
-          name: test-1.10.7-buster-onbuild
-          airflow_version: 1.10.7
-          docker_repo: "astronomerio/ap-airflow"
-          distribution_name: buster
-          requires:
-            - build-1.10.7-buster
-      - publish:
-          name: publish-1.10.7-buster
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.7-buster-onbuild
-            - scan-trivy-1.10.7-buster-onbuild
-            - test-1.10.7-buster-onbuild
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.7-buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11.dev-buster-onbuild"
-          requires:
-            - scan-1.10.7-buster-onbuild
-            - scan-trivy-1.10.7-buster-onbuild
-            - test-1.10.7-buster-onbuild
-          filters:
-            branches:
-              only: master
 
 
 jobs:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-7", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-3", ["alpine3.10", "buster"]),
-    ("1.10.7-11.dev", ["alpine3.10", "buster"]),
+    ("1.10.7-11", ["alpine3.10", "buster"]),
     ("1.10.10-1", ["alpine3.10", "buster"]),
 ])
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Changelog
 
-Astronomer Certified 1.10.7-11.dev [DEV Package]
--------------------------------------------------
+Astronomer Certified 1.10.7-11, 2020-05-28
+--------------------------------------------
 
 ### Bug Fixes
 
+- Make loading plugins from entrypoint fault-tolerant (#628) ([commit](https://github.com/astronomer/airflow/commit/ae9d5b7))
+- Pin Azure storage to <0.37.0 (#8833) ([commit](https://github.com/astronomer/airflow/commit/cd12692))
 - Pin Version of Azure Cosmos to <4 ([commit](https://github.com/astronomer/airflow/commit/ff74293))
-- Make loading plugins from entrypoint fault-tolerant - 1.10.* Backport ([commit](https://github.com/astronomer/airflow/commit/ae9d5b770d8))
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/astronomer/airflow/commit/69dba65))
 
+### New Features
+- Add support for AWS Secrets Manager as Secrets Backend (#8186)([commit](https://github.com/astronomer/airflow/commit/0dc4736))
 
 Astronomer Certified 1.10.7-10, 2020-04-29
 --------------------------------------------

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-11.*"
+ARG VERSION="1.10.7-11"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-11.*"
+ARG VERSION="1.10.7-11"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
Tag: https://github.com/astronomer/airflow/releases/tag/v1.10.7+astro.11

User-facing changes are

### Bug Fixes

- Make loading plugins from entrypoint fault-tolerant (#628) ([commit](astronomer/airflow@ae9d5b7))
- Pin Azure storage to <0.37.0 (#8833) ([commit](astronomer/airflow@cd12692))
- Pin Version of Azure Cosmos to <4 ([commit](astronomer/airflow@ff74293))
- Stop showing Import Errors for Plugins in Webserver ([commit](astronomer/airflow@69dba65))

### New Features
- Add support for AWS Secrets Manager as Secrets Backend (#8186)([commit](astronomer/airflow@0dc4736))