### PR TITLE
Move labels to the main stage of buster image building

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -110,9 +110,6 @@ ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.10"
 
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -135,6 +132,11 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="1.10.10-7.*"
+ARG AIRFLOW_VERSION="1.10.10"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -110,9 +110,6 @@ ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.12"
 
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -135,6 +132,11 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="1.10.12-3.*"
+ARG AIRFLOW_VERSION="1.10.12"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -110,9 +110,6 @@ ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.14"
 
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -135,6 +132,11 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="1.10.14-2.*"
+ARG AIRFLOW_VERSION="1.10.14"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -113,9 +113,6 @@ ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,
 ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
 ARG AIRFLOW_VERSION="1.10.5"
 
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-
 # Force pip to install these specific versions when ever it installs a module
 ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
@@ -146,6 +143,11 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="1.10.5-11"
+ARG AIRFLOW_VERSION="1.10.5"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -112,9 +112,6 @@ ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.7"
 
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -137,6 +134,11 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="1.10.7-17.*"
+ARG AIRFLOW_VERSION="1.10.7"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -110,9 +110,6 @@ ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kub
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
 
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
 COPY include/pip.conf /etc/pip.conf
@@ -135,6 +132,11 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="2.0.0-1.*"
+ARG AIRFLOW_VERSION="2.0.0"
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages


### PR DESCRIPTION
https://stackoverflow.com/questions/65331437/difference-in-how-docker-labels-are-applied-in-multi-stage-builds-across-platfor -- even though it works on CI -- not sure why it does. Better be safe
