### PR TITLE
Release AC 1.10.12-2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
       - push:
           name: push-1.10.12-alpine3.10
           tag: "1.10.12-alpine3.10"
-          dev_build: true
+          dev_build: false
           extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM},1.10.12-2-alpine3.10"
           context:
             - quay.io
@@ -438,7 +438,7 @@ workflows:
       - push:
           name: push-1.10.12-alpine3.10-onbuild
           tag: "1.10.12-alpine3.10-onbuild"
-          dev_build: true
+          dev_build: false
           extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2-alpine3.10-onbuild"
           context:
             - quay.io
@@ -478,7 +478,7 @@ workflows:
       - push:
           name: push-1.10.12-buster
           tag: "1.10.12-buster"
-          dev_build: true
+          dev_build: false
           extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM},1.10.12-2-buster"
           context:
             - quay.io
@@ -493,7 +493,7 @@ workflows:
       - push:
           name: push-1.10.12-buster-onbuild
           tag: "1.10.12-buster-onbuild"
-          dev_build: true
+          dev_build: false
           extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2-buster-onbuild"
           context:
             - quay.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,8 +399,7 @@ workflows:
           name: build-1.10.12-alpine3.10
           airflow_version: 1.10.12
           distribution_name: alpine3.10
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
+          dev_build: false
           requires:
             - static-checks
       - scan-clair:
@@ -425,7 +424,7 @@ workflows:
           name: push-1.10.12-alpine3.10
           tag: "1.10.12-alpine3.10"
           dev_build: true
-          extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM},1.10.12-2.dev-alpine3.10"
+          extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM},1.10.12-2-alpine3.10"
           context:
             - quay.io
           requires:
@@ -440,7 +439,7 @@ workflows:
           name: push-1.10.12-alpine3.10-onbuild
           tag: "1.10.12-alpine3.10-onbuild"
           dev_build: true
-          extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2.dev-alpine3.10-onbuild"
+          extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2-alpine3.10-onbuild"
           context:
             - quay.io
           requires:
@@ -455,8 +454,7 @@ workflows:
           name: build-1.10.12-buster
           airflow_version: 1.10.12
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
+          dev_build: false
           requires:
             - static-checks
       - scan-clair:
@@ -481,7 +479,7 @@ workflows:
           name: push-1.10.12-buster
           tag: "1.10.12-buster"
           dev_build: true
-          extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM},1.10.12-2.dev-buster"
+          extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM},1.10.12-2-buster"
           context:
             - quay.io
           requires:
@@ -496,7 +494,7 @@ workflows:
           name: push-1.10.12-buster-onbuild
           tag: "1.10.12-buster-onbuild"
           dev_build: true
-          extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2.dev-buster-onbuild"
+          extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -840,114 +838,6 @@ workflows:
             - scan-clair-1.10.10-buster-onbuild
             - scan-trivy-1.10.10-buster-onbuild
             - test-1.10.10-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-1.10.12-alpine3.10
-          airflow_version: 1.10.12
-          distribution_name: alpine3.10
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
-      - scan-clair:
-          name: scan-clair-1.10.12-alpine3.10-onbuild
-          airflow_version: 1.10.12
-          distribution_name: alpine3.10-onbuild
-          requires:
-            - build-1.10.12-alpine3.10
-      - scan-trivy:
-          name: scan-trivy-1.10.12-alpine3.10-onbuild
-          airflow_version: 1.10.12
-          distribution: alpine3.10
-          distribution_name: alpine3.10-onbuild
-          requires:
-            - build-1.10.12-alpine3.10
-      - test:
-          name: test-1.10.12-alpine3.10-images
-          tag: "1.10.12-alpine3.10"
-          requires:
-            - build-1.10.12-alpine3.10
-      - push:
-          name: push-1.10.12-alpine3.10
-          tag: "1.10.12-alpine3.10"
-          dev_build: true
-          extra_tags: "1.10.12-alpine3.10-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.12-alpine3.10-onbuild
-            - scan-trivy-1.10.12-alpine3.10-onbuild
-            - test-1.10.12-alpine3.10-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-1.10.12-alpine3.10-onbuild
-          tag: "1.10.12-alpine3.10-onbuild"
-          dev_build: true
-          extra_tags: "1.10.12-alpine3.10-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2.dev-alpine3.10-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.12-alpine3.10-onbuild
-            - scan-trivy-1.10.12-alpine3.10-onbuild
-            - test-1.10.12-alpine3.10-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-1.10.12-buster
-          airflow_version: 1.10.12
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.12.build)"
-      - scan-clair:
-          name: scan-clair-1.10.12-buster-onbuild
-          airflow_version: 1.10.12
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.12-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.12-buster-onbuild
-          airflow_version: 1.10.12
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.12-buster
-      - test:
-          name: test-1.10.12-buster-images
-          tag: "1.10.12-buster"
-          requires:
-            - build-1.10.12-buster
-      - push:
-          name: push-1.10.12-buster
-          tag: "1.10.12-buster"
-          dev_build: true
-          extra_tags: "1.10.12-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.12-buster-onbuild
-            - scan-trivy-1.10.12-buster-onbuild
-            - test-1.10.12-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-1.10.12-buster-onbuild
-          tag: "1.10.12-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.12-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.12-2.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.12-buster-onbuild
-            - scan-trivy-1.10.12-buster-onbuild
-            - test-1.10.12-buster-images
           filters:
             branches:
               only:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -14,7 +14,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.5-11", ["alpine3.10", "buster", "rhel7"]),
     ("1.10.7-16.dev", ["alpine3.10", "buster"]),
     ("1.10.10-6.dev", ["alpine3.10", "buster"]),
-    ("1.10.12-2.dev", ["alpine3.10", "buster"]),
+    ("1.10.12-2", ["alpine3.10", "buster"]),
     ("1.10.14-1.dev", ["buster"]),
     ("2.0.0-1.dev", ["buster"]),
 ])

--- a/1.10.12/CHANGELOG.md
+++ b/1.10.12/CHANGELOG.md
@@ -1,28 +1,38 @@
 # Changelog
 
-Astronomer Certified 1.10.12-2, 2020-12-01
+Astronomer Certified 1.10.12-2, 2020-12-04
 -----------------------------------------------
 
 ### Bug Fixes
 
 - SkipMixin: Handle empty branches ([commit](https://github.com/astronomer/airflow/commit/64a37512e))
-- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/26ad9eba6))
-- Fixes issue with affinity backcompat in Airflow 1.10 ([commit](https://github.com/astronomer/airflow/commit/d7ac1b911))
-- Fix empty asctime field in JSON formatted logs ([commit](https://github.com/astronomer/airflow/commit/376e8c445))
-- Show Generic Error for Charts & Query View in old UI ([commit](https://github.com/astronomer/airflow/commit/e87277dcd))
-- Webserver: Further Sanitize values passed to origin param ([commit](https://github.com/astronomer/airflow/commit/4c27334a5))
-- Mask Password in Log table when using the CLI ([commit](https://github.com/astronomer/airflow/commit/a09201069))
-- Limit version of marshmallow-sqlalchemy ([commit](https://github.com/astronomer/airflow/commit/f88ae68e5))
-- Bump attrs to > 20.0 ([commit](https://github.com/astronomer/airflow/commit/7fcf2e5eb))
-- Bump attrs and cattrs dependencies ([commit](https://github.com/astronomer/airflow/commit/aede56833))
-- Install cattr on Python 3.7 ([commit](https://github.com/astronomer/airflow/commit/1173785c3))
-- Pin `kubernetes` to a max version of 11.0.0 ([commit](https://github.com/astronomer/airflow/commit/2d070bdab))
-- Allow overrides for pod_template_file ([commit](https://github.com/astronomer/airflow/commit/76b17f23b))
+- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/3db82c98f))
+- Fixes issue with affinity backcompat in Airflow 1.10 ([commit](https://github.com/astronomer/airflow/commit/aa13576d0))
+- Fix empty asctime field in JSON formatted logs ([commit](https://github.com/astronomer/airflow/commit/21a9bd07c))
+- Show Generic Error for Charts & Query View in old UI ([commit](https://github.com/astronomer/airflow/commit/d737558eb))
+- Webserver: Further Sanitize values passed to origin param ([commit](https://github.com/astronomer/airflow/commit/728dbddf5))
+- Mask Password in Log table when using the CLI ([commit](https://github.com/astronomer/airflow/commit/f746e3c75))
+- Limit version of marshmallow-sqlalchemy ([commit](https://github.com/astronomer/airflow/commit/97a39dd19))
+- Bump attrs to > 20.0 ([commit](https://github.com/astronomer/airflow/commit/2379b6a23))
+- Bump attrs and cattrs dependencies ([commit](https://github.com/astronomer/airflow/commit/dad229d71))
+- Install cattr on Python 3.7 ([commit](https://github.com/astronomer/airflow/commit/dacc4ab8c))
+- Pin `kubernetes` to a max version of 11.0.0 ([commit](https://github.com/astronomer/airflow/commit/d9a90c26c))
+- Pin pyzmq<20.0 for Alpine images ([commit](https://github.com/astronomer/ap-airflow/commit/3059797))
+- Dockerfile: Add `sync_perm` command to buster images ([commit](https://github.com/astronomer/ap-airflow/commit/5a28d3f))
+- BugFix: Tasks with depends_on_past or task_concurrency are stuck ([commit](https://github.com/astronomer/airflow/commit/381a55009))
+- Fix issue with empty Resources in executor_config ([commit](https://github.com/astronomer/airflow/commit/d5b89e88e))
+- [AIRFLOW-2809] Fix security issue regarding Flask SECRET_KEY ([commit](https://github.com/astronomer/airflow/commit/91f64a3d1))
+- [AIRFLOW-2884] Fix Flask SECRET_KEY security issue in www_rbac ([commit](https://github.com/astronomer/airflow/commit/f0b4547d5))
+- [AIRFLOW-2886] Generate random Flask SECRET_KEY in default config ([commit](https://github.com/astronomer/airflow/commit/2efe39197))
+- Don't let webserver run with dangerous config ([commit](https://github.com/astronomer/airflow/commit/075d4ddb0))
 
 ### Improvements
 
-- [AIRFLOW-3607] Only query DB once per DAG run for TriggerRuleDep ([commit](https://github.com/astronomer/airflow/commit/e1659b2d1))
-- [AIRFLOW-3607] Optimize dep checking when depends on past set and concurrency limit ([commit](https://github.com/astronomer/airflow/commit/8673e0147))
+- [AIRFLOW-3607] Only query DB once per DAG run for TriggerRuleDep ([commit](https://github.com/astronomer/airflow/commit/7693514bb))
+- [AIRFLOW-3607] Optimize dep checking when depends on past set and concurrency limit ([commit](https://github.com/astronomer/airflow/commit/63bb7f3ae))
+- Dockerfile: Stop running `sync_perm` multiple times for Airflow >= 1.10.7 ([commit](https://github.com/astronomer/ap-airflow/commit/9c10dcf))
+- Dockerfile: Bump astronomer_airflow_scripts to 0.0.5 ([commit](https://github.com/astronomer/ap-airflow/commit/42b4169))
+- Dockerfile: Use Airflow Constraints file for AC 1.10.12 and 1.10.13 ([commit](https://github.com/astronomer/ap-airflow/commit/e968f12))
 
 Astronomer Certified 1.10.12-1, 2020-09-29
 -----------------------------------------------

--- a/1.10.12/CHANGELOG.md
+++ b/1.10.12/CHANGELOG.md
@@ -1,9 +1,28 @@
 # Changelog
 
-Astronomer Certified 1.10.12-2.dev
+Astronomer Certified 1.10.12-2, 2020-12-01
 -----------------------------------------------
 
-TBD
+### Bug Fixes
+
+- SkipMixin: Handle empty branches ([commit](https://github.com/astronomer/airflow/commit/64a37512e))
+- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/26ad9eba6))
+- Fixes issue with affinity backcompat in Airflow 1.10 ([commit](https://github.com/astronomer/airflow/commit/d7ac1b911))
+- Fix empty asctime field in JSON formatted logs ([commit](https://github.com/astronomer/airflow/commit/376e8c445))
+- Show Generic Error for Charts & Query View in old UI ([commit](https://github.com/astronomer/airflow/commit/e87277dcd))
+- Webserver: Further Sanitize values passed to origin param ([commit](https://github.com/astronomer/airflow/commit/4c27334a5))
+- Mask Password in Log table when using the CLI ([commit](https://github.com/astronomer/airflow/commit/a09201069))
+- Limit version of marshmallow-sqlalchemy ([commit](https://github.com/astronomer/airflow/commit/f88ae68e5))
+- Bump attrs to > 20.0 ([commit](https://github.com/astronomer/airflow/commit/7fcf2e5eb))
+- Bump attrs and cattrs dependencies ([commit](https://github.com/astronomer/airflow/commit/aede56833))
+- Install cattr on Python 3.7 ([commit](https://github.com/astronomer/airflow/commit/1173785c3))
+- Pin `kubernetes` to a max version of 11.0.0 ([commit](https://github.com/astronomer/airflow/commit/2d070bdab))
+- Allow overrides for pod_template_file ([commit](https://github.com/astronomer/airflow/commit/76b17f23b))
+
+### Improvements
+
+- [AIRFLOW-3607] Only query DB once per DAG run for TriggerRuleDep ([commit](https://github.com/astronomer/airflow/commit/e1659b2d1))
+- [AIRFLOW-3607] Optimize dep checking when depends on past set and concurrency limit ([commit](https://github.com/astronomer/airflow/commit/8673e0147))
 
 Astronomer Certified 1.10.12-1, 2020-09-29
 -----------------------------------------------
@@ -12,22 +31,22 @@ CHANGELOG for AC `1.10.12+astro.1` from Airflow `1.10.12`:
 
 ### Bug Fixes
 
-- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/49d4840))
-- KubernetesPodOperator template fix (#10963) ([commit](https://github.com/apache/airflow/commit/259f1b797))
-- Fix operator field update for SerializedBaseOperator ([commit](https://github.com/apache/airflow/commit/cfc9732d7))
-- Fix pod_mutation_hook ([commit](https://github.com/apache/airflow/commit/73b5fe1aa))
-- Fix formatting of Host information ([commit](https://github.com/apache/airflow/commit/4d820744c))
+- Add role-based authentication backend ([commit](https://github.com/astronomer/airflow/commit/49d4840))
+- KubernetesPodOperator template fix (#10963) ([commit](https://github.com/astronomer/airflow/commit/259f1b797))
+- Fix operator field update for SerializedBaseOperator ([commit](https://github.com/astronomer/airflow/commit/cfc9732d7))
+- Fix pod_mutation_hook ([commit](https://github.com/astronomer/airflow/commit/73b5fe1aa))
+- Fix formatting of Host information ([commit](https://github.com/astronomer/airflow/commit/4d820744c))
 
 ### Improvements
 
-- Adding body as templated field for CloudSqlImportOperator ([commit](https://github.com/apache/airflow/commit/18e3a3b))
-- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/ac17612))
-- Restrict 'nteract-scrapbook' to <0.4 ([commit](https://github.com/apache/airflow/commit/b4312ef))
-- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/8da0ad8))
-- Remove deprecation warning from contrib/kubernetes/pod.py ([commit](https://github.com/apache/airflow/commit/5721d39))
-- Make grace_period_seconds option on KubernetesPodOperator ([commit](https://github.com/apache/airflow/commit/236b9b3b2))
-- Add on_kill support for the KubernetesPodOperator ([commit](https://github.com/apache/airflow/commit/ce94497cc))
+- Adding body as templated field for CloudSqlImportOperator ([commit](https://github.com/astronomer/airflow/commit/18e3a3b))
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/astronomer/airflow/commit/ac17612))
+- Restrict 'nteract-scrapbook' to <0.4 ([commit](https://github.com/astronomer/airflow/commit/b4312ef))
+- Enable DAG Serialization by default ([commit](https://github.com/astronomer/airflow/commit/8da0ad8))
+- Remove deprecation warning from contrib/kubernetes/pod.py ([commit](https://github.com/astronomer/airflow/commit/5721d39))
+- Make grace_period_seconds option on KubernetesPodOperator ([commit](https://github.com/astronomer/airflow/commit/236b9b3b2))
+- Add on_kill support for the KubernetesPodOperator ([commit](https://github.com/astronomer/airflow/commit/ce94497cc))
 
 ### New Features
 
-- Add Secrets backend for Microsoft Azure Key Vault ([commit](https://github.com/apache/airflow/commit/908515f13))
+- Add Secrets backend for Microsoft Azure Key Vault ([commit](https://github.com/astronomer/airflow/commit/908515f13))

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ORG="astronomer"
-ARG VERSION="1.10.12-2.*"
+ARG VERSION="1.10.12-2"
 ARG SUBMODULES="all, statsd, elasticsearch"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG REPO_BRANCH=master

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.12-2.*"
+ARG VERSION="1.10.12-2"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.12"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All changes applied to available point releases will be documented in the `CHANG
 - [1.10.5 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.5/CHANGELOG.md)
 - [1.10.7 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)
 - [1.10.10 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)
+- [1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)
 
 ## Testing
 


### PR DESCRIPTION
Astronomer Certified 1.10.12-2, 2020-12-04
-----------------------------------------------

### Bug Fixes

- SkipMixin: Handle empty branches ([commit](https://github.com/astronomer/airflow/commit/64a37512e))
- Sync FAB Permissions for all base views ([commit](https://github.com/astronomer/airflow/commit/3db82c98f))
- Fixes issue with affinity backcompat in Airflow 1.10 ([commit](https://github.com/astronomer/airflow/commit/aa13576d0))
- Fix empty asctime field in JSON formatted logs ([commit](https://github.com/astronomer/airflow/commit/21a9bd07c))
- Show Generic Error for Charts & Query View in old UI ([commit](https://github.com/astronomer/airflow/commit/d737558eb))
- Webserver: Further Sanitize values passed to origin param ([commit](https://github.com/astronomer/airflow/commit/728dbddf5))
- Mask Password in Log table when using the CLI ([commit](https://github.com/astronomer/airflow/commit/f746e3c75))
- Limit version of marshmallow-sqlalchemy ([commit](https://github.com/astronomer/airflow/commit/97a39dd19))
- Bump attrs to > 20.0 ([commit](https://github.com/astronomer/airflow/commit/2379b6a23))
- Bump attrs and cattrs dependencies ([commit](https://github.com/astronomer/airflow/commit/dad229d71))
- Install cattr on Python 3.7 ([commit](https://github.com/astronomer/airflow/commit/dacc4ab8c))
- Pin `kubernetes` to a max version of 11.0.0 ([commit](https://github.com/astronomer/airflow/commit/d9a90c26c))
- Pin pyzmq<20.0 for Alpine images ([commit](https://github.com/astronomer/ap-airflow/commit/3059797))
- Dockerfile: Add `sync_perm` command to buster images ([commit](https://github.com/astronomer/ap-airflow/commit/5a28d3f))
- BugFix: Tasks with depends_on_past or task_concurrency are stuck ([commit](https://github.com/astronomer/airflow/commit/381a55009))
- Fix issue with empty Resources in executor_config ([commit](https://github.com/astronomer/airflow/commit/d5b89e88e))
- [AIRFLOW-2809] Fix security issue regarding Flask SECRET_KEY ([commit](https://github.com/astronomer/airflow/commit/91f64a3d1))
- [AIRFLOW-2884] Fix Flask SECRET_KEY security issue in www_rbac ([commit](https://github.com/astronomer/airflow/commit/f0b4547d5))
- [AIRFLOW-2886] Generate random Flask SECRET_KEY in default config ([commit](https://github.com/astronomer/airflow/commit/2efe39197))
- Don't let webserver run with dangerous config ([commit](https://github.com/astronomer/airflow/commit/075d4ddb0))

### Improvements

- [AIRFLOW-3607] Only query DB once per DAG run for TriggerRuleDep ([commit](https://github.com/astronomer/airflow/commit/7693514bb))
- [AIRFLOW-3607] Optimize dep checking when depends on past set and concurrency limit ([commit](https://github.com/astronomer/airflow/commit/63bb7f3ae))
- Dockerfile: Stop running `sync_perm` multiple times for Airflow >= 1.10.7 ([commit](https://github.com/astronomer/ap-airflow/commit/9c10dcf))
- Dockerfile: Bump astronomer_airflow_scripts to 0.0.5 ([commit](https://github.com/astronomer/ap-airflow/commit/42b4169))
- Dockerfile: Use Airflow Constraints file for AC 1.10.12 and 1.10.13 ([commit](https://github.com/astronomer/ap-airflow/commit/e968f12))
