### PR TITLE
Use Airflow Constraints file for AC 1.10.12 and 1.10.13

### DIFF
--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -90,8 +90,8 @@ def replace_version_info():
 
                 # Replace Airflow Version
                 new_text = re.sub(
-                    r'ENV AIRFLOW_VERSION=(.*)',
-                    f'ENV AIRFLOW_VERSION="{airflow_version}"',
+                    r'ARG AIRFLOW_VERSION=(.*)',
+                    f'ARG AIRFLOW_VERSION="{airflow_version}"',
                     new_text,
                     flags=re.MULTILINE
                 )

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -90,8 +90,8 @@ def replace_version_info():
 
                 # Replace Airflow Version
                 new_text = re.sub(
-                    r'LABEL io.astronomer.docker.airflow.version=(.*)',
-                    f'LABEL io.astronomer.docker.airflow.version="{airflow_version}"',
+                    r'ENV AIRFLOW_VERSION=(.*)',
+                    f'ENV AIRFLOW_VERSION="{airflow_version}"',
                     new_text,
                     flags=re.MULTILINE
                 )

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -21,12 +21,13 @@ ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
+ENV AIRFLOW_VERSION="1.10.10"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
-LABEL io.astronomer.docker.airflow.version="1.10.10"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_HOME="/usr/local/airflow"

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -21,7 +21,7 @@ ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
-ENV AIRFLOW_VERSION="1.10.10"
+ARG AIRFLOW_VERSION="1.10.10"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -108,8 +108,9 @@ RUN apt-get update \
 ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
+ENV AIRFLOW_VERSION="1.10.10"
 
-LABEL io.astronomer.docker.airflow.version="1.10.10"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Make pip look at our pip repo too, and force it to install these specific

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
 ARG VERSION="1.10.10-6.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
-ENV AIRFLOW_VERSION="1.10.10"
+ARG AIRFLOW_VERSION="1.10.10"
 
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -21,7 +21,7 @@ ARG VERSION="1.10.12-2.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
-ENV AIRFLOW_VERSION="1.10.12"
+ARG AIRFLOW_VERSION="1.10.12"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -21,12 +21,13 @@ ARG VERSION="1.10.12-2.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
+ENV AIRFLOW_VERSION="1.10.12"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
-LABEL io.astronomer.docker.airflow.version="1.10.12"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_HOME="/usr/local/airflow"
@@ -92,7 +93,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
-	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
+	&& pip3 install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip3 install --no-cache-dir "astronomer-fab-security-manager~=1.2, >=1.2.2" \
 	&& apk del .build-deps py3-numpy-dev \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -108,8 +108,9 @@ RUN apt-get update \
 ARG VERSION="1.10.12-2.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
+ENV AIRFLOW_VERSION="1.10.12"
 
-LABEL io.astronomer.docker.airflow.version="1.10.12"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Make pip look at our pip repo too, and force it to install these specific
@@ -118,7 +119,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" \
+RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.2, >=1.2.2"
 

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
 ARG VERSION="1.10.12-2.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
-ENV AIRFLOW_VERSION="1.10.12"
+ARG AIRFLOW_VERSION="1.10.12"
 
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/1.10.12/buster/include/pip-constraints.txt
+++ b/1.10.12/buster/include/pip-constraints.txt
@@ -2,10 +2,5 @@
 
 redis!=3.4.0
 
-WTforms<2.3.0
-
-# Details: https://github.com/apache/airflow/issues/8599
-flask-appbuilder<2.3.3
-
 # Details: https://github.com/apache/airflow/pull/8833
 azure-storage<0.37.0

--- a/1.10.13/buster/Dockerfile
+++ b/1.10.13/buster/Dockerfile
@@ -108,8 +108,9 @@ RUN apt-get update \
 ARG VERSION="1.10.13-1.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
+ENV AIRFLOW_VERSION="1.10.13"
 
-LABEL io.astronomer.docker.airflow.version="1.10.13"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Make pip look at our pip repo too, and force it to install these specific
@@ -118,7 +119,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" \
+RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.2, >=1.2.2"
 

--- a/1.10.13/buster/Dockerfile
+++ b/1.10.13/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
 ARG VERSION="1.10.13-1.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
-ENV AIRFLOW_VERSION="1.10.13"
+ARG AIRFLOW_VERSION="1.10.13"
 
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/1.10.13/buster/include/pip-constraints.txt
+++ b/1.10.13/buster/include/pip-constraints.txt
@@ -2,10 +2,5 @@
 
 redis!=3.4.0
 
-WTforms<2.3.0
-
-# Details: https://github.com/apache/airflow/issues/8599
-flask-appbuilder<2.3.3
-
 # Details: https://github.com/apache/airflow/pull/8833
 azure-storage<0.37.0

--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -20,12 +20,13 @@ ARG ORG="astronomer"
 ARG VERSION="1.10.5-11"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
+ENV AIRFLOW_VERSION="1.10.5"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
-LABEL io.astronomer.docker.airflow.version="1.10.5"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_REPOSITORY="https://github.com/${ORG}/airflow"

--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -20,7 +20,7 @@ ARG ORG="astronomer"
 ARG VERSION="1.10.5-11"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG REPO_BRANCH=master
-ENV AIRFLOW_VERSION="1.10.5"
+ARG AIRFLOW_VERSION="1.10.5"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -111,8 +111,9 @@ RUN apt-get update \
 ARG VERSION="1.10.5-11"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
+ENV AIRFLOW_VERSION="1.10.5"
 
-LABEL io.astronomer.docker.airflow.version="1.10.5"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Force pip to install these specific versions when ever it installs a module

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -111,7 +111,7 @@ RUN apt-get update \
 ARG VERSION="1.10.5-11"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
-ENV AIRFLOW_VERSION="1.10.5"
+ARG AIRFLOW_VERSION="1.10.5"
 
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -21,7 +21,7 @@ ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
-ENV AIRFLOW_VERSION="1.10.7"
+ARG AIRFLOW_VERSION="1.10.7"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -21,12 +21,13 @@ ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master
+ENV AIRFLOW_VERSION="1.10.7"
 
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
-LABEL io.astronomer.docker.airflow.version="1.10.7"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 ENV AIRFLOW_HOME="/usr/local/airflow"

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
 ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
-ENV AIRFLOW_VERSION="1.10.7"
+ARG AIRFLOW_VERSION="1.10.7"
 
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -110,8 +110,9 @@ RUN apt-get update \
 ARG VERSION="1.10.7-16.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
+ENV AIRFLOW_VERSION="1.10.7"
 
-LABEL io.astronomer.docker.airflow.version="1.10.7"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Make pip look at our pip repo too, and force it to install these specific

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
 ARG VERSION="2.0.0-1.*"
 ARG SUBMODULES="async,azure,aws,celery,elasticsearch,gcp,password,kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
-ENV AIRFLOW_VERSION="2.0.0"
+ARG AIRFLOW_VERSION="2.0.0"
 
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -108,8 +108,9 @@ RUN apt-get update \
 ARG VERSION="2.0.0-1.*"
 ARG SUBMODULES="async,azure,aws,celery,elasticsearch,gcp,password,kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
+ENV AIRFLOW_VERSION="2.0.0"
 
-LABEL io.astronomer.docker.airflow.version="2.0.0"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Make pip look at our pip repo too, and force it to install these specific


### PR DESCRIPTION
Use Apache Airflow constraints file to maintain dependencies during build time for AC 1.10.12 and AC 1.10.13
