### PR TITLE
Restrict pinned Airflow version in the requirements.txt

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -217,7 +217,8 @@ def test_apache_airflow_in_requirements(tmp_path):
     image_name = get_image_name(ImageType.ONBUILD.value)
 
     restricted_value_patterns = [
-        "apache-airflow==1.10.10", "apache-airflow>=1.10.5", "apache-airflow~=1.10.7"
+        "apache-airflow==1.10.10", "apache-airflow>=1.10.5", "apache-airflow~=1.10.7",
+        "apache-airflow == 1.10.10",
     ]
 
     (test_project / "Dockerfile").write_text(f"FROM {image_name}")

--- a/1.10.10/alpine3.10/trivyignore
+++ b/1.10.10/alpine3.10/trivyignore
@@ -1,4 +1,7 @@
 # Only used in the dev pipeline, not at runtime
+# lodash
+NSWG-ECO-516
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487

--- a/1.10.10/buster/trivyignore
+++ b/1.10.10/buster/trivyignore
@@ -1,4 +1,7 @@
 # Only used in the dev pipeline, not at runtime
+# lodash
+NSWG-ECO-516
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487

--- a/1.10.7/alpine3.10/trivyignore
+++ b/1.10.7/alpine3.10/trivyignore
@@ -1,4 +1,7 @@
 # Only used in the dev pipeline, not at runtime
+# lodash
+NSWG-ECO-516
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487

--- a/1.10.7/buster/trivyignore
+++ b/1.10.7/buster/trivyignore
@@ -1,4 +1,7 @@
 # Only used in the dev pipeline, not at runtime
+# lodash
+NSWG-ECO-516
+
 # lodash: Prototype pollution in utilities function fixed in >=4.17.11
 CVE-2019-10744
 CVE-2018-16487

--- a/common/Dockerfile.onbuild-alpine3.10
+++ b/common/Dockerfile.onbuild-alpine3.10
@@ -28,7 +28,7 @@ ONBUILD RUN cat packages.txt | xargs apk add --no-cache
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -Eqx 'apache-airflow[=~>]{1,2}.*' requirements.txt; then \
+ONBUILD RUN if grep -Eqx 'apache-airflow\s*[=~>]{1,2}.*' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-alpine3.10
+++ b/common/Dockerfile.onbuild-alpine3.10
@@ -28,7 +28,7 @@ ONBUILD RUN cat packages.txt | xargs apk add --no-cache
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -qx 'apache-airflow' requirements.txt; then \
+ONBUILD RUN if grep -Eqx 'apache-airflow[=~>]{1,2}.*' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-buster
+++ b/common/Dockerfile.onbuild-buster
@@ -31,7 +31,7 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -Eqx 'apache-airflow[=~>]{1,2}.*' requirements.txt; then \
+ONBUILD RUN if grep -Eqx 'apache-airflow\s*[=~>]{1,2}.*' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-buster
+++ b/common/Dockerfile.onbuild-buster
@@ -31,7 +31,7 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -qx 'apache-airflow' requirements.txt; then \
+ONBUILD RUN if grep -Eqx 'apache-airflow[=~>]{1,2}.*' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-rhel7
+++ b/common/Dockerfile.onbuild-rhel7
@@ -30,7 +30,7 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -Eqx 'apache-airflow[=~>]{1,2}.*' requirements.txt; then \
+ONBUILD RUN if grep -Eqx 'apache-airflow\s*[=~>]{1,2}.*' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt

--- a/common/Dockerfile.onbuild-rhel7
+++ b/common/Dockerfile.onbuild-rhel7
@@ -30,7 +30,7 @@ ONBUILD RUN if [[ -s packages.txt ]]; then \
 
 # Install python packages
 ONBUILD COPY requirements.txt .
-ONBUILD RUN if grep -qx 'apache-airflow' requirements.txt; then \
+ONBUILD RUN if grep -Eqx 'apache-airflow[=~>]{1,2}.*' requirements.txt; then \
     echo >&2 "Do not upgrade by specifying 'apache-airflow' in your requirements.txt, change the base image instead!";  exit 1; \
   fi; \
   pip install --no-cache-dir -q -r requirements.txt


### PR DESCRIPTION
Restrict Usage of the following patterns:

["apache-airflow==1.10.10", "apache-airflow>=1.10.5", "apache-airflow~=1.10.7", "apache-airflow == 1.10.10",]
