### PR TITLE
Ignore False positive CVE in Claire Scanner

### DIFF
--- a/cve-allowlist.yaml
+++ b/cve-allowlist.yaml
@@ -1,4 +1,7 @@
 generalwhitelist:
+  # False Positive
+  CVE-2020-29363: p11-kit
+
   CVE-2020-14155: pcre3
 
   # These are minor issues for Buster images

--- a/cve-allowlist.yaml
+++ b/cve-allowlist.yaml
@@ -1,5 +1,5 @@
 generalwhitelist:
-  # False Positive
+  # False Positive - we have installed the fixed package, but clair is confused about it.
   CVE-2020-29363: p11-kit
 
   CVE-2020-14155: pcre3


### PR DESCRIPTION
`CVE-2020-29363` was fixed by (#193) and trivy scanner is succeeding now but not sure what's with claire
