### PR TITLE
Skip Werkzeug version test for Airflow >2

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -81,6 +81,7 @@ def test_elasticsearch_version(webserver):
         "elasticsearch module must be version 5.5.3 or greater"
 
 
+@pytest.mark.skipif(airflow_2, reason="Not needed for Airflow>=2")
 def test_werkzeug_version(webserver):
     """ Werkzeug pip module version >= 1.0.0 has an issue
     """


### PR DESCRIPTION
This was pinned for Airflow < 2 as it was a breaking change, since Airflow 2 this works fine. 