### PR TITLE
Release AC 1.10.10+astro.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,36 +283,35 @@ workflows:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10
           distribution_name: alpine3.10
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.10-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
             - build-1.10.10-alpine3.10
       - test:
           name: test-1.10.10-alpine3.10-images
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10"
           requires:
             - build-1.10.10-alpine3.10
       - publish:
           name: publish-1.10.10-alpine3.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-4.dev-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-4-alpine3.10"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -322,9 +321,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-4.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-4-alpine3.10-onbuild"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -337,36 +336,35 @@ workflows:
           name: build-1.10.10-buster
           airflow_version: 1.10.10
           distribution_name: buster
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-buster-onbuild
           airflow_version: 1.10.10
           distribution_name: buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.10-buster
       - scan-trivy:
           name: scan-trivy-1.10.10-buster-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
             - build-1.10.10-buster
       - test:
           name: test-1.10.10-buster-images
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster"
           requires:
             - build-1.10.10-buster
       - publish:
           name: publish-1.10.10-buster
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-4.dev-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-4-buster"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -376,9 +374,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-4.dev-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-4-buster-onbuild"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -497,109 +495,6 @@ workflows:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
             - test-1.10.7-buster-images
-          filters:
-            branches:
-              only: master
-
-      - build:
-          name: build-1.10.10-alpine3.10
-          airflow_version: 1.10.10
-          distribution_name: alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
-      - scan:
-          name: scan-1.10.10-alpine3.10-onbuild
-          airflow_version: 1.10.10
-          distribution_name: alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.10-alpine3.10
-      - scan-trivy:
-          name: scan-trivy-1.10.10-alpine3.10-onbuild
-          airflow_version: 1.10.10
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: alpine3.10
-          distribution_name: alpine3.10-onbuild
-          requires:
-            - build-1.10.10-alpine3.10
-      - test:
-          name: test-1.10.10-alpine3.10-images
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-alpine3.10"
-          requires:
-            - build-1.10.10-alpine3.10
-      - publish:
-          name: publish-1.10.10-alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.10-alpine3.10-onbuild
-            - scan-trivy-1.10.10-alpine3.10-onbuild
-            - test-1.10.10-alpine3.10-images
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.10-alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-4.dev-alpine3.10-onbuild"
-          requires:
-            - scan-1.10.10-alpine3.10-onbuild
-            - scan-trivy-1.10.10-alpine3.10-onbuild
-            - test-1.10.10-alpine3.10-images
-          filters:
-            branches:
-              only: master
-      - build:
-          name: build-1.10.10-buster
-          airflow_version: 1.10.10
-          distribution_name: buster
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
-      - scan:
-          name: scan-1.10.10-buster-onbuild
-          airflow_version: 1.10.10
-          distribution_name: buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.10-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.10-buster-onbuild
-          airflow_version: 1.10.10
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.10-buster
-      - test:
-          name: test-1.10.10-buster-images
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-buster"
-          requires:
-            - build-1.10.10-buster
-      - publish:
-          name: publish-1.10.10-buster
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.10-buster-onbuild
-            - scan-trivy-1.10.10-buster-onbuild
-            - test-1.10.10-buster-images
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.10-buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-4.dev-buster-onbuild"
-          requires:
-            - scan-1.10.10-buster-onbuild
-            - scan-trivy-1.10.10-buster-onbuild
-            - test-1.10.10-buster-images
           filters:
             branches:
               only: master

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-10", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.7-14.dev", ["alpine3.10", "buster"]),
-    ("1.10.10-4.dev", ["alpine3.10", "buster"]),
+    ("1.10.10-4", ["alpine3.10", "buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
-Astronomer Certified 1.10.10-4.dev, 2020-06-29
-----------------------------------------------
+Astronomer Certified 1.10.10-4, 2020-08-04
+--------------------------------------------
+
+### Bug Fixes
 
 - Fix broken `/landing_times` View ([commit](https://github.com/astronomer/airflow/commit/a55b8f6))
 - Run Kubernetes Worker Pods as astro user ([commit](https://github.com/astronomer/ap-airflow/commit/f6819a4))
 - **Dockerfile**: Exactly match `apache-airflow` in `requirements.txt` to restrict installation of 'apache-airflow' ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
 - **Astro Version Check Plugin**: Only show warnings on old versions ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/24ad49e))
 - **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60))
+- Fix Broken PapermillOperator ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/811cc75))
 
 ### Improvements
 

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.10-4.*"
+ARG VERSION="1.10.10-4"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.10-4.*"
+ARG VERSION="1.10.10-4"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v1.10.10%2Bastro.4

@shmanu017 has tested this

### Bug Fixes

- Fix broken `/landing_times` View ([commit](https://github.com/astronomer/airflow/commit/a55b8f6))
- Run Kubernetes Worker Pods as astro user ([commit](https://github.com/astronomer/ap-airflow/commit/f6819a4))
- **Dockerfile**: Exactly match `apache-airflow` in `requirements.txt` to restrict installation of 'apache-airflow' ([commit](https://github.com/astronomer/ap-airflow/commit/c2536db))
- **Astro Version Check Plugin**: Only show warnings on old versions ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/24ad49e))
- **Astro Version Check Plugin**: Make the plugin MySQL compatible ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/0210f60))
- Fix Broken PapermillOperator ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/811cc75))

### Improvements

- **Astro Version Check Plugin**: Add more data to UserAgent on Updater Service requests ([commit](https://github.com/astronomer/astronomer-airflow-version-check/commit/ea7dc6a))
