### PR TITLE
Add more info about AC Docker images

### DIFF
--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -3,9 +3,15 @@
 Astronomer Certified 1.10.10-4.dev, 2020-06-29
 ----------------------------------------------
 
+- Fix broken `/landing_times` View ([commit](https://github.com/astronomer/airflow/commit/a55b8f6))
+- Run Kubernetes Worker Pods as astro user ([commit](https://github.com/astronomer/ap-airflow/commit/f6819a4))
+- **Dockerfile**: Exactly match `apache-airflow` in `requirements.txt` to restrict installation of 'apache-airflow' ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
+- **Astro Version Check Plugin**: Only show warnings on old versions ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/24ad49e))
+- **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60))
+
 ### Improvements
 
-- Enable Dag Serialization by default ([commit](https://github.com/astronomer/airflow/commit/d587b6f))
+- **Astro Version Check Plugin**: Add more data to UserAgent on Updater Service requests ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/ea7dc6a))
 
 
 Astronomer Certified 1.10.10-3, 2020-06-17

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ If you'd like to see the platform in action, [start a free trial on our SaaS ser
 Docker images for deploying and running Astronomer Certified are currently available on
 [DockerHub](https://hub.docker.com/u/astronomerinc/).
 
+We publish 2 variants for each AC Version (example: `1.10.10-3`) and distribution (`debian buster` and `alpine`):
+
+1. `astronomerinc/ap-airflow:1.10.10-3-buster`
+1. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild`
+
+The only difference between them is that the `-onbuild` images uses Docker `ONBUILD` commands to
+copy `packages.txt`, `requirements.txt` and the entire project directory (including `dags`,
+`plugins` folders etc) in the docker file.
+
+For each of our `-onbuild` images we publish two flavors of tag:
+
+1. `astronomerinc/ap-airflow:1.10.10-buster-onbuild` which is our latest release of the `1.10.10` series,
+including latest security patches. This tag is "floating" or movable.
+1. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild` once this tag is pushed it will never change again.
+
 ## Contents of this repo
 
 * The official Dockerfiles that build Astronomer Certified Images
@@ -28,6 +43,8 @@ All changes applied to available point releases will be documented in the `CHANG
 - [1.10.5 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)
 - [1.10.7 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)
 - [1.10.10 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)
+
+## Testing
 
 ### Local testing
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For each of our `-onbuild` images we publish two flavors of tag:
 
 1. `astronomerinc/ap-airflow:1.10.10-buster-onbuild` which is our latest release of the `1.10.10` series,
 including latest security patches. This tag is "floating" or movable.
-1. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild` once this tag is pushed it will never change again.
+2. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild` once this tag is pushed it will never change again.
 
 ## Contents of this repo
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docker images for deploying and running Astronomer Certified are currently avail
 We publish 2 variants for each AC Version (example: `1.10.10-3`) and distribution (`debian buster` and `alpine`):
 
 1. `astronomerinc/ap-airflow:1.10.10-3-buster`
-1. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild`
+2. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild`
 
 The only difference between them is that the `-onbuild` images uses Docker `ONBUILD` commands to
 copy `packages.txt`, `requirements.txt` and the entire project directory (including `dags`,


### PR DESCRIPTION
This docs will help us and the customers.


We publish 2 variants for each AC Version (example: `1.10.10-3`) and distribution (`debian buster` and `alpine`):

1. `astronomerinc/ap-airflow:1.10.10-3-buster`
1. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild`

The only difference between them is that the `-onbuild` images uses Docker `ONBUILD` commands to
copy `packages.txt`, `requirements.txt` and the entire project directory (including `dags`,
`plugins` folders etc) in the docker file.

For each of our `-onbuild` images we publish two flavors of tag:

1. `astronomerinc/ap-airflow:1.10.10-buster-onbuild` which is our latest release of the `1.10.10` series,
including latest security patches. This tag is "floating" or movable.
1. `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild` once this tag is pushed it will never change again.
