### PR TITLE
Add astro user to group 101

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -77,7 +77,10 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip==19.3.1
 
-RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER}
+RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER} \
+    && groupadd astrogroup --gid 101 \
+    && usermod --append --groups astrogroup ${ASTRONOMER_USER}
+
 
 # From the airflow image on master
 

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -81,7 +81,6 @@ RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER} \
     && groupadd astrogroup --gid 101 \
     && usermod --append --groups astrogroup ${ASTRONOMER_USER}
 
-
 # From the airflow image on master
 
 #################################################################

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -77,7 +77,9 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip==19.3.1
 
-RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER}
+RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER} \
+    && groupadd astrogroup --gid 101 \
+    && usermod --append --groups astrogroup ${ASTRONOMER_USER}
 
 # From the airflow image on master
 

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -79,7 +79,9 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip==19.3.1
 
-RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER}
+RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER} \
+    && groupadd astrogroup --gid 101 \
+    && usermod --append --groups astrogroup ${ASTRONOMER_USER}
 
 # From the airflow image on master
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -79,7 +79,9 @@ RUN apt-get update \
 
 RUN pip install --upgrade pip==19.3.1
 
-RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER}
+RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER} \
+    && groupadd astrogroup --gid 101 \
+    && usermod --append --groups astrogroup ${ASTRONOMER_USER}
 
 # From the airflow image on master
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- When using an IAM role in place of connection credentials + our debian image, we see the following error:
`[Errno 13] Permission denied: '/var/run/secrets/eks.amazonaws.com/serviceaccount/token'`
- Becuase we run with `uid 100` and `gid 101` by default (in airflow-chart), `/var/run/secrets/eks.amazonaws.com/serviceaccount/` has the following permissions set and is accessible by `gid 101`:
  - `drwxrwsrwt 3 root 101 100 Sep 15 18:36 serviceaccount`
- We need to add our `astro` (which by default has `uid 50000` and `gid 50000`) to `gid 101`
- Related to https://github.com/astronomer/issues/issues/1797

**Special notes for your reviewer**:
- The group `101` doesn't actually exist and shows up as `nogroup`. I added a step to create this group and named it `astrogroup`. Please feel free to change this name.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
