### PR TITLE
Pin pyzmq<20.0 for Alpine images

### DIFF
--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -7,6 +7,7 @@ JPype1<0.7.3
 # Make sure we don't get pyarrow installed, libarrow is difficult to get working in Alpine
 papermill<2.0
 nteract-scrapbook<0.4
+pyzmq<20.0
 
 WTforms<2.3.0
 

--- a/1.10.12/alpine3.10/include/pip-constraints.txt
+++ b/1.10.12/alpine3.10/include/pip-constraints.txt
@@ -7,6 +7,7 @@ JPype1<0.7.3
 # Make sure we don't get pyarrow installed, libarrow is difficult to get working in Alpine
 papermill<2.0
 nteract-scrapbook<0.4
+pyzmq<20.0
 
 WTforms<2.3.0
 

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -8,6 +8,7 @@ JPype1<0.7.3
 # Make sure we don't get pyarrow installed, libarrow is difficult to get working in Alpine
 papermill<2.0
 nteract-scrapbook<0.4
+pyzmq<20.0
 
 WTforms<2.3.0
 


### PR DESCRIPTION
Pyzmq>=20.0 is causing issues with Alpine images: https://app.circleci.com/pipelines/github/astronomer/ap-airflow/942/workflows/36119999-b555-41a3-9d10-d0ab638462d5/jobs/22427
