### PR TITLE
Ignore CVE-2020-8116 in AC 1.10.5

### DIFF
--- a/1.10.5/alpine3.10/trivyignore
+++ b/1.10.5/alpine3.10/trivyignore
@@ -1,5 +1,8 @@
 # ignore in old airflow versions; it's fixed ONLY in new airflow version
 # Only used in the dev pipeline, not at runtime
+# dot-prop: Prototype Pollution in dot-prop
+CVE-2020-8116
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487

--- a/1.10.5/buster/trivyignore
+++ b/1.10.5/buster/trivyignore
@@ -1,5 +1,8 @@
 # ignore in old airflow versions; it's fixed ONLY in new airflow version
 # Only used in the dev pipeline, not at runtime
+# dot-prop: Prototype Pollution in dot-prop
+CVE-2020-8116
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487

--- a/1.10.5/rhel7/trivyignore
+++ b/1.10.5/rhel7/trivyignore
@@ -1,5 +1,8 @@
 # ignore in old airflow versions; it's fixed ONLY in new airflow version
 # Only used in the dev pipeline, not at runtime
+# dot-prop: Prototype Pollution in dot-prop
+CVE-2020-8116
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487


### PR DESCRIPTION
This dependency is only used during build time and not runtime and only affects 1.10.5