### PR TITLE
Bugfix: Publish moving master tags for AC Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1317,6 +1317,15 @@ commands:
                 docker push "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
               fi
             done
+
+            # The following code block publishes Moving Master builds (e.g. 1.10.13-buster-onbuild)
+            # as compared to above code-blocks that publish images with build-number & immutable tag
+            # e.g (e.g. 1.10.13-1-buster-onbuild and 1.10.13-buster-onbuild-24119)
+            if $NEW_POINT_RELEASE ; then
+              docker push "$image"
+            else
+              echo "Image with Tag ($image) not pushed as it is not a new point release"
+            fi
             set +x
   clair-scan:
     description: "Vulnerability scan a Docker image"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -462,6 +462,15 @@ commands:
                 docker push "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
               fi
             done
+
+            # The following code block publishes Moving Master builds (e.g. 1.10.13-buster-onbuild)
+            # as compared to above code-blocks that publish images with build-number & immutable tag
+            # e.g (e.g. 1.10.13-1-buster-onbuild and 1.10.13-buster-onbuild-24119)
+            if $NEW_POINT_RELEASE ; then
+              docker push "$image"
+            else
+              echo "Image with Tag ($image) not pushed as it is not a new point release"
+            fi
             set +x
   clair-scan:
     description: "Vulnerability scan a Docker image"


### PR DESCRIPTION
For each of our `-onbuild` images we publish three flavors of tag:

- `astronomerinc/ap-airflow:1.10.10-buster-onbuild` which is our latest release of the 1.10.10 series, including latest security patches. This tag is "floating" or movable.
- `astronomerinc/ap-airflow:1.10.10-3-buster-onbuild` once this tag is pushed it will never change again.
- `astronomerinc/ap-airflow:1.10.10-buster-onbuild-24119` once this tag is pushed it will never change again.

This was mistakenly removed in https://github.com/astronomer/ap-airflow/pull/142


