### PR TITLE
Release AC 1.10.13-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,8 +511,7 @@ workflows:
           name: build-1.10.13-buster
           airflow_version: 1.10.13
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.13.build)"
+          dev_build: false
           requires:
             - static-checks
       - scan-clair:
@@ -537,7 +536,7 @@ workflows:
           name: push-1.10.13-buster
           tag: "1.10.13-buster"
           dev_build: false
-          extra_tags: "1.10.13-buster-${CIRCLE_BUILD_NUM},1.10.13-1.dev-buster"
+          extra_tags: "1.10.13-buster-${CIRCLE_BUILD_NUM},1.10.13-1-buster"
           context:
             - quay.io
           requires:
@@ -552,7 +551,7 @@ workflows:
           name: push-1.10.13-buster-onbuild
           tag: "1.10.13-buster-onbuild"
           dev_build: false
-          extra_tags: "1.10.13-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.13-1.dev-buster-onbuild"
+          extra_tags: "1.10.13-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.13-1-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -948,60 +947,6 @@ workflows:
             - scan-clair-1.10.12-buster-onbuild
             - scan-trivy-1.10.12-buster-onbuild
             - test-1.10.12-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-1.10.13-buster
-          airflow_version: 1.10.13
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.13.build)"
-      - scan-clair:
-          name: scan-clair-1.10.13-buster-onbuild
-          airflow_version: 1.10.13
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.13-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.13-buster-onbuild
-          airflow_version: 1.10.13
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.13-buster
-      - test:
-          name: test-1.10.13-buster-images
-          tag: "1.10.13-buster"
-          requires:
-            - build-1.10.13-buster
-      - push:
-          name: push-1.10.13-buster
-          tag: "1.10.13-buster"
-          dev_build: true
-          extra_tags: "1.10.13-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.13-buster-onbuild
-            - scan-trivy-1.10.13-buster-onbuild
-            - test-1.10.13-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-1.10.13-buster-onbuild
-          tag: "1.10.13-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.13-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.13-1.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.13-buster-onbuild
-            - scan-trivy-1.10.13-buster-onbuild
-            - test-1.10.13-buster-images
           filters:
             branches:
               only:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -15,7 +15,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.7-16.dev", ["alpine3.10", "buster"]),
     ("1.10.10-6.dev", ["alpine3.10", "buster"]),
     ("1.10.12-2.dev", ["alpine3.10", "buster"]),
-    ("1.10.13-1.dev", ["buster"]),
+    ("1.10.13-1", ["buster"]),
     ("2.0.0-1.dev", ["buster"]),
 ])
 

--- a/1.10.13/CHANGELOG.md
+++ b/1.10.13/CHANGELOG.md
@@ -1,9 +1,21 @@
 # Changelog
 
-Astronomer Certified 1.10.13-1.dev
+Astronomer Certified 1.10.13-1, 2020-11-25
 -----------------------------------------------
 
+User-facing CHANGELOG for AC `1.10.13+astro.1` from Airflow `1.10.13`:
 
-CHANGELOG for AC `1.10.13+astro.1` from Airflow `1.10.13`:
+### Bug Fixes
 
-TBD
+- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/d64ad84))
+- Fix operator field update for SerializedBaseOperator ([commit](https://github.com/apache/airflow/commit/cfc9732d7))
+- Fix empty asctime field in JSON formatted logs ([commit](https://github.com/apache/airflow/commit/a4b4d84))
+
+### Improvements
+
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/cd3a34e))
+- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/2954e4c))
+
+### New Features
+
+- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/apache/airflow/commit/386487e))

--- a/1.10.13/buster/Dockerfile
+++ b/1.10.13/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.13-1.*"
+ARG VERSION="1.10.13-1"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.13"


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v1.10.13%2Bastro.1

This does not include internal changes like Istio stuff, Astronomer theming

Astronomer Certified 1.10.13-1, 2020-11-25
-----------------------------------------------

User-facing CHANGELOG for AC `1.10.13+astro.1` from Airflow `1.10.13`:

### Bug Fixes

- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/d64ad84))
- Fix operator field update for SerializedBaseOperator ([commit](https://github.com/apache/airflow/commit/cfc9732d7))
- Fix empty asctime field in JSON formatted logs ([commit](https://github.com/apache/airflow/commit/a4b4d84))

### Improvements

- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/cd3a34e))
- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/2954e4c))

### New Features

- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/apache/airflow/commit/386487e))



