### PR TITLE
Add sync_perm / sync-perm command to our buster images

### DIFF
--- a/1.10.10/buster/include/entrypoint
+++ b/1.10.10/buster/include/entrypoint
@@ -44,5 +44,9 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
+if [[ $CMD == "webserver" ]]; then
+  airflow sync_perm
+fi
+
 # Run the original command
 exec "$@"

--- a/1.10.12/buster/include/entrypoint
+++ b/1.10.12/buster/include/entrypoint
@@ -44,5 +44,9 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
+if [[ $CMD == "webserver" ]]; then
+  airflow sync_perm
+fi
+
 # Run the original command
 exec "$@"

--- a/1.10.7/buster/include/entrypoint
+++ b/1.10.7/buster/include/entrypoint
@@ -44,5 +44,9 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
+if [[ $CMD == "webserver" ]]; then
+  airflow sync_perm
+fi
+
 # Run the original command
 exec "$@"

--- a/2.0.0/buster/include/entrypoint
+++ b/2.0.0/buster/include/entrypoint
@@ -44,5 +44,9 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|celery worker
   done
 fi
 
+if [[ $CMD == "webserver" ]]; then
+  airflow sync-perm
+fi
+
 # Run the original command
 exec "$@"


### PR DESCRIPTION
Looks like only alpine and rhel images had sync_perm (1.10.x) / sync-perm (2.0) command in their entrypoints. This commit adds to buster images too

