### PR TITLE
Release AC 1.10.12-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,36 +389,35 @@ workflows:
           name: build-1.10.12-alpine3.10
           airflow_version: 1.10.12
           distribution_name: alpine3.10
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.12-alpine3.10-onbuild
           airflow_version: 1.10.12
           distribution_name: alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.12-alpine3.10
       - scan-trivy:
           name: scan-trivy-1.10.12-alpine3.10-onbuild
           airflow_version: 1.10.12
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: alpine3.10
           distribution_name: alpine3.10-onbuild
           requires:
             - build-1.10.12-alpine3.10
       - test:
           name: test-1.10.12-alpine3.10-images
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.12-alpine3.10"
           requires:
             - build-1.10.12-alpine3.10
       - publish:
           name: publish-1.10.12-alpine3.10
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.12-alpine3.10"
-          extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM},1.10.12-1.dev-alpine3.10"
+          extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM},1.10.12-1-alpine3.10"
           requires:
             - scan-1.10.12-alpine3.10-onbuild
             - scan-trivy-1.10.12-alpine3.10-onbuild
@@ -428,9 +427,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.12-alpine3.10-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.12-alpine3.10-onbuild"
-          extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-1.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-1-alpine3.10-onbuild"
           requires:
             - scan-1.10.12-alpine3.10-onbuild
             - scan-trivy-1.10.12-alpine3.10-onbuild
@@ -443,36 +442,35 @@ workflows:
           name: build-1.10.12-buster
           airflow_version: 1.10.12
           distribution_name: buster
-          docker_repo: astronomerio/ap-airflow
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - static-checks
       - scan:
           name: scan-1.10.12-buster-onbuild
           airflow_version: 1.10.12
           distribution_name: buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           requires:
             - build-1.10.12-buster
       - scan-trivy:
           name: scan-trivy-1.10.12-buster-onbuild
           airflow_version: 1.10.12
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           distribution: buster
           distribution_name: buster-onbuild
           requires:
             - build-1.10.12-buster
       - test:
           name: test-1.10.12-buster-images
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.12-buster"
           requires:
             - build-1.10.12-buster
       - publish:
           name: publish-1.10.12-buster
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.12-buster"
-          extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM},1.10.12-1.dev-buster"
+          extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM},1.10.12-1-buster"
           requires:
             - scan-1.10.12-buster-onbuild
             - scan-trivy-1.10.12-buster-onbuild
@@ -482,9 +480,9 @@ workflows:
               only: master
       - publish:
           name: publish-1.10.12-buster-onbuild
-          docker_repo: astronomerio/ap-airflow
+          docker_repo: astronomerinc/ap-airflow
           tag: "1.10.12-buster-onbuild"
-          extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-1.dev-buster-onbuild"
+          extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-1-buster-onbuild"
           requires:
             - scan-1.10.12-buster-onbuild
             - scan-trivy-1.10.12-buster-onbuild
@@ -493,119 +491,6 @@ workflows:
             branches:
               only: master
 
-
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          name: build-1.10.12-alpine3.10
-          airflow_version: 1.10.12
-          distribution_name: alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
-      - scan:
-          name: scan-1.10.12-alpine3.10-onbuild
-          airflow_version: 1.10.12
-          distribution_name: alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.12-alpine3.10
-      - scan-trivy:
-          name: scan-trivy-1.10.12-alpine3.10-onbuild
-          airflow_version: 1.10.12
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: alpine3.10
-          distribution_name: alpine3.10-onbuild
-          requires:
-            - build-1.10.12-alpine3.10
-      - test:
-          name: test-1.10.12-alpine3.10-images
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.12-alpine3.10"
-          requires:
-            - build-1.10.12-alpine3.10
-      - publish:
-          name: publish-1.10.12-alpine3.10
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.12-alpine3.10"
-          extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.12-alpine3.10-onbuild
-            - scan-trivy-1.10.12-alpine3.10-onbuild
-            - test-1.10.12-alpine3.10-images
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.12-alpine3.10-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.12-alpine3.10-onbuild"
-          extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-1.dev-alpine3.10-onbuild"
-          requires:
-            - scan-1.10.12-alpine3.10-onbuild
-            - scan-trivy-1.10.12-alpine3.10-onbuild
-            - test-1.10.12-alpine3.10-images
-          filters:
-            branches:
-              only: master
-      - build:
-          name: build-1.10.12-buster
-          airflow_version: 1.10.12
-          distribution_name: buster
-          docker_repo: "astronomerio/ap-airflow"
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
-      - scan:
-          name: scan-1.10.12-buster-onbuild
-          airflow_version: 1.10.12
-          distribution_name: buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          requires:
-            - build-1.10.12-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.12-buster-onbuild
-          airflow_version: 1.10.12
-          docker_repo: "astronomerio/ap-airflow"
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.12-buster
-      - test:
-          name: test-1.10.12-buster-images
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.12-buster"
-          requires:
-            - build-1.10.12-buster
-      - publish:
-          name: publish-1.10.12-buster
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.12-buster"
-          extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM}"
-          requires:
-            - scan-1.10.12-buster-onbuild
-            - scan-trivy-1.10.12-buster-onbuild
-            - test-1.10.12-buster-images
-          filters:
-            branches:
-              only: master
-      - publish:
-          name: publish-1.10.12-buster-onbuild
-          docker_repo: "astronomerio/ap-airflow"
-          tag: "1.10.12-buster-onbuild"
-          extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-1.dev-buster-onbuild"
-          requires:
-            - scan-1.10.12-buster-onbuild
-            - scan-trivy-1.10.12-buster-onbuild
-            - test-1.10.12-buster-images
-          filters:
-            branches:
-              only: master
 
 
 jobs:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -14,7 +14,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-11.dev", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.7-15", ["alpine3.10", "buster"]),
     ("1.10.10-5", ["alpine3.10", "buster"]),
-    ("1.10.12-1.dev", ["alpine3.10", "buster"]),
+    ("1.10.12-1", ["alpine3.10", "buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/1.10.12/CHANGELOG.md
+++ b/1.10.12/CHANGELOG.md
@@ -1,8 +1,28 @@
 # Changelog
 
-Astronomer Certified 1.10.12-1.dev, 2020-08-18
+Astronomer Certified 1.10.12-1, 2020-09-29
 -----------------------------------------------
 
 CHANGELOG for AC `1.10.12+astro.1` from Airflow `1.10.12`:
 
-TBD
+### Bug Fixes
+
+- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/49d4840))
+- KubernetesPodOperator template fix (#10963) ([commit](https://github.com/apache/airflow/commit/259f1b797))
+- Fix operator field update for SerializedBaseOperator ([commit](https://github.com/apache/airflow/commit/cfc9732d7))
+- Fix pod_mutation_hook ([commit](https://github.com/apache/airflow/commit/73b5fe1aa))
+- Fix formatting of Host information ([commit](https://github.com/apache/airflow/commit/4d820744c))
+
+### Improvements
+
+- Adding body as templated field for CloudSqlImportOperator ([commit](https://github.com/apache/airflow/commit/18e3a3b))
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/ac17612))
+- Restrict 'nteract-scrapbook' to <0.4 ([commit](https://github.com/apache/airflow/commit/b4312ef))
+- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/8da0ad8))
+- Remove deprecation warning from contrib/kubernetes/pod.py ([commit](https://github.com/apache/airflow/commit/5721d39))
+- Make grace_period_seconds option on KubernetesPodOperator ([commit](https://github.com/apache/airflow/commit/236b9b3b2))
+- Add on_kill support for the KubernetesPodOperator ([commit](https://github.com/apache/airflow/commit/ce94497cc))
+
+### New Features
+
+- Add Secrets backend for Microsoft Azure Key Vault ([commit](https://github.com/apache/airflow/commit/908515f13))

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.12-1.*"
+ARG VERSION="1.10.12-1"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.12-1.*"
+ARG VERSION="1.10.12-1"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
Release: https://github.com/astronomer/airflow/releases/tag/v1.10.12%2Bastro.1

CHANGELOG for AC `1.10.12+astro.1` from Airflow `1.10.12`:

### Bug Fixes

- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/49d4840))
- KubernetesPodOperator template fix (#10963) ([commit](https://github.com/apache/airflow/commit/259f1b797))
- Fix operator field update for SerializedBaseOperator ([commit](https://github.com/apache/airflow/commit/cfc9732d7))
- Fix pod_mutation_hook ([commit](https://github.com/apache/airflow/commit/73b5fe1aa))
- Fix formatting of Host information ([commit](https://github.com/apache/airflow/commit/4d820744c))

### Improvements

- Adding body as templated field for CloudSqlImportOperator ([commit](https://github.com/apache/airflow/commit/18e3a3b))
- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/ac17612))
- Restrict 'nteract-scrapbook' to <0.4 ([commit](https://github.com/apache/airflow/commit/b4312ef))
- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/8da0ad8))
- Remove deprecation warning from contrib/kubernetes/pod.py ([commit](https://github.com/apache/airflow/commit/5721d39))
- Make grace_period_seconds option on KubernetesPodOperator ([commit](https://github.com/apache/airflow/commit/236b9b3b2))
- Add on_kill support for the KubernetesPodOperator ([commit](https://github.com/apache/airflow/commit/ce94497cc))

### New Features

- Add Secrets backend for Microsoft Azure Key Vault ([commit](https://github.com/apache/airflow/commit/908515f13))