### PR TITLE
Update alpine images to install Python 3.7.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,20 +12,21 @@ workflows:
           name: build-1.10.5-alpine3.10
           airflow_version: 1.10.5
           distribution_name: alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.5.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.5-alpine3.10-onbuild
           airflow_version: 1.10.5
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.5-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.5-alpine3.10-onbuild
           airflow_version: 1.10.5
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -33,15 +34,15 @@ workflows:
       - test:
           name: test-1.10.5-alpine3.10-onbuild
           airflow_version: 1.10.5
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: alpine3.10
           requires:
             - build-1.10.5-alpine3.10
       - publish:
           name: publish-1.10.5-alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.5-alpine3.10"
-          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM},1.10.5-8.dev-alpine3.10"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -51,9 +52,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.5-alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.5-alpine3.10-onbuild"
-          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-alpine3.10-onbuild"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-8.dev-alpine3.10-onbuild"
           requires:
             - scan-1.10.5-alpine3.10-onbuild
             - scan-trivy-1.10.5-alpine3.10-onbuild
@@ -66,20 +67,21 @@ workflows:
           name: build-1.10.5-buster
           airflow_version: 1.10.5
           distribution_name: buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.5.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.5-buster-onbuild
           airflow_version: 1.10.5
           distribution_name: buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.5-buster
       - scan-trivy:
           name: scan-trivy-1.10.5-buster-onbuild
           airflow_version: 1.10.5
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -87,15 +89,15 @@ workflows:
       - test:
           name: test-1.10.5-buster-onbuild
           airflow_version: 1.10.5
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: buster
           requires:
             - build-1.10.5-buster
       - publish:
           name: publish-1.10.5-buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.5-buster"
-          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-7-buster"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM},1.10.5-8.dev-buster"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -105,9 +107,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.5-buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.5-buster-onbuild"
-          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-buster-onbuild"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-8.dev-buster-onbuild"
           requires:
             - scan-1.10.5-buster-onbuild
             - scan-trivy-1.10.5-buster-onbuild
@@ -120,20 +122,21 @@ workflows:
           name: build-1.10.5-rhel7
           airflow_version: 1.10.5
           distribution_name: rhel7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.5.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.5-rhel7-onbuild
           airflow_version: 1.10.5
           distribution_name: rhel7-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.5-rhel7
       - scan-trivy:
           name: scan-trivy-1.10.5-rhel7-onbuild
           airflow_version: 1.10.5
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: rhel7
           distribution_name: rhel7-onbuild
           requires:
@@ -141,15 +144,15 @@ workflows:
       - test:
           name: test-1.10.5-rhel7-onbuild
           airflow_version: 1.10.5
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: rhel7
           requires:
             - build-1.10.5-rhel7
       - publish:
           name: publish-1.10.5-rhel7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.5-rhel7"
-          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM},1.10.5-8.dev-rhel7"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -159,9 +162,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.5-rhel7-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.5-rhel7-onbuild"
-          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-7-rhel7-onbuild"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-8.dev-rhel7-onbuild"
           requires:
             - scan-1.10.5-rhel7-onbuild
             - scan-trivy-1.10.5-rhel7-onbuild
@@ -286,20 +289,21 @@ workflows:
           name: build-1.10.7-alpine3.10
           airflow_version: 1.10.7
           distribution_name: alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.7-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -307,15 +311,15 @@ workflows:
       - test:
           name: test-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: alpine3.10
           requires:
             - build-1.10.7-alpine3.10
       - publish:
           name: publish-1.10.7-alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-11-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-12.dev-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -325,9 +329,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-12.dev-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -340,20 +344,21 @@ workflows:
           name: build-1.10.7-buster
           airflow_version: 1.10.7
           distribution_name: buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-buster-onbuild
           airflow_version: 1.10.7
           distribution_name: buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.7-buster
       - scan-trivy:
           name: scan-trivy-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -361,15 +366,15 @@ workflows:
       - test:
           name: test-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: buster
           requires:
             - build-1.10.7-buster
       - publish:
           name: publish-1.10.7-buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-11-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-12.dev-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -379,9 +384,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-11-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-12.dev-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -396,20 +401,21 @@ workflows:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10
           distribution_name: alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.10-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -417,15 +423,15 @@ workflows:
       - test:
           name: test-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: alpine3.10
           requires:
             - build-1.10.10-alpine3.10
       - publish:
           name: publish-1.10.10-alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-2.dev-alpine3.10"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -435,9 +441,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-alpine3.10-onbuild"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -450,20 +456,21 @@ workflows:
           name: build-1.10.10-buster
           airflow_version: 1.10.10
           distribution_name: buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-buster-onbuild
           airflow_version: 1.10.10
           distribution_name: buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.10-buster
       - scan-trivy:
           name: scan-trivy-1.10.10-buster-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -471,15 +478,15 @@ workflows:
       - test:
           name: test-1.10.10-buster-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: buster
           requires:
             - build-1.10.10-buster
       - publish:
           name: publish-1.10.10-buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-1-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-2.dev-buster"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -489,9 +496,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-buster-onbuild"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -500,6 +507,383 @@ workflows:
             branches:
               only: master
 
+
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          name: build-1.10.5-alpine3.10
+          airflow_version: 1.10.5
+          distribution_name: alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.5.build)"
+      - scan:
+          name: scan-1.10.5-alpine3.10-onbuild
+          airflow_version: 1.10.5
+          distribution_name: alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.5-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.5-alpine3.10-onbuild
+          airflow_version: 1.10.5
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.5-alpine3.10
+      - test:
+          name: test-1.10.5-alpine3.10-onbuild
+          airflow_version: 1.10.5
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: alpine3.10
+          requires:
+            - build-1.10.5-alpine3.10
+      - publish:
+          name: publish-1.10.5-alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.5-alpine3.10"
+          extra_tags: "1.10.5-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.5-alpine3.10-onbuild
+            - scan-trivy-1.10.5-alpine3.10-onbuild
+            - test-1.10.5-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.5-alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.5-alpine3.10-onbuild"
+          extra_tags: "1.10.5-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.5-8.dev-alpine3.10-onbuild"
+          requires:
+            - scan-1.10.5-alpine3.10-onbuild
+            - scan-trivy-1.10.5-alpine3.10-onbuild
+            - test-1.10.5-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.5-buster
+          airflow_version: 1.10.5
+          distribution_name: buster
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.5.build)"
+      - scan:
+          name: scan-1.10.5-buster-onbuild
+          airflow_version: 1.10.5
+          distribution_name: buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.5-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.5-buster-onbuild
+          airflow_version: 1.10.5
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.5-buster
+      - test:
+          name: test-1.10.5-buster-onbuild
+          airflow_version: 1.10.5
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: buster
+          requires:
+            - build-1.10.5-buster
+      - publish:
+          name: publish-1.10.5-buster
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.5-buster"
+          extra_tags: "1.10.5-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.5-buster-onbuild
+            - scan-trivy-1.10.5-buster-onbuild
+            - test-1.10.5-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.5-buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.5-buster-onbuild"
+          extra_tags: "1.10.5-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.5-8.dev-buster-onbuild"
+          requires:
+            - scan-1.10.5-buster-onbuild
+            - scan-trivy-1.10.5-buster-onbuild
+            - test-1.10.5-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.5-rhel7
+          airflow_version: 1.10.5
+          distribution_name: rhel7
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.5.build)"
+      - scan:
+          name: scan-1.10.5-rhel7-onbuild
+          airflow_version: 1.10.5
+          distribution_name: rhel7-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.5-rhel7
+      - scan-trivy:
+          name: scan-trivy-1.10.5-rhel7-onbuild
+          airflow_version: 1.10.5
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: rhel7
+          distribution_name: rhel7-onbuild
+          requires:
+            - build-1.10.5-rhel7
+      - test:
+          name: test-1.10.5-rhel7-onbuild
+          airflow_version: 1.10.5
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: rhel7
+          requires:
+            - build-1.10.5-rhel7
+      - publish:
+          name: publish-1.10.5-rhel7
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.5-rhel7"
+          extra_tags: "1.10.5-rhel7-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.5-rhel7-onbuild
+            - scan-trivy-1.10.5-rhel7-onbuild
+            - test-1.10.5-rhel7-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.5-rhel7-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.5-rhel7-onbuild"
+          extra_tags: "1.10.5-rhel7-onbuild-${CIRCLE_BUILD_NUM},1.10.5-8.dev-rhel7-onbuild"
+          requires:
+            - scan-1.10.5-rhel7-onbuild
+            - scan-trivy-1.10.5-rhel7-onbuild
+            - test-1.10.5-rhel7-onbuild
+          filters:
+            branches:
+              only: master
+
+      - build:
+          name: build-1.10.7-alpine3.10
+          airflow_version: 1.10.7
+          distribution_name: alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+      - scan:
+          name: scan-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          distribution_name: alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.7-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.7-alpine3.10
+      - test:
+          name: test-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: alpine3.10
+          requires:
+            - build-1.10.7-alpine3.10
+      - publish:
+          name: publish-1.10.7-alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-alpine3.10-onbuild
+            - scan-trivy-1.10.7-alpine3.10-onbuild
+            - test-1.10.7-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.7-alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-12.dev-alpine3.10-onbuild"
+          requires:
+            - scan-1.10.7-alpine3.10-onbuild
+            - scan-trivy-1.10.7-alpine3.10-onbuild
+            - test-1.10.7-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.7-buster
+          airflow_version: 1.10.7
+          distribution_name: buster
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+      - scan:
+          name: scan-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          distribution_name: buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.7-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.7-buster
+      - test:
+          name: test-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: buster
+          requires:
+            - build-1.10.7-buster
+      - publish:
+          name: publish-1.10.7-buster
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-buster-onbuild
+            - scan-trivy-1.10.7-buster-onbuild
+            - test-1.10.7-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.7-buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-12.dev-buster-onbuild"
+          requires:
+            - scan-1.10.7-buster-onbuild
+            - scan-trivy-1.10.7-buster-onbuild
+            - test-1.10.7-buster-onbuild
+          filters:
+            branches:
+              only: master
+
+      - build:
+          name: build-1.10.10-alpine3.10
+          airflow_version: 1.10.10
+          distribution_name: alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+      - scan:
+          name: scan-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          distribution_name: alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.10-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.10-alpine3.10
+      - test:
+          name: test-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: alpine3.10
+          requires:
+            - build-1.10.10-alpine3.10
+      - publish:
+          name: publish-1.10.10-alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10-alpine3.10-onbuild
+            - scan-trivy-1.10.10-alpine3.10-onbuild
+            - test-1.10.10-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.10-alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-alpine3.10-onbuild"
+          requires:
+            - scan-1.10.10-alpine3.10-onbuild
+            - scan-trivy-1.10.10-alpine3.10-onbuild
+            - test-1.10.10-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.10-buster
+          airflow_version: 1.10.10
+          distribution_name: buster
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+      - scan:
+          name: scan-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          distribution_name: buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.10-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.10-buster
+      - test:
+          name: test-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: buster
+          requires:
+            - build-1.10.10-buster
+      - publish:
+          name: publish-1.10.10-buster
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10-buster-onbuild
+            - scan-trivy-1.10.10-buster-onbuild
+            - test-1.10.10-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.10-buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-buster-onbuild"
+          requires:
+            - scan-1.10.10-buster-onbuild
+            - scan-trivy-1.10.10-buster-onbuild
+            - test-1.10.10-buster-onbuild
+          filters:
+            branches:
+              only: master
 
 
 jobs:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,10 +11,10 @@ import re
 from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
-    ("1.10.5-7", ["alpine3.10", "buster", "rhel7"]),
+    ("1.10.5-8.dev", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-3", ["alpine3.10", "buster"]),
-    ("1.10.7-11", ["alpine3.10", "buster"]),
-    ("1.10.10-1", ["alpine3.10", "buster"]),
+    ("1.10.7-12.dev", ["alpine3.10", "buster"]),
+    ("1.10.10-2.dev", ["alpine3.10", "buster"]),
 ])
 
 

--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+Astronomer Certified 1.10.10-2.dev, [DEV Package]
+-----------------------------------------------
+
+### Bug Fixes
+
+- Fix pip install issue caused by Python3.7.7 packages on Alpine-based images
+
+
 Astronomer Certified 1.10.10-1, 2020-04-22
 -----------------------------------------------
 

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.10-1"
+ARG VERSION="1.10.10-2.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
@@ -80,6 +80,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-numpy-dev \
 		py3-numpy \
 		py3-pandas \
+		py3-pip \
 		py3-psycopg2 \
 		py3-pycryptodome \
 		py3-pynacl \
@@ -90,8 +91,6 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
-	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \
-	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
@@ -99,7 +98,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
-	&& sed -i -e '\#https://github.com/astronomer/astronomer/#d' /etc/apk/repositories
+	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.10-1"
+ARG VERSION="1.10.10-2.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 

--- a/1.10.5/CHANGELOG.md
+++ b/1.10.5/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+Astronomer Certified 1.10.5-8.dev, [DEV Package]
+-----------------------------------------------
+
+### Bug Fixes
+
+- Fix pip install issue caused by Python3.7.7 packages on Alpine-based images
+
 Astronomer Certified 1.10.5-7, 2020-04-27
 --------------------------------------------
 

--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -23,7 +23,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-7"
+ARG VERSION="1.10.5-8.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 
@@ -82,6 +82,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-numpy-dev \
 		py3-numpy \
 		py3-pandas \
+		py3-pip \
 		py3-psycopg2 \
 		py3-pycryptodome \
 		py3-pynacl \
@@ -92,8 +93,6 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
-	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \
-	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
@@ -105,7 +104,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
-	&& sed -i -e '\#https://github.com/astronomer/astronomer/#d' /etc/apk/repositories
+	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.5-7"
+ARG VERSION="1.10.5-8.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.5-7"
+ARG VERSION="1.10.5-8.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+Astronomer Certified 1.10.7-12.dev, [DEV Package]
+-----------------------------------------------
+
+### Bug Fixes
+
+- Fix pip install issue caused by Python3.7.7 packages on Alpine-based images
+
 Astronomer Certified 1.10.7-11, 2020-05-28
 --------------------------------------------
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-11"
+ARG VERSION="1.10.7-12.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
@@ -82,14 +82,13 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-pycryptodome \
 		py3-pynacl \
 		py3-typed-ast \
+		py3-pip \
 		python3 \
 		tini \
 	&& apk add --upgrade \
 		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
-	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \
-	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
@@ -97,7 +96,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
-	&& sed -i -e '\#https://github.com/astronomer/astronomer/#d' /etc/apk/repositories
+	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-11"
+ARG VERSION="1.10.7-12.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
Alpine pushed a python3 image for Python 3.7.7 yesterday, and in so
doing that image caused pip to start failing after upgrading, and
installing `python3-dev` would upgrade python3.

Given Alpine doesn't have working wheels, python3-dev is needed for more
of the "interesting" python packages

The "fix" is just to rebuild the image -- I'm just installing pip via a
package now since it is available