### PR TITLE
Update test for deleting connections for 2.0

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -134,7 +134,7 @@ def test_airflow_connections(scheduler):
             'airflow connections add --conn-uri %s %s', test_conn_uri, test_conn_id)
 
         # Assert Connection can be removed
-        assert f"Successfully deleted `conn_id`={test_conn_id}" in scheduler.check_output(
+        assert f"Successfully deleted connection with `conn_id`={test_conn_id}" in scheduler.check_output(
             'airflow connections delete %s', test_conn_id)
     else:
         # Assert Connection can be added


### PR DESCRIPTION
Looks like we updated the logged info message when deleting connections.

```
E           AssertionError: assert 'Successfully deleted `conn_id`=test' in '[2020-12-08 00:25:22,486] {plugins_manager.py:286} INFO - Loading 1 plugin(s) took 3.01 seconds\nSuccessfully deleted connection with `conn_id`=test'
E            +  where '[2020-12-08 00:25:22,486] {plugins_manager.py:286} INFO - Loading 1 plugin(s) took 3.01 seconds\nSuccessfully deleted connection with `conn_id`=test' = <bound method Host.check_output of <testinfra.host.Host object at 0x7ff7e06ba460>>('airflow connections delete %s', 'test')
E            +    where <bound method Host.check_output of <testinfra.host.Host object at 0x7ff7e06ba460>> = <testinfra.host.Host object at 0x7ff7e06ba460>.check_output

```