### PR TITLE
Add 1.10.10-2.dev & update 1.10.7 Alpine images to install Python 3.7.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,20 +398,21 @@ workflows:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10
           distribution_name: alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.10-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
@@ -419,15 +420,15 @@ workflows:
       - test:
           name: test-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: alpine3.10
           requires:
             - build-1.10.10-alpine3.10
       - publish:
           name: publish-1.10.10-alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-2.dev-alpine3.10"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -437,9 +438,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-alpine3.10-onbuild"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -452,20 +453,21 @@ workflows:
           name: build-1.10.10-buster
           airflow_version: 1.10.10
           distribution_name: buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-buster-onbuild
           airflow_version: 1.10.10
           distribution_name: buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.10-buster
       - scan-trivy:
           name: scan-trivy-1.10.10-buster-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
@@ -473,15 +475,15 @@ workflows:
       - test:
           name: test-1.10.10-buster-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution_name: buster
           requires:
             - build-1.10.10-buster
       - publish:
           name: publish-1.10.10-buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-1-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-2.dev-buster"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -491,9 +493,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-1-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-buster-onbuild"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -614,6 +616,111 @@ workflows:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
             - test-1.10.7-buster-onbuild
+          filters:
+            branches:
+              only: master
+
+      - build:
+          name: build-1.10.10-alpine3.10
+          airflow_version: 1.10.10
+          distribution_name: alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+      - scan:
+          name: scan-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          distribution_name: alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.10-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.10-alpine3.10
+      - test:
+          name: test-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: alpine3.10
+          requires:
+            - build-1.10.10-alpine3.10
+      - publish:
+          name: publish-1.10.10-alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10-alpine3.10-onbuild
+            - scan-trivy-1.10.10-alpine3.10-onbuild
+            - test-1.10.10-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.10-alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-alpine3.10-onbuild"
+          requires:
+            - scan-1.10.10-alpine3.10-onbuild
+            - scan-trivy-1.10.10-alpine3.10-onbuild
+            - test-1.10.10-alpine3.10-onbuild
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.10-buster
+          airflow_version: 1.10.10
+          distribution_name: buster
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+      - scan:
+          name: scan-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          distribution_name: buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.10-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.10-buster
+      - test:
+          name: test-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          docker_repo: "astronomerio/ap-airflow"
+          distribution_name: buster
+          requires:
+            - build-1.10.10-buster
+      - publish:
+          name: publish-1.10.10-buster
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.10-buster-onbuild
+            - scan-trivy-1.10.10-buster-onbuild
+            - test-1.10.10-buster-onbuild
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.10-buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.10-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-2.dev-buster-onbuild"
+          requires:
+            - scan-1.10.10-buster-onbuild
+            - scan-trivy-1.10.10-buster-onbuild
+            - test-1.10.10-buster-onbuild
           filters:
             branches:
               only: master

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -14,7 +14,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-8.dev", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.6-3", ["alpine3.10", "buster"]),
     ("1.10.7-12.dev", ["alpine3.10", "buster"]),
-    ("1.10.10-1", ["alpine3.10", "buster"]),
+    ("1.10.10-2.dev", ["alpine3.10", "buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+Astronomer Certified 1.10.10-2.dev, [DEV Package]
+--------------------------------------------------
+
+### Bug Fixes
+
+- Fix pip install issue caused by Python3.7.7 packages on Alpine-based images
+- BugFix: DAG trigger via UI error in RBAC UI ([commit](https://github.com/astronomer/airflow/commit/356b7b1))
+- Remove duplicate error message on chart connection failure ([commit](https://github.com/astronomer/airflow/commit/c4ff230))
+- Correctly deserialize dagrun_timeout field on DAGs ([commit](https://github.com/astronomer/airflow/commit/1f12f3f))
+- Correctly store non-default Nones in serialized tasks/dags ([commit](https://github.com/astronomer/airflow/commit/2bf89bf))
+- Correctly restore upstream_task_ids when deserializing Operators ([commit](https://github.com/astronomer/airflow/commit/bf04e3e))
+- Make loading plugins from entrypoint fault-tolerant ([commit](https://github.com/astronomer/airflow/commit/35c068c))
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/astronomer/airflow/commit/ef70c9c))
+
 Astronomer Certified 1.10.10-1, 2020-04-22
 -----------------------------------------------
 

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.10-1"
+ARG VERSION="1.10.10-2.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
@@ -80,6 +80,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		py3-numpy-dev \
 		py3-numpy \
 		py3-pandas \
+		py3-pip \
 		py3-psycopg2 \
 		py3-pycryptodome \
 		py3-pynacl \
@@ -90,8 +91,6 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		openssl \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
-	&& pip3 install --no-cache-dir --upgrade pip==19.3.1 \
-	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.4/astronomer_airflow_scripts-0.0.4-py3-none-any.whl" \
@@ -99,7 +98,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
-	&& sed -i -e '\#https://github.com/astronomer/astronomer/#d' /etc/apk/repositories
+	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.10-1"
+ARG VERSION="1.10.10-2.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
Fixed the failing CI: https://github.com/astronomer/airflow/commits/v1-10-10

https://github.com/astronomer/airflow/runs/732801683

I haven't rebased as some of the commits were CI related, and the ones that were already cherry-picked fixes some known issues with DAG Serialization and Plugin Loading