### PR TITLE
Stopping running sync_perm multiple times for Airflow >= 1.10.7

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -251,6 +251,12 @@ def test_airflow_configs(scheduler, docker_client):
                 "cat /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg | "
                 "grep '^run_as_user' | awk '{print $3}'").strip() == ""
 
+    if semantic_version(airflow_version) >= semantic_version('1.10.10'):
+        assert scheduler.check_output(
+            "cat /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg | "
+            "grep '^update_fab_perms' | awk '{print $3}'"
+        ) == "False", "[webserver] update_fab_perms needs to be False for AC >= 1.10.10"
+
 
 def test_labels_for_onbuild_image(docker_client):
     """ Ensure correct labels exists on onbuild image """

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -251,7 +251,7 @@ def test_airflow_configs(scheduler, docker_client):
                 "cat /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg | "
                 "grep '^run_as_user' | awk '{print $3}'").strip() == ""
 
-    if semantic_version(airflow_version) >= semantic_version('1.10.10'):
+    if semantic_version(airflow_version) >= semantic_version('1.10.7'):
         assert scheduler.check_output(
             "cat /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg | "
             "grep '^update_fab_perms' | awk '{print $3}'"

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -100,8 +100,14 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
 	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 100/g' /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 100/g' \
+    # Needed by astronomer-version-check-plugin
+    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -105,7 +105,7 @@ RUN sed -i \
     -e 's/^run_as_user =.*/run_as_user = 100/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
-    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+    /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -103,8 +103,6 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 100/g' \
-    # Needed by astronomer-version-check-plugin
-    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -140,8 +140,14 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 50000/g' /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 50000/g' \
+    # Needed by astronomer-version-check-plugin
+    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -143,8 +143,6 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # Needed by astronomer-version-check-plugin
-    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -100,8 +100,14 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
 	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 100/g' /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 100/g' \
+    # Needed by astronomer-version-check-plugin
+    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -105,7 +105,7 @@ RUN sed -i \
     -e 's/^run_as_user =.*/run_as_user = 100/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
-    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+    /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -103,8 +103,6 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 100/g' \
-    # Needed by astronomer-version-check-plugin
-    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -140,8 +140,14 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 50000/g' /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 50000/g' \
+    # Needed by astronomer-version-check-plugin
+    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -143,8 +143,6 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # Needed by astronomer-version-check-plugin
-    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -103,7 +103,7 @@ RUN sed -i \
     -e 's/^run_as_user =.*/run_as_user = 100/g' \
     # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
-    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+    /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -98,8 +98,12 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \
 	&& sed -i -e '\#https://github.com/astronomer/#d' /etc/apk/repositories
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 100/g' /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 100/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -142,8 +142,12 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 50000/g' /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 50000/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -141,11 +141,14 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
-# Run pods spun up by Kubernetes Executor as astro user
-RUN sed -i -e 's/^run_as_user =.*/run_as_user = 50000/g' /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
-
-# Needed by astronomer-version-check-plugin
-RUN sed -i -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 50000/g' \
+    # Needed by astronomer-version-check-plugin
+    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    /usr/local/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes
 RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \


### PR DESCRIPTION
We already run `sync_perm` in the entrypoint, so sync'ing permissions when the webserver is started is not needed. Otherwise each gunicorn workers run this commands unncessary and cause a delayed start

closes https://github.com/astronomer/issues/issues/1962