### PR TITLE
Use 2.0.0rc3 constraints for installing AC 2.0.0-1 dev image

### DIFF
--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -119,7 +119,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" \
+RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.0rc3/constraints-3.7.txt" \
   && pip install "apache-airflow-providers-elasticsearch" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.5"


### PR DESCRIPTION
https://raw.githubusercontent.com/apache/airflow/constraints-2.0.0rc3/constraints-3.7.txt

We will need to update it when Airflo 2.0.0 is released