### PR TITLE
Fix publishing Moving Master images to Dev repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1322,7 +1322,24 @@ commands:
             # as compared to above code-blocks that publish images with build-number & immutable tag
             # e.g (e.g. 1.10.13-1-buster-onbuild and 1.10.13-buster-onbuild-24119)
             if $NEW_POINT_RELEASE ; then
-              docker push "$image"
+              if ! <<parameters.dev_release >> ; then
+                # If it is not a Dev Release publish the image to Prod Repos
+                echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_docker_repo_quay_io >>"
+                docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:<< parameters.tag >>"
+                docker push "<< parameters.prod_docker_repo_quay_io >>:<< parameters.tag >>"
+
+                echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_docker_repo_docker_hub >>"
+                docker tag "$image" "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
+                docker push "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
+              fi
+
+              echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_docker_hub >>"
+              docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
+              docker push "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
+
+              echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_quay_io >>"
+              docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:<< parameters.tag >>"
+              docker push "<< parameters.dev_docker_repo_quay_io >>:<< parameters.tag >>"
             else
               echo "Image with Tag ($image) not pushed as it is not a new point release"
             fi

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -467,7 +467,24 @@ commands:
             # as compared to above code-blocks that publish images with build-number & immutable tag
             # e.g (e.g. 1.10.13-1-buster-onbuild and 1.10.13-buster-onbuild-24119)
             if $NEW_POINT_RELEASE ; then
-              docker push "$image"
+              if ! <<parameters.dev_release >> ; then
+                # If it is not a Dev Release publish the image to Prod Repos
+                echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_docker_repo_quay_io >>"
+                docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:<< parameters.tag >>"
+                docker push "<< parameters.prod_docker_repo_quay_io >>:<< parameters.tag >>"
+
+                echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_docker_repo_docker_hub >>"
+                docker tag "$image" "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
+                docker push "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
+              fi
+
+              echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_docker_hub >>"
+              docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
+              docker push "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
+
+              echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_quay_io >>"
+              docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:<< parameters.tag >>"
+              docker push "<< parameters.dev_docker_repo_quay_io >>:<< parameters.tag >>"
             else
               echo "Image with Tag ($image) not pushed as it is not a new point release"
             fi


### PR DESCRIPTION
CI is failing on nightly jobs to publish images with Moving Master (1.10.12-buster) on Dev repo

```
+ docker push ap-airflow:1.10.10-alpine3.10
The push refers to a repository [docker.io/library/ap-airflow]

42ebf10d: Preparing
02e6bedd: Preparing
3175ca94: Preparing
ae324da0: Preparing
d6dd38d3: Preparing
6b23e88a: Preparing
a18a7ade: Preparing
5363c244: Preparing
368ddfe8: Preparing
68e333b0: Preparing
denied: requested access to the resource is denied
```

This commit fixes it by adding the correct docker repo url