### PR TITLE
Fix Kubectl logs command to get logs on failures

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -215,13 +215,23 @@ def test_airflow_trigger_dags(scheduler):
             print("Timed out waiting for DAG to succeed")
             print()
             print("Logs: ")
-            subprocess.run(["kubectl", "logs", os.environ.get('SCHEDULER_POD'), os.environ.get('NAMESPACE')])
+            subprocess.run(
+                [
+                    "kubectl", "logs", os.environ.get('SCHEDULER_POD'), "-n", os.environ.get('NAMESPACE'),
+                    "-c", "scheduler", "--tail", "100"
+                ]
+            )
             raise Exception("DAGRun failed !")
         if sleep_count >= timeout:
             print("Timed out waiting for DAG to succeed")
             print()
             print("Logs: ")
-            subprocess.run(["kubectl", "logs", os.environ.get('SCHEDULER_POD'), os.environ.get('NAMESPACE')])
+            subprocess.run(
+                [
+                    "kubectl", "logs", os.environ.get('SCHEDULER_POD'), "-n", os.environ.get('NAMESPACE'),
+                    "-c", "scheduler", "--tail", "100"
+                ]
+            )
             break
 
     assert "success" in scheduler.check_output(dag_state_command)


### PR DESCRIPTION
On jobs that are failing, example https://app.circleci.com/pipelines/github/astronomer/ap-airflow/1045/workflows/4d95124e-a7ad-46c2-80ea-ce2e59ecbbb6/jobs/26972,
this commands were not working an instead just showed:

```
Error from server (NotFound): pods "airflow-4606-scheduler-84b45c4f55-r2zhn" not found
```

instead. And So we need to SSH into the POD to find more details.

This commit should fix it.

