### PR TITLE
Use newer machine image, newer python.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,7 +725,7 @@ jobs:
       - run:
           name: Load archived Docker image
           command: |
-            pyenv global 3.7.0
+            pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
             pre-commit run --all-files
   build:
@@ -851,7 +851,7 @@ executors:
       - image: circleci/python:3
   machine-executor:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202008-01
 commands:
 
   docker-build-base-and-onbuild:
@@ -931,7 +931,7 @@ commands:
           name: Test Airflow Docker images (Base + Onbuild)
           command: |
             set -e
-            pyenv global 3.7.0
+            pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
             .circleci/bin/test-airflow << parameters.repository >> << parameters.tag >>
       - store_test_results:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -151,7 +151,7 @@ jobs:
       - run:
           name: Load archived Docker image
           command: |
-            pyenv global 3.7.0
+            pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
             pre-commit run --all-files
   build:
@@ -277,7 +277,7 @@ executors:
       - image: circleci/python:3
   machine-executor:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202008-01
 commands:
 
   docker-build-base-and-onbuild:
@@ -357,7 +357,7 @@ commands:
           name: Test Airflow Docker images (Base + Onbuild)
           command: |
             set -e
-            pyenv global 3.7.0
+            pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
             .circleci/bin/test-airflow << parameters.repository >> << parameters.tag >>
       - store_test_results:


### PR DESCRIPTION
**What this PR does / why we need it**:

The machine image we are currently using is being deprecated. This change set updates the machine image, and also updates the version of python being used in CI to one supported by the new machine image.

All changes only affect CI runs.

