### PR TITLE
Use EPOCH to force upgrading buster packages

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -128,6 +128,9 @@ RUN pip install "${AIRFLOW_MODULE}" \
 
 FROM ${APT_DEPS_IMAGE} as main
 
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -128,6 +128,9 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 
 FROM ${APT_DEPS_IMAGE} as main
 
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -128,6 +128,9 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 
 FROM ${APT_DEPS_IMAGE} as main
 
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -139,6 +139,8 @@ RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
 
 FROM ${APT_DEPS_IMAGE} as main
 
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -130,6 +130,9 @@ RUN pip install "${AIRFLOW_MODULE}" \
 
 FROM ${APT_DEPS_IMAGE} as main
 
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -129,6 +129,9 @@ RUN pip install "${AIRFLOW_MODULE}" \
 
 FROM ${APT_DEPS_IMAGE} as main
 
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \


### PR DESCRIPTION
CI currently uses cache when there are no changes to Dockerfile or build args which prevents running `apt-get update`. And some of the CVEs that can be fixed because of it are not. This will allow us to force upgrading dependencies
