### PR TITLE
Don't check for commits against master -- it breaks CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,6 @@ repos:
         files: '^.gitignore$'
       - id: mixed-line-ending
         args: ["--fix=lf"]
-      - id: no-commit-to-branch
-        args: ["--branch", "master", '--branch', 'main']
       - id: trailing-whitespace
   - repo: local
     hooks:


### PR DESCRIPTION
We can't have this check -- as it breaks when pre-commit is used in CI
to run the same checks.


**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py