### PR TITLE
Fix AC Version Docker label for Buster images

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -67,6 +67,10 @@ def test_version(webserver, docker_client):
     version_output = webserver.check_output('airflow version')
     assert airflow_ver in version_output
 
+    # AC Version should not be empty and should contain Airflow Version in it
+    ac_version = get_label(docker_client, 'io.astronomer.docker.ac.version')
+    assert airflow_ver in ac_version
+
 
 def test_elasticsearch_version(webserver):
     """ Astronomer runs a version of ElasticSearch that requires

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -109,6 +109,9 @@ ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
+LABEL io.astronomer.docker.airflow.version="1.10.10"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -123,9 +126,6 @@ RUN pip install "${AIRFLOW_MODULE}" \
 ## move this to same layer as airflow because its from tag.
 
 FROM ${APT_DEPS_IMAGE} as main
-
-LABEL io.astronomer.docker.airflow.version="1.10.10"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -109,6 +109,9 @@ ARG VERSION="1.10.12-2.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
+LABEL io.astronomer.docker.airflow.version="1.10.12"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -123,9 +126,6 @@ RUN pip install "${AIRFLOW_MODULE}" \
 ## move this to same layer as airflow because its from tag.
 
 FROM ${APT_DEPS_IMAGE} as main
-
-LABEL io.astronomer.docker.airflow.version="1.10.12"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -16,16 +16,17 @@
 FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
+ARG ORG="astronomer"
+ARG VERSION="1.10.5-11"
+ARG SUBMODULES="all, statsd, elasticsearch"
+ARG REPO_BRANCH=master
+
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
-
-ARG ORG="astronomer"
-ARG VERSION="1.10.5-11"
-ARG SUBMODULES="all, statsd, elasticsearch"
-ARG REPO_BRANCH=master
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_REPOSITORY="https://github.com/${ORG}/airflow"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -112,6 +112,9 @@ ARG VERSION="1.10.5-11"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 
+LABEL io.astronomer.docker.airflow.version="1.10.5"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+
 # Force pip to install these specific versions when ever it installs a module
 ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
@@ -135,7 +138,6 @@ RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
 
 FROM ${APT_DEPS_IMAGE} as main
 
-LABEL io.astronomer.docker.airflow.version="1.10.5"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.5/rhel7/Dockerfile
+++ b/1.10.5/rhel7/Dockerfile
@@ -3,16 +3,17 @@ MAINTAINER Astronomer <humans@astronomer.io>
 
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
+ARG ORG="astronomer"
+ARG VERSION="1.10.5-11"
+ARG SUBMODULES="all, statsd, elasticsearch"
+ARG REPO_BRANCH=master
+
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="rhel"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"
-
-ARG ORG="astronomer"
-ARG VERSION="1.10.5-11"
-ARG SUBMODULES="all, statsd, elasticsearch"
-ARG REPO_BRANCH=master
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 
 ENV AIRFLOW_REPOSITORY="https://github.com/${ORG}/airflow"

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -111,6 +111,9 @@ ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
+LABEL io.astronomer.docker.airflow.version="1.10.7"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -125,9 +128,6 @@ RUN pip install "${AIRFLOW_MODULE}" \
 ## move this to same layer as airflow because its from tag.
 
 FROM ${APT_DEPS_IMAGE} as main
-
-LABEL io.astronomer.docker.airflow.version="1.10.7"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -109,6 +109,9 @@ ARG VERSION="2.0.0-1.*"
 ARG SUBMODULES="async,azure,aws,celery,elasticsearch,gcp,password,kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
+LABEL io.astronomer.docker.airflow.version="2.0.0"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -124,9 +127,6 @@ RUN pip install "${AIRFLOW_MODULE}" \
 ## move this to same layer as airflow because its from tag.
 
 FROM ${APT_DEPS_IMAGE} as main
-
-LABEL io.astronomer.docker.airflow.version="2.0.0"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
Our Buster Image had empty string as AC Version, I think it was because the labels were applied in a different image in our Stage build.

![image](https://user-images.githubusercontent.com/8811558/99396328-85a30600-28d9-11eb-9de0-69a303b02f8e.png)
