### PR TITLE
Add AC 1.10.7-14.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,35 +173,36 @@ workflows:
           name: build-1.10.7-alpine3.10
           airflow_version: 1.10.7
           distribution_name: alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.7-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
             - build-1.10.7-alpine3.10
       - test:
           name: test-1.10.7-alpine3.10-images
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10"
           requires:
             - build-1.10.7-alpine3.10
       - publish:
           name: publish-1.10.7-alpine3.10
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10"
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-13-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-14.dev-alpine3.10"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -211,9 +212,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-alpine3.10-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-alpine3.10-onbuild"
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-13-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-14.dev-alpine3.10-onbuild"
           requires:
             - scan-1.10.7-alpine3.10-onbuild
             - scan-trivy-1.10.7-alpine3.10-onbuild
@@ -226,35 +227,36 @@ workflows:
           name: build-1.10.7-buster
           airflow_version: 1.10.7
           distribution_name: buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan:
           name: scan-1.10.7-buster-onbuild
           airflow_version: 1.10.7
           distribution_name: buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           requires:
             - build-1.10.7-buster
       - scan-trivy:
           name: scan-trivy-1.10.7-buster-onbuild
           airflow_version: 1.10.7
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
             - build-1.10.7-buster
       - test:
           name: test-1.10.7-buster-images
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster"
           requires:
             - build-1.10.7-buster
       - publish:
           name: publish-1.10.7-buster
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster"
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-13-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-14.dev-buster"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -264,9 +266,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.7-buster-onbuild
-          docker_repo: astronomerinc/ap-airflow
+          docker_repo: astronomerio/ap-airflow
           tag: "1.10.7-buster-onbuild"
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-13-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-14.dev-buster-onbuild"
           requires:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
@@ -396,6 +398,109 @@ workflows:
               only:
                 - master
     jobs:
+      - build:
+          name: build-1.10.7-alpine3.10
+          airflow_version: 1.10.7
+          distribution_name: alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+      - scan:
+          name: scan-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          distribution_name: alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.7-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.7-alpine3.10
+      - test:
+          name: test-1.10.7-alpine3.10-images
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-alpine3.10"
+          requires:
+            - build-1.10.7-alpine3.10
+      - publish:
+          name: publish-1.10.7-alpine3.10
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-alpine3.10-onbuild
+            - scan-trivy-1.10.7-alpine3.10-onbuild
+            - test-1.10.7-alpine3.10-images
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.7-alpine3.10-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-14.dev-alpine3.10-onbuild"
+          requires:
+            - scan-1.10.7-alpine3.10-onbuild
+            - scan-trivy-1.10.7-alpine3.10-onbuild
+            - test-1.10.7-alpine3.10-images
+          filters:
+            branches:
+              only: master
+      - build:
+          name: build-1.10.7-buster
+          airflow_version: 1.10.7
+          distribution_name: buster
+          docker_repo: "astronomerio/ap-airflow"
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+      - scan:
+          name: scan-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          distribution_name: buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          requires:
+            - build-1.10.7-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          docker_repo: "astronomerio/ap-airflow"
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.7-buster
+      - test:
+          name: test-1.10.7-buster-images
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-buster"
+          requires:
+            - build-1.10.7-buster
+      - publish:
+          name: publish-1.10.7-buster
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
+          requires:
+            - scan-1.10.7-buster-onbuild
+            - scan-trivy-1.10.7-buster-onbuild
+            - test-1.10.7-buster-images
+          filters:
+            branches:
+              only: master
+      - publish:
+          name: publish-1.10.7-buster-onbuild
+          docker_repo: "astronomerio/ap-airflow"
+          tag: "1.10.7-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-14.dev-buster-onbuild"
+          requires:
+            - scan-1.10.7-buster-onbuild
+            - scan-trivy-1.10.7-buster-onbuild
+            - test-1.10.7-buster-images
+          filters:
+            branches:
+              only: master
+
       - build:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -12,7 +12,7 @@ from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-9", ["alpine3.10", "buster", "rhel7"]),
-    ("1.10.7-13", ["alpine3.10", "buster"]),
+    ("1.10.7-14.dev", ["alpine3.10", "buster"]),
     ("1.10.10-4.dev", ["alpine3.10", "buster"]),
 ])
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -9,7 +9,11 @@ Astronomer Certified 1.10.7-14.dev, 2020-08-03
 - Run Kubernetes Worker Pods as astro user ([commit](https://github.com/astronomer/ap-airflow/commit/f6819a4))
 - **Dockerfile**: Exactly match `apache-airflow` in `requirements.txt` to restrict installation of 'apache-airflow' ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
 - **Astro Version Check Plugin**: Only show warnings on old versions ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/24ad49e))
-- **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60f91bd54fced1a2d06c40d082be23c0d8a))
+- **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60))
+
+### Improvements
+
+- **Astro Version Check Plugin**: Add more data to UserAgent on Updater Service requests ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/ea7dc6a))
 
 Astronomer Certified 1.10.7-13, 2020-06-18
 --------------------------------------------

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+Astronomer Certified 1.10.7-14.dev, 2020-08-03
+-----------------------------------------------
+
+### Bug Fixes
+
+- Fix broken `/landing_times` View ([commit](https://github.com/astronomer/airflow/commit/5e27133))
+- Run Kubernetes Worker Pods as astro user ([commit](https://github.com/astronomer/ap-airflow/commit/f6819a4))
+- **Dockerfile**: Exactly match `apache-airflow` in `requirements.txt` to restrict installation of 'apache-airflow' ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
+- **Astro Version Check Plugin**: Only show warnings on old versions ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/24ad49e))
+- **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60f91bd54fced1a2d06c40d082be23c0d8a))
+
 Astronomer Certified 1.10.7-13, 2020-06-18
 --------------------------------------------
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-13"
+ARG VERSION="1.10.7-14.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-13"
+ARG VERSION="1.10.7-14.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
https://github.com/astronomer/airflow/commits/v1-10-7

### Bug Fixes

- Fix broken `/landing_times` View ([commit](https://github.com/astronomer/airflow/commit/5e27133))
- Run Kubernetes Worker Pods as astro user ([commit](https://github.com/astronomer/ap-airflow/commit/f6819a4))
- **Dockerfile**: Exactly match `apache-airflow` in `requirements.txt` to restrict installation of 'apache-airflow' ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
- **Astro Version Check Plugin**: Only show warnings on old versions ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/24ad49e))
- **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60f91bd54fced1a2d06c40d082be23c0d8a))