### PR TITLE
Update deprecated Extras for 2.0

### DIFF
--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION="2.0.0-1.*"
-ARG SUBMODULES="async,azure,aws,celery,elasticsearch,gcp,password,kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
+ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
 


### PR DESCRIPTION
To my surprise snowflake was not installed:

```
astro@721a97e42cfd:/usr/local/airflow$ pip freeze | grep snowflake
astro@721a97e42cfd:/usr/local/airflow$
```

I though aws / amazon or google might be pulling it in

