### PR TITLE
Exactly match 'apache-airflow' in requirements.txt

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -200,6 +200,11 @@ def test_apache_airflow_in_requirements(tmp_path):
     assert output.returncode == 1
     assert b"Do not upgrade by specifying 'apache-airflow' in your requirements.txt" in output.stderr
 
+    # Test that you can still use backport-packages that start with "apache-airflow"
+    (test_project / "requirements.txt").write_text("apache-airflow-backport-providers-amazon")
+    output = subprocess.run(['docker', 'build', '-t', 'testimage', test_project.resolve()], capture_output=True)
+    assert output.returncode == 0
+
 
 @pytest.fixture(scope='session')
 def webserver(request):

--- a/common/Dockerfile.onbuild-alpine3.10
+++ b/common/Dockerfile.onbuild-alpine3.10
@@ -28,7 +28,7 @@ ONBUILD RUN cat packages.txt | xargs apk add --no-cache
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -q 'apache-airflow' requirements.txt; then \
+ONBUILD RUN if grep -qx 'apache-airflow' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-buster
+++ b/common/Dockerfile.onbuild-buster
@@ -31,7 +31,7 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -q 'apache-airflow' requirements.txt; then \
+ONBUILD RUN if grep -qx 'apache-airflow' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-rhel7
+++ b/common/Dockerfile.onbuild-rhel7
@@ -30,7 +30,7 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -q 'apache-airflow' requirements.txt; then \
+ONBUILD RUN if grep -qx 'apache-airflow' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt


### PR DESCRIPTION
fixes https://github.com/astronomer/issues/issues/1562

Use `grep -qx` instead of `grep -q`:

**Before**:
```
❯ cat re.txt
apache-airflow
apache-airflow-backport-providers-amazon==2020.6.24

❯ grep -q 'apache-airflow' re.txt
❯ echo $?
0
```

**After**:
```
❯ cat re.txt
apache-airflow-backport-providers-amazon==2020.6.24

❯ grep -q 'apache-airflow' re.txt
❯ echo $?
1

❯ grep -qx "apache-airflow" re.txt
❯ echo $?
1
```

