### PR TITLE
Psql vuln low risk

### DIFF
--- a/1.10.10/buster/trivyignore
+++ b/1.10.10/buster/trivyignore
@@ -18,3 +18,6 @@ CVE-2019-10746
 
 # nodejs-set-value
 CVE-2019-10747
+
+# only applies to running psql interactively -- low risk for us
+CVE-2020-25696

--- a/1.10.12/buster/trivyignore
+++ b/1.10.12/buster/trivyignore
@@ -18,3 +18,6 @@ CVE-2019-10746
 
 # nodejs-set-value
 CVE-2019-10747
+
+# only applies to running psql interactively -- low risk for us
+CVE-2020-25696

--- a/1.10.14/buster/trivyignore
+++ b/1.10.14/buster/trivyignore
@@ -18,3 +18,6 @@ CVE-2019-10746
 
 # nodejs-set-value
 CVE-2019-10747
+
+# only applies to running psql interactively -- low risk for us
+CVE-2020-25696

--- a/1.10.5/buster/trivyignore
+++ b/1.10.5/buster/trivyignore
@@ -19,3 +19,6 @@ CVE-2019-10746
 
 # nodejs-set-value
 CVE-2019-10747
+
+# only applies to running psql interactively -- low risk for us
+CVE-2020-25696

--- a/1.10.7/buster/trivyignore
+++ b/1.10.7/buster/trivyignore
@@ -30,3 +30,6 @@ CVE-2020-7660
 
 # tar
 CVE-2018-20834
+
+# only applies to running psql interactively -- low risk for us
+CVE-2020-25696

--- a/2.0.0/buster/trivyignore
+++ b/2.0.0/buster/trivyignore
@@ -5,3 +5,6 @@ CVE-2020-8203
 
 # nodejs-set-value
 CVE-2019-10747
+
+# only applies to running psql interactively -- low risk for us
+CVE-2020-25696

--- a/cve-allowlist.yaml
+++ b/cve-allowlist.yaml
@@ -22,3 +22,6 @@ generalwhitelist:
   RHSA-2018:1967: kernel-headers
   RHSA-2017:0372: kernel-headers
   RHSA-2018:2772: kernel-headers
+
+  # Only a problem with psql in interactive mode, low risk for us
+  CVE-2020-25696: postgresql


### PR DESCRIPTION
Add this vulnerability to the allowed list

Name | CVE-2020-25696
-- | --
Description | A  flaw was found in the psql interactive terminal of PostgreSQL in  versions before 13.1, before 12.5, before 11.10, before 10.15, before  9.6.20 and before 9.5.24. If an interactive psql session uses \gset when  querying a compromised server, the attacker can execute arbitrary code  as the operating system account running psql. The highest threat from  this vulnerability is to data confidentiality and integrity as well as  system availability.

