### PR TITLE
Add 1.10.7-16.dev & 1.10.10-6.dev image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,8 @@ workflows:
           name: build-1.10.7-alpine3.10
           airflow_version: 1.10.7
           distribution_name: alpine3.10
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan-clair:
@@ -200,7 +201,7 @@ workflows:
           name: push-1.10.7-alpine3.10
           tag: "1.10.7-alpine3.10"
           dev_build: false
-          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-15-alpine3.10"
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM},1.10.7-16.dev-alpine3.10"
           context:
             - quay.io
           requires:
@@ -215,7 +216,7 @@ workflows:
           name: push-1.10.7-alpine3.10-onbuild
           tag: "1.10.7-alpine3.10-onbuild"
           dev_build: false
-          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-15-alpine3.10-onbuild"
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-16.dev-alpine3.10-onbuild"
           context:
             - quay.io
           requires:
@@ -230,7 +231,8 @@ workflows:
           name: build-1.10.7-buster
           airflow_version: 1.10.7
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
           requires:
             - static-checks
       - scan-clair:
@@ -255,7 +257,7 @@ workflows:
           name: push-1.10.7-buster
           tag: "1.10.7-buster"
           dev_build: false
-          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-15-buster"
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM},1.10.7-16.dev-buster"
           context:
             - quay.io
           requires:
@@ -270,7 +272,7 @@ workflows:
           name: push-1.10.7-buster-onbuild
           tag: "1.10.7-buster-onbuild"
           dev_build: false
-          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-15-buster-onbuild"
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-16.dev-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -285,7 +287,8 @@ workflows:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10
           distribution_name: alpine3.10
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
           requires:
             - static-checks
       - scan-clair:
@@ -310,7 +313,7 @@ workflows:
           name: push-1.10.10-alpine3.10
           tag: "1.10.10-alpine3.10"
           dev_build: false
-          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-5-alpine3.10"
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM},1.10.10-6.dev-alpine3.10"
           context:
             - quay.io
           requires:
@@ -325,7 +328,7 @@ workflows:
           name: push-1.10.10-alpine3.10-onbuild
           tag: "1.10.10-alpine3.10-onbuild"
           dev_build: false
-          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5-alpine3.10-onbuild"
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-6.dev-alpine3.10-onbuild"
           context:
             - quay.io
           requires:
@@ -340,7 +343,8 @@ workflows:
           name: build-1.10.10-buster
           airflow_version: 1.10.10
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
           requires:
             - static-checks
       - scan-clair:
@@ -365,7 +369,7 @@ workflows:
           name: push-1.10.10-buster
           tag: "1.10.10-buster"
           dev_build: false
-          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-5-buster"
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM},1.10.10-6.dev-buster"
           context:
             - quay.io
           requires:
@@ -380,7 +384,7 @@ workflows:
           name: push-1.10.10-buster-onbuild
           tag: "1.10.10-buster-onbuild"
           dev_build: false
-          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-5-buster-onbuild"
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-6.dev-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -568,6 +572,222 @@ workflows:
               only:
                 - master
     jobs:
+      - build:
+          name: build-1.10.7-alpine3.10
+          airflow_version: 1.10.7
+          distribution_name: alpine3.10
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+      - scan-clair:
+          name: scan-clair-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.7-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.7-alpine3.10-onbuild
+          airflow_version: 1.10.7
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.7-alpine3.10
+      - test:
+          name: test-1.10.7-alpine3.10-images
+          tag: "1.10.7-alpine3.10"
+          requires:
+            - build-1.10.7-alpine3.10
+      - push:
+          name: push-1.10.7-alpine3.10
+          tag: "1.10.7-alpine3.10"
+          dev_build: true
+          extra_tags: "1.10.7-alpine3.10-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.7-alpine3.10-onbuild
+            - scan-trivy-1.10.7-alpine3.10-onbuild
+            - test-1.10.7-alpine3.10-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-1.10.7-alpine3.10-onbuild
+          tag: "1.10.7-alpine3.10-onbuild"
+          dev_build: true
+          extra_tags: "1.10.7-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.7-16.dev-alpine3.10-onbuild"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.7-alpine3.10-onbuild
+            - scan-trivy-1.10.7-alpine3.10-onbuild
+            - test-1.10.7-alpine3.10-images
+          filters:
+            branches:
+              only:
+                - master
+      - build:
+          name: build-1.10.7-buster
+          airflow_version: 1.10.7
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.7.build)"
+      - scan-clair:
+          name: scan-clair-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.7-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.7-buster-onbuild
+          airflow_version: 1.10.7
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.7-buster
+      - test:
+          name: test-1.10.7-buster-images
+          tag: "1.10.7-buster"
+          requires:
+            - build-1.10.7-buster
+      - push:
+          name: push-1.10.7-buster
+          tag: "1.10.7-buster"
+          dev_build: true
+          extra_tags: "1.10.7-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.7-buster-onbuild
+            - scan-trivy-1.10.7-buster-onbuild
+            - test-1.10.7-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-1.10.7-buster-onbuild
+          tag: "1.10.7-buster-onbuild"
+          dev_build: true
+          extra_tags: "1.10.7-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.7-16.dev-buster-onbuild"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.7-buster-onbuild
+            - scan-trivy-1.10.7-buster-onbuild
+            - test-1.10.7-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - build:
+          name: build-1.10.10-alpine3.10
+          airflow_version: 1.10.10
+          distribution_name: alpine3.10
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+      - scan-clair:
+          name: scan-clair-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.10-alpine3.10
+      - scan-trivy:
+          name: scan-trivy-1.10.10-alpine3.10-onbuild
+          airflow_version: 1.10.10
+          distribution: alpine3.10
+          distribution_name: alpine3.10-onbuild
+          requires:
+            - build-1.10.10-alpine3.10
+      - test:
+          name: test-1.10.10-alpine3.10-images
+          tag: "1.10.10-alpine3.10"
+          requires:
+            - build-1.10.10-alpine3.10
+      - push:
+          name: push-1.10.10-alpine3.10
+          tag: "1.10.10-alpine3.10"
+          dev_build: true
+          extra_tags: "1.10.10-alpine3.10-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.10-alpine3.10-onbuild
+            - scan-trivy-1.10.10-alpine3.10-onbuild
+            - test-1.10.10-alpine3.10-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-1.10.10-alpine3.10-onbuild
+          tag: "1.10.10-alpine3.10-onbuild"
+          dev_build: true
+          extra_tags: "1.10.10-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.10-6.dev-alpine3.10-onbuild"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.10-alpine3.10-onbuild
+            - scan-trivy-1.10.10-alpine3.10-onbuild
+            - test-1.10.10-alpine3.10-images
+          filters:
+            branches:
+              only:
+                - master
+      - build:
+          name: build-1.10.10-buster
+          airflow_version: 1.10.10
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.10.build)"
+      - scan-clair:
+          name: scan-clair-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.10-buster
+      - scan-trivy:
+          name: scan-trivy-1.10.10-buster-onbuild
+          airflow_version: 1.10.10
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.10-buster
+      - test:
+          name: test-1.10.10-buster-images
+          tag: "1.10.10-buster"
+          requires:
+            - build-1.10.10-buster
+      - push:
+          name: push-1.10.10-buster
+          tag: "1.10.10-buster"
+          dev_build: true
+          extra_tags: "1.10.10-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.10-buster-onbuild
+            - scan-trivy-1.10.10-buster-onbuild
+            - test-1.10.10-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-1.10.10-buster-onbuild
+          tag: "1.10.10-buster-onbuild"
+          dev_build: true
+          extra_tags: "1.10.10-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.10-6.dev-buster-onbuild"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-1.10.10-buster-onbuild
+            - scan-trivy-1.10.10-buster-onbuild
+            - test-1.10.10-buster-images
+          filters:
+            branches:
+              only:
+                - master
       - build:
           name: build-1.10.12-alpine3.10
           airflow_version: 1.10.12

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -12,8 +12,8 @@ from jinja2 import Environment, FileSystemLoader
 
 IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-11", ["alpine3.10", "buster", "rhel7"]),
-    ("1.10.7-15", ["alpine3.10", "buster"]),
-    ("1.10.10-5", ["alpine3.10", "buster"]),
+    ("1.10.7-16.dev", ["alpine3.10", "buster"]),
+    ("1.10.10-6.dev", ["alpine3.10", "buster"]),
     ("1.10.12-2.dev", ["alpine3.10", "buster"]),
     ("2.0.0-1.dev", ["buster"]),
 ])

--- a/1.10.10/CHANGELOG.md
+++ b/1.10.10/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+Astronomer Certified 1.10.10-6.dev, TBD
+--------------------------------------------
+
+### Bug Fixes
+
+- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/1096bd10329bb77837bacf5b1c364f936057f7a4))
+- Stopping running `sync_perm` multiple times for Airflow >= 1.10.7 ([commit](https://github.com/astronomer/ap-airflow/commit/9c10dcfcda53dbbb88a0a41f6ae917c4edbd8694))
+
 Astronomer Certified 1.10.10-5, 2020-09-16
 --------------------------------------------
 

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.10-5"
+ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.10-5"
+ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 

--- a/1.10.7/CHANGELOG.md
+++ b/1.10.7/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+Astronomer Certified 1.10.7-16.dev, TBD
+-------------------------------------------
+
+### Bug Fixes
+
+- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/bfff55cfed414adf3dca33b410266a80c7a69666))
+- Stopping running `sync_perm` multiple times for Airflow >= 1.10.7 ([commit](https://github.com/astronomer/ap-airflow/commit/9c10dcfcda53dbbb88a0a41f6ae917c4edbd8694))
+
+
 Astronomer Certified 1.10.7-15, 2020-09-22
 -------------------------------------------
 

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.7-15"
+ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -107,7 +107,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.7-15"
+ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 


### PR DESCRIPTION
https://github.com/astronomer/airflow/tree/v1-10-7
https://github.com/astronomer/airflow/tree/v1-10-10

Contains the following bug-fixes:

### Bug Fixes

- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/1096bd10329bb77837bacf5b1c364f936057f7a4))
- Stopping running `sync_perm` multiple times for Airflow >= 1.10.7 ([commit](https://github.com/astronomer/ap-airflow/commit/9c10dcfcda53dbbb88a0a41f6ae917c4edbd8694))
