### PR TITLE
Update to new helm stable repo

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -23,7 +23,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $DIR/install-ci-tools
 source $DIR/start-kind-cluster
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add stable https://charts.helm.sh/stable/
 helm repo add astronomer https://internal-helm.astronomer.io/
 helm repo update
 


### PR DESCRIPTION
Switch out deprecated helm repo for new stable repo.

- <https://www.cncf.io/blog/2020/11/05/helm-chart-repository-deprecation-update/>
- <https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository>

Relates to astronomer/issues#2003