### PR TITLE
Fix Providers repackaging script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ java/.project
 java/.settings/
 kubeconfig
 local.make
+out
 target
 temp
 Untitled*


### PR DESCRIPTION
Allows repackaging from https://dist.apache.org/repos/dist/release/airflow/backport-providers/
