### PR TITLE
Add 2.0.0-3.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,7 +560,8 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
           requires:
             - static-checks
       - scan-clair:
@@ -584,8 +585,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: false
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-2-buster"
+          dev_build: true
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-3.dev-buster"
           context:
             - quay.io
           requires:
@@ -599,8 +600,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: false
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-2-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-3.dev-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -611,6 +612,70 @@ workflows:
             branches:
               only:
                 - master
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          name: build-2.0.0-buster
+          airflow_version: 2.0.0
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+      - scan-clair:
+          name: scan-clair-2.0.0-buster-onbuild
+          airflow_version: 2.0.0
+          distribution_name: buster-onbuild
+          requires:
+            - build-2.0.0-buster
+      - scan-trivy:
+          name: scan-trivy-2.0.0-buster-onbuild
+          airflow_version: 2.0.0
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-2.0.0-buster
+      - test:
+          name: test-2.0.0-buster-images
+          tag: "2.0.0-buster"
+          requires:
+            - build-2.0.0-buster
+      - push:
+          name: push-2.0.0-buster
+          tag: "2.0.0-buster"
+          dev_build: true
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-2.0.0-buster-onbuild
+            - scan-trivy-2.0.0-buster-onbuild
+            - test-2.0.0-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-2.0.0-buster-onbuild
+          tag: "2.0.0-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-3.dev-buster-onbuild"
+          context:
+            - quay.io
+          requires:
+            - scan-clair-2.0.0-buster-onbuild
+            - scan-trivy-2.0.0-buster-onbuild
+            - test-2.0.0-buster-images
+          filters:
+            branches:
+              only:
+                - master
+
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -16,7 +16,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.10-7", ["alpine3.10", "buster"]),
     ("1.10.12-3", ["alpine3.10", "buster"]),
     ("1.10.14-2", ["buster"]),
-    ("2.0.0-2", ["buster"]),
+    ("2.0.0-3.dev", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+Astronomer Certified 2.0.0-3.dev
+-----------------------------------------
+
+## Bugfixes
+
+- Bugfix: Return XCom Value in the XCom Endpoint API ([commit](https://github.com/astronomer/airflow/commit/c2c9c06b3))
+- BugFix: Dag-level Callback Requests were not run ([commit](https://github.com/astronomer/airflow/commit/4412aba55))
+- Increase the default ``min_file_process_interval`` to decrease CPU Usage ([commit](https://github.com/astronomer/airflow/commit/6de02157f))
+- Stop creating duplicate Dag File Processors ([commit](https://github.com/astronomer/airflow/commit/4ced807ab))
+
 Astronomer Certified 2.0.0-2, 2020-12-23
 -----------------------------------------
 

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -105,7 +105,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-2"
+ARG VERSION="2.0.0-3.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -133,7 +133,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-2"
+ARG VERSION="2.0.0-3.*"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Current changes:

## Bugfixes

- Bugfix: Return XCom Value in the XCom Endpoint API ([commit](https://github.com/astronomer/airflow/commit/c2c9c06b3))
- BugFix: Dag-level Callback Requests were not run ([commit](https://github.com/astronomer/airflow/commit/4412aba55))
- Increase the default ``min_file_process_interval`` to decrease CPU Usage ([commit](https://github.com/astronomer/airflow/commit/6de02157f))
- Stop creating duplicate Dag File Processors ([commit](https://github.com/astronomer/airflow/commit/4ced807ab))

