### PR TITLE
Ignore minor CVEs for Buster images

### DIFF
--- a/cve-allowlist.yaml
+++ b/cve-allowlist.yaml
@@ -1,4 +1,8 @@
 generalwhitelist:
+  # These are minor issues for Buster images
+  CVE-2020-10878: perl
+  CVE-2020-10543: perl
+
   CVE-2020-13630: sqlite3
   CVE-2020-13249: mariadb
 


### PR DESCRIPTION
Depends on https://github.com/astronomer/ap-airflow/pull/101


The notes at https://security-tracker.debian.org/tracker/CVE-2020-10878 says it is a Minor issue. for buster & stretch
![image](https://user-images.githubusercontent.com/8811558/84422365-d4ef5700-ac14-11ea-925f-45af343d6737.png)
