### PR TITLE
Release 2.0.0-2 AC Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,8 +567,7 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+          dev_build: false
           requires:
             - static-checks
       - scan-clair:
@@ -592,8 +591,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-2.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-2-buster"
           context:
             - quay.io
           requires:
@@ -607,8 +606,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-2.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-2-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -1002,60 +1001,6 @@ workflows:
             - scan-clair-1.10.14-buster-onbuild
             - scan-trivy-1.10.14-buster-onbuild
             - test-1.10.14-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.0.0-buster
-          airflow_version: 2.0.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
-      - scan-clair:
-          name: scan-clair-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - scan-trivy:
-          name: scan-trivy-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - test:
-          name: test-2.0.0-buster-images
-          tag: "2.0.0-buster"
-          requires:
-            - build-2.0.0-buster
-      - push:
-          name: push-2.0.0-buster
-          tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-2.0.0-buster-onbuild
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.0-buster-onbuild
-          tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-2.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-2.0.0-buster-onbuild
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
           filters:
             branches:
               only:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -16,7 +16,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.10-7.dev", ["alpine3.10", "buster"]),
     ("1.10.12-3.dev", ["alpine3.10", "buster"]),
     ("1.10.14-2.dev", ["buster"]),
-    ("2.0.0-2.dev", ["buster"]),
+    ("2.0.0-2", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+Astronomer Certified 2.0.0-2, 2020-12-23
+-----------------------------------------
+
+## Bugfixes
+
+- Allow PID file path to be relative when daemonizing a process (scheduler, kerberos, etc) (#13232) ([commit](https://github.com/astronomer/airflow/commit/ebfb6f207))
+- Dispose connections when running tasks with `os.fork` & CeleryExecutor ([commit](https://github.com/astronomer/airflow/commit/3a7d34c7a))
+- Bump datatables.net from 1.10.21 to 1.10.23 in /airflow/www ([commit](https://github.com/astronomer/airflow/commit/a46642b6d))
+- Stop sending Callback Requests if no callbacks are defined on DAG (#13163) ([commit](https://github.com/astronomer/airflow/commit/0c54f684c))
+- Filter DagRuns with Task Instances in removed State while Scheduling (#13165) ([commit](https://github.com/astronomer/airflow/commit/426ce80cc))
+
 Astronomer Certified 2.0.0-1, 2020-12-17
 -----------------------------------------
 

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-2.*"
+ARG VERSION="2.0.0-2"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -133,7 +133,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-2.*"
+ARG VERSION="2.0.0-2"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v2.0.0%2Bastro.2

Astronomer Certified 2.0.0-2, 2020-12-23
-----------------------------------------

## Bugfixes

- Allow PID file path to be relative when daemonizing a process (scheduler, kerberos, etc) (#13232) ([commit](https://github.com/astronomer/airflow/commit/ebfb6f207))
- Dispose connections when running tasks with `os.fork` & CeleryExecutor ([commit](https://github.com/astronomer/airflow/commit/3a7d34c7a))
- Bump datatables.net from 1.10.21 to 1.10.23 in /airflow/www ([commit](https://github.com/astronomer/airflow/commit/a46642b6d))
- Stop sending Callback Requests if no callbacks are defined on DAG (#13163) ([commit](https://github.com/astronomer/airflow/commit/0c54f684c))
- Filter DagRuns with Task Instances in removed State while Scheduling (#13165) ([commit](https://github.com/astronomer/airflow/commit/426ce80cc))
