### PR TITLE
Release AC 1.10.14-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,8 +505,7 @@ workflows:
           name: build-1.10.14-buster
           airflow_version: 1.10.14
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.14.build)"
+          dev_build: false
           requires:
             - static-checks
       - scan-clair:
@@ -530,8 +529,8 @@ workflows:
       - push:
           name: push-1.10.14-buster
           tag: "1.10.14-buster"
-          dev_build: true
-          extra_tags: "1.10.14-buster-${CIRCLE_BUILD_NUM},1.10.14-1.dev-buster"
+          dev_build: false
+          extra_tags: "1.10.14-buster-${CIRCLE_BUILD_NUM},1.10.14-1-buster"
           context:
             - quay.io
           requires:
@@ -545,8 +544,8 @@ workflows:
       - push:
           name: push-1.10.14-buster-onbuild
           tag: "1.10.14-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.14-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.14-1.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "1.10.14-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.14-1-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -622,60 +621,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          name: build-1.10.14-buster
-          airflow_version: 1.10.14
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.14.build)"
-      - scan-clair:
-          name: scan-clair-1.10.14-buster-onbuild
-          airflow_version: 1.10.14
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.14-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.14-buster-onbuild
-          airflow_version: 1.10.14
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.14-buster
-      - test:
-          name: test-1.10.14-buster-images
-          tag: "1.10.14-buster"
-          requires:
-            - build-1.10.14-buster
-      - push:
-          name: push-1.10.14-buster
-          tag: "1.10.14-buster"
-          dev_build: true
-          extra_tags: "1.10.14-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.14-buster-onbuild
-            - scan-trivy-1.10.14-buster-onbuild
-            - test-1.10.14-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-1.10.14-buster-onbuild
-          tag: "1.10.14-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.14-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.14-1.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.14-buster-onbuild
-            - scan-trivy-1.10.14-buster-onbuild
-            - test-1.10.14-buster-images
-          filters:
-            branches:
-              only:
-                - master
       - build:
           name: build-2.0.0-buster
           airflow_version: 2.0.0

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -15,7 +15,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.7-16", ["alpine3.10", "buster"]),
     ("1.10.10-6", ["alpine3.10", "buster"]),
     ("1.10.12-2", ["alpine3.10", "buster"]),
-    ("1.10.14-1.dev", ["buster"]),
+    ("1.10.14-1", ["buster"]),
     ("2.0.0-1.dev", ["buster"]),
 ])
 

--- a/1.10.14/CHANGELOG.md
+++ b/1.10.14/CHANGELOG.md
@@ -1,19 +1,15 @@
 # Changelog
 
-Astronomer Certified 1.10.14-1.dev
+Astronomer Certified 1.10.14-1, 2020-12-10
 -----------------------------------------------
 
 User-facing CHANGELOG for AC `1.10.14+astro.1` from Airflow `1.10.14`:
 
-### Bug Fixes
+## Improvements
 
-- Add role-based authentication backend ([commit](https://github.com/astronomer/airflow/commit/d64ad84))
+- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/8a265067e))
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/ad871021b))
+- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/540eb0a0e))
 
-### Improvements
-
-- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/astronomer/airflow/commit/cd3a34e))
-- Enable DAG Serialization by default ([commit](https://github.com/astronomer/airflow/commit/2954e4c))
-
-### New Features
-
-- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/astronomer/airflow/commit/386487e))
+## New Features
+- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/apache/airflow/commit/0e40ddd8e))

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.14-1.*"
+ARG VERSION="1.10.14-1"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.14"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All changes applied to available point releases will be documented in the `CHANG
 - [1.10.7 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.7/CHANGELOG.md)
 - [1.10.10 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.10/CHANGELOG.md)
 - [1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)
+- [1.10.14 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md)
 
 ## Testing
 


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v1.10.14%2Bastro.1

Astronomer Certified 1.10.14-1, 2020-12-10
-----------------------------------------------

User-facing CHANGELOG for AC `1.10.14+astro.1` from Airflow `1.10.14`:

## Improvements

- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/8a265067e))
- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/ad871021b))
- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/540eb0a0e))

## New Features
- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/apache/airflow/commit/0e40ddd8e))

