### PR TITLE
Pin PyOpenSSL to <20.0 in Alpine images

### DIFF
--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -19,3 +19,6 @@ azure-storage<0.37.0
 
 # 0.13.3 installs PyArrow which has issues with Alpine
 pandas-gbq<=0.13.2
+
+# 20.0 breaks with snowflake-connector-python installed in Alpine images
+pyOpenSSL<20.0

--- a/1.10.12/alpine3.10/include/pip-constraints.txt
+++ b/1.10.12/alpine3.10/include/pip-constraints.txt
@@ -19,3 +19,6 @@ azure-storage<0.37.0
 
 # 0.13.3 installs PyArrow which has issues with Alpine
 pandas-gbq<=0.13.2
+
+# 20.0 breaks with snowflake-connector-python installed in Alpine images
+pyOpenSSL<20.0

--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -22,3 +22,6 @@ azure-storage<0.37.0
 
 # 0.13.3 installs PyArrow which has issues with Alpine
 pandas-gbq<=0.13.2
+
+# 20.0 breaks with snowflake-connector-python installed in Alpine images
+pyOpenSSL<20.0

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -20,3 +20,6 @@ azure-storage<0.37.0
 
 # 0.13.3 installs PyArrow which has issues with Alpine
 pandas-gbq<=0.13.2
+
+# 20.0 breaks with snowflake-connector-python installed in Alpine images
+pyOpenSSL<20.0


### PR DESCRIPTION
We install `snowflake-connector-python==1.9.1` in our alpine images which conflicts with `pyOpenSSL==20.0`

https://app.circleci.com/pipelines/github/astronomer/ap-airflow/1004/workflows/51db19c7-f09d-404f-a25e-960a78bb7ca6/jobs/25011


Stacktrace:

```
Collecting snowflake-connector-python==1.9.1
  Downloading https://files.pythonhosted.org/packages/d0/dd/06a18f4f491b3296f3aad2ef9f3e06720ab86b33b375087bdab1c8fc87f6/snowflake_connector_python-1.9.1-py2.py3-none-any.whl (170kB)
Requirement already satisfied, skipping upgrade: cryptography>=1.8.2 in /usr/lib/python3.7/site-packages (from snowflake-connector-python==1.9.1) (2.8)
Requirement already satisfied, skipping upgrade: pytz in /usr/lib/python3.7/site-packages (from snowflake-connector-python==1.9.1) (2019.1)
Requirement already satisfied, skipping upgrade: six in /usr/lib/python3.7/site-packages (from snowflake-connector-python==1.9.1) (1.12.0)
Collecting azure-common (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/19/2b/46ada1753c4a640bc3ad04a1e20b1a5ea52a8f18079e1b8238e536aa0c98/azure_common-1.1.26-py2.py3-none-any.whl
Collecting pyjwt (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/87/8b/6a9f14b5f781697e51259d81657e6048fd31a113229cf346880bb7545565/PyJWT-1.7.1-py2.py3-none-any.whl
Collecting pycryptodomex!=3.5.0,>=3.2 (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/14/90/f4a934bffae029e16fb33f3bd87014a0a18b4bec591249c4fc01a18d3ab6/pycryptodomex-3.9.9.tar.gz (15.5MB)
Collecting azure-storage-blob (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/e7/5d/0bb4ed37da2523c393789b1d8ecbf56b1d35fa344af30fe423da2c06cbe9/azure_storage_blob-12.6.0-py2.py3-none-any.whl (328kB)
Collecting certifi (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/c1/6f/3d85f0850962279a7e4c622695d7b3171e95ac65308a57d3b29738b27149/certifi-2020.11.8-py2.py3-none-any.whl (155kB)
Collecting pyOpenSSL>=16.2.0 (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/c9/86/e21398551956735fef8f7883908771445878ccb16cd17c0896176419cd75/pyOpenSSL-20.0.0-py2.py3-none-any.whl (54kB)
Collecting ijson (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/6b/78/c3144ac57cee06ccd7d6de8e99f9ac60812743a488878fc57fd586fd2f3f/ijson-3.1.3.tar.gz (56kB)
Requirement already satisfied, skipping upgrade: idna in /usr/lib/python3.7/site-packages (from snowflake-connector-python==1.9.1) (2.8)
Requirement already satisfied, skipping upgrade: cffi>=1.9 in /usr/lib/python3.7/site-packages (from snowflake-connector-python==1.9.1) (1.11.5)
Requirement already satisfied, skipping upgrade: asn1crypto<1.0.0 in /usr/lib/python3.7/site-packages (from snowflake-connector-python==1.9.1) (0.24.0)
Collecting botocore<1.13.0,>=1.5.0 (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/8e/7b/88f10115b4748f86be6b7b1d8761ba5023fccf6e6cbe762e368f63eddcf9/botocore-1.12.253-py2.py3-none-any.whl (5.7MB)
Collecting future (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz (829kB)
Collecting boto3<1.10.0,>=1.4.4 (from snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/f6/fa/6397049020b312f71c397fff8d10247c2e49da760e2807af7d21e3c23695/boto3-1.9.253-py2.py3-none-any.whl (128kB)
Collecting azure-core<2.0.0,>=1.9.0 (from azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/f8/4b/ea7faaafac956a168ab9a95a7ebe583f9d308e8332a68af0ed3128ef520c/azure_core-1.9.0-py2.py3-none-any.whl (124kB)
Collecting msrest>=0.6.10 (from azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/fa/f5/9e315fe8cb985b0ce052b34bcb767883dc739f46fadb62f05a7e6d6eedbe/msrest-0.6.19-py2.py3-none-any.whl (84kB)
Requirement already satisfied, skipping upgrade: pycparser in /usr/lib/python3.7/site-packages (from cffi>=1.9->snowflake-connector-python==1.9.1) (2.19)
Requirement already satisfied, skipping upgrade: python-dateutil<3.0.0,>=2.1; python_version >= "2.7" in /usr/lib/python3.7/site-packages (from botocore<1.13.0,>=1.5.0->snowflake-connector-python==1.9.1) (2.7.3)
Collecting urllib3<1.26,>=1.20; python_version >= "3.4" (from botocore<1.13.0,>=1.5.0->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/56/aa/4ef5aa67a9a62505db124a5cb5262332d1d4153462eb8fd89c9fa41e5d92/urllib3-1.25.11-py2.py3-none-any.whl (127kB)
Collecting docutils<0.16,>=0.10 (from botocore<1.13.0,>=1.5.0->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/22/cd/a6aa959dca619918ccb55023b4cb151949c64d4d5d55b3f4ffd7eee0c6e8/docutils-0.15.2-py3-none-any.whl (547kB)
Collecting jmespath<1.0.0,>=0.7.1 (from botocore<1.13.0,>=1.5.0->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/07/cb/5f001272b6faeb23c1c9e0acc04d48eaaf5c862c17709d20e3469c6e0139/jmespath-0.10.0-py2.py3-none-any.whl
Collecting s3transfer<0.3.0,>=0.2.0 (from boto3<1.10.0,>=1.4.4->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/16/8a/1fc3dba0c4923c2a76e1ff0d52b305c44606da63f718d14d3231e21c51b0/s3transfer-0.2.1-py2.py3-none-any.whl (70kB)
Collecting requests>=2.18.4 (from azure-core<2.0.0,>=1.9.0->azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/39/fc/f91eac5a39a65f75a7adb58eac7fa78871ea9872283fb9c44e6545998134/requests-2.25.0-py2.py3-none-any.whl (61kB)
Collecting isodate>=0.6.0 (from msrest>=0.6.10->azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/9b/9f/b36f7774ff5ea8e428fdcfc4bb332c39ee5b9362ddd3d40d9516a55221b2/isodate-0.6.0-py2.py3-none-any.whl (45kB)
Collecting requests-oauthlib>=0.5.0 (from msrest>=0.6.10->azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/a3/12/b92740d845ab62ea4edf04d2f4164d82532b5a0b03836d4d4e71c6f3d379/requests_oauthlib-1.3.0-py2.py3-none-any.whl
Collecting chardet<4,>=3.0.2 (from requests>=2.18.4->azure-core<2.0.0,>=1.9.0->azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl (133kB)
Collecting oauthlib>=3.0.0 (from requests-oauthlib>=0.5.0->msrest>=0.6.10->azure-storage-blob->snowflake-connector-python==1.9.1)
  Downloading https://files.pythonhosted.org/packages/05/57/ce2e7a8fa7c0afb54a0581b14a65b56e62b5759dbc98e80627142b8a3704/oauthlib-3.1.0-py2.py3-none-any.whl (147kB)
ERROR: pyopenssl 20.0.0 has requirement cryptography>=3.2, but you'll have cryptography 2.8 which is incompatible.
Installing collected packages: azure-common, pyjwt, pycryptodomex, chardet, certifi, urllib3, requests, azure-core, isodate, oauthlib, requests-oauthlib, msrest, azure-storage-blob, pyOpenSSL, ijson, docutils, jmespath, botocore, future, s3transfer, boto3, snowflake-connector-python
  Running setup.py install for pycryptodomex: started
    Running setup.py install for pycryptodomex: finished with status 'done'
  Running setup.py install for ijson: started
    Running setup.py install for ijson: finished with status 'done'
  Running setup.py install for future: started
    Running setup.py install for future: finished with status 'done'
Successfully installed azure-common-1.1.26 azure-core-1.9.0 azure-storage-blob-12.6.0 boto3-1.9.253 botocore-1.12.253 certifi-2020.11.8 chardet-3.0.4 docutils-0.15.2 future-0.18.2 ijson-3.1.3 isodate-0.6.0 jmespath-0.10.0 msrest-0.6.19 oauthlib-3.1.0 pyOpenSSL-20.0.0 pycryptodomex-3.9.9 pyjwt-1.7.1 requests-2.25.0 requests-oauthlib-1.3.0 s3transfer-0.2.1 snowflake-connector-python-1.9.1 urllib3-1.25.11
WARNING: You are using pip version 19.2.3, however version 20.2.4 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
ERROR: Exception:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 188, in main
    status = self.run(options, args)
  File "/usr/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 319, in run
    self.name, wheel_cache
  File "/usr/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 270, in populate_requirement_set
    session=session, wheel_cache=wheel_cache):
  File "/usr/lib/python3.7/site-packages/pip/_internal/req/req_file.py", line 104, in parse_requirements
    filename, comes_from=comes_from, session=session
  File "/usr/lib/python3.7/site-packages/pip/_internal/download.py", line 661, in get_file_content
    resp = session.get(url)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/requests/sessions.py", line 546, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python3.7/site-packages/pip/_internal/download.py", line 624, in request
    return super(PipSession, self).request(method, url, *args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/cachecontrol/adapter.py", line 53, in send
    resp = super(CacheControlAdapter, self).send(request, **kw)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/usr/lib/python3.7/site-packages/pip/_vendor/urllib3/connectionpool.py", line 603, in urlopen
    chunked=chunked)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/urllib3/connectionpool.py", line 355, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3.7/http/client.py", line 1252, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1298, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1247, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.7/http/client.py", line 1026, in _send_output
    self.send(msg)
  File "/usr/lib/python3.7/http/client.py", line 987, in send
    self.sock.sendall(data)
  File "/usr/lib/python3.7/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py", line 342, in sendall
    sent = self._send_until_done(data[total_sent:total_sent + SSL_WRITE_BLOCKSIZE])
  File "/usr/lib/python3.7/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py", line 331, in _send_until_done
    return self.connection.send(data)
  File "/usr/lib/python3.7/site-packages/OpenSSL/SSL.py", line 1641, in send
    with _from_buffer(buf) as data:
AttributeError: __enter__
```