### PR TITLE
Bugfix: Non-dev builds were not pushed to PROD repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1135,6 +1135,7 @@ jobs:
         type: string
     steps:
       - push:
+          dev_release: "<< parameters.dev_build >>"
           extra_tags: "<< parameters.extra_tags >>"
           tag: "<< parameters.tag >>"
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -280,6 +280,7 @@ jobs:
         type: string
     steps:
       - push:
+          dev_release: "<< parameters.dev_build >>"
           extra_tags: "<< parameters.extra_tags >>"
           tag: "<< parameters.tag >>"
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"


### PR DESCRIPTION
Non-dev builds were not released to Prod as we were not passing `dev_release` param to push step, hence it was defaulting to true
