### PR TITLE
Release AC 1.10.10-5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,36 +283,35 @@ workflows:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10
           distribution_name: alpine3.10
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.10-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
             - build-1.10.10-alpine3.10
       - test:
           name: test-1.10.10-alpine3.10-images
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10"
           requires:
             - build-1.10.10-alpine3.10
       - publish:
           name: publish-1.10.10-alpine3.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-5.dev-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-5-alpine3.10"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -322,9 +321,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5-alpine3.10-onbuild"
           requires:
             - scan-1.10.10-alpine3.10-onbuild
             - scan-trivy-1.10.10-alpine3.10-onbuild
@@ -337,36 +336,35 @@ workflows:
           name: build-1.10.10-buster
           airflow_version: 1.10.10
           distribution_name: buster
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.10-buster-onbuild
           airflow_version: 1.10.10
           distribution_name: buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.10-buster
       - scan-trivy:
           name: scan-trivy-1.10.10-buster-onbuild
           airflow_version: 1.10.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
             - build-1.10.10-buster
       - test:
           name: test-1.10.10-buster-images
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster"
           requires:
             - build-1.10.10-buster
       - publish:
           name: publish-1.10.10-buster
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-5.dev-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-5-buster"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -376,9 +374,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.10-buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5.dev-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5-buster-onbuild"
           requires:
             - scan-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
@@ -607,109 +605,6 @@ workflows:
             - scan-1.10.7-buster-onbuild
             - scan-trivy-1.10.7-buster-onbuild
             - test-1.10.7-buster-images
-          filters:
-            branches:
-              only: master
-
-      - build:
-          name: build-1.10.10-alpine3.10
-          airflow_version: 1.10.10
-          distribution_name: alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
-      - scan:
-          name: scan-1.10.10-alpine3.10-onbuild
-          airflow_version: 1.10.10
-          distribution_name: alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.10-alpine3.10
-      - scan-trivy:
-          name: scan-trivy-1.10.10-alpine3.10-onbuild
-          airflow_version: 1.10.10
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: alpine3.10
-          distribution_name: alpine3.10-onbuild
-          requires:
-            - build-1.10.10-alpine3.10
-      - test:
-          name: test-1.10.10-alpine3.10-images
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-alpine3.10"
-          requires:
-            - build-1.10.10-alpine3.10
-      - publish:
-          name: publish-1.10.10-alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-alpine3.10"
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.10-alpine3.10-onbuild
-            - scan-trivy-1.10.10-alpine3.10-onbuild
-            - test-1.10.10-alpine3.10-images
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.10-alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-alpine3.10-onbuild"
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5.dev-alpine3.10-onbuild"
-          requires:
-            - scan-1.10.10-alpine3.10-onbuild
-            - scan-trivy-1.10.10-alpine3.10-onbuild
-            - test-1.10.10-alpine3.10-images
-          filters:
-            branches:
-              only: master
-      - build:
-          name: build-1.10.10-buster
-          airflow_version: 1.10.10
-          distribution_name: buster
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
-      - scan:
-          name: scan-1.10.10-buster-onbuild
-          airflow_version: 1.10.10
-          distribution_name: buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.10-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.10-buster-onbuild
-          airflow_version: 1.10.10
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.10-buster
-      - test:
-          name: test-1.10.10-buster-images
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-buster"
-          requires:
-            - build-1.10.10-buster
-      - publish:
-          name: publish-1.10.10-buster
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-buster"
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.10-buster-onbuild
-            - scan-trivy-1.10.10-buster-onbuild
-            - test-1.10.10-buster-images
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.10-buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.10-buster-onbuild"
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5.dev-buster-onbuild"
-          requires:
-            - scan-1.10.10-buster-onbuild
-            - scan-trivy-1.10.10-buster-onbuild
-            - test-1.10.10-buster-images
           filters:
             branches:
               only: master

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -13,7 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-10", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.7-15.dev", ["alpine3.10", "buster"]),
-    ("1.10.10-5.dev", ["alpine3.10", "buster"]),
+    ("1.10.10-5", ["alpine3.10", "buster"]),
     ("1.10.12-1.dev", ["alpine3.10", "buster"]),
 ])
 

--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 1.10.10-5, 2020-09-15
+Astronomer Certified 1.10.10-5, 2020-09-16
 --------------------------------------------
 
 ### Bug Fixes

--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+Astronomer Certified 1.10.10-5, 2020-09-15
+--------------------------------------------
+
+### Bug Fixes
+
+- Use Serialized DAGs to sync permissions when DAG Serialization is enabled ([commit](https://github.com/astronomer/airflow/commit/4f546071712728da3db0afcd9fcdabd5851acfd3))
+- Webserver: Sanitize values passed to origin param ([commit](https://github.com/astronomer/airflow/commit/f89a3cfd7ef1d45a17b1354ba60711bc2539839d))
+- Update JS packages to latest versions ([commit](https://github.com/astronomer/airflow/commit/655c7707c228fbf7bb3d2e6bd00515c9acb301f8))
+- Avoid sharing session with RenderedTaskInstanceFields write and delete ([commit](https://github.com/astronomer/airflow/commit/46c6c43c7889b5df7d58ead33e5843b0ea98a9f6))
+- Fix the trigger_dag api in the case of nested subdags ([commit](https://github.com/astronomer/airflow/commit/8c4c4979ca39441e0ce057f02d01f8dfe1773693))
+
 Astronomer Certified 1.10.10-4, 2020-08-04
 --------------------------------------------
 

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.10-5.*"
+ARG VERSION="1.10.10-5"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.10-5.*"
+ARG VERSION="1.10.10-5"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
Astronomer Certified 1.10.10-5, 2020-09-15
--------------------------------------------

### Bug Fixes

- Use Serialized DAGs to sync permissions when DAG Serialization is enabled ([commit](https://github.com/astronomer/airflow/commit/4f546071712728da3db0afcd9fcdabd5851acfd3))
- Webserver: Sanitize values passed to origin param ([commit](https://github.com/astronomer/airflow/commit/f89a3cfd7ef1d45a17b1354ba60711bc2539839d))
- Update JS packages to latest versions ([commit](https://github.com/astronomer/airflow/commit/655c7707c228fbf7bb3d2e6bd00515c9acb301f8))
- Avoid sharing session with RenderedTaskInstanceFields write and delete ([commit](https://github.com/astronomer/airflow/commit/46c6c43c7889b5df7d58ead33e5843b0ea98a9f6))
- Fix the trigger_dag api in the case of nested subdags ([commit](https://github.com/astronomer/airflow/commit/8c4c4979ca39441e0ce057f02d01f8dfe1773693))