### PR TITLE
Approvals Needed by the Team to generate new Docker Builds 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.5
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "1.10.5 Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:
@@ -207,25 +240,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.7
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "1.10.7 Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:
@@ -349,25 +415,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.10
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "1.10.10 Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:
@@ -491,25 +590,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.12
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "1.10.12 Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:
@@ -633,25 +765,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.14
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "1.10.14 Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:
@@ -719,25 +884,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-2.0.0
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "2.0.0 Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },
@@ -275,7 +275,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },
@@ -451,7 +451,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },
@@ -627,7 +627,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },
@@ -803,7 +803,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },
@@ -923,7 +923,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,10 @@
 # Warning: automatically generated file
 # Please edit config.yml.j2, and use the script generate_circleci_config.py
 version: 2.1
+
 orbs:
-    slack: circleci/slack@4.2.0  
+    slack: circleci/slack@4.2.0 
+    
 workflows:
   version: 2.1
   certified-airflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-1.10.5
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -35,7 +34,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {
@@ -241,7 +245,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-1.10.7
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -267,7 +270,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {
@@ -417,7 +425,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-1.10.10
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -443,7 +450,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {
@@ -593,7 +605,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-1.10.12
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -619,7 +630,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {
@@ -769,7 +785,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-1.10.14
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -795,7 +810,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {
@@ -889,7 +909,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-2.0.0
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -915,7 +934,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,48 @@
 # Warning: automatically generated file
 # Please edit config.yml.j2, and use the script generate_circleci_config.py
 version: 2.1
+orbs:
+    slack: circleci/slack@4.2.0  
 workflows:
   version: 2.1
   certified-airflow:
     jobs:
-      - static-checks
+      - static-checks- slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "1.10.5 Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-1.10.5
+          requires:
+            - slack/on-hold
+          type: approval
+
       - build:
           name: build-1.10.5-alpine3.10
           airflow_version: 1.10.5
           distribution_name: alpine3.10
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.5
       - scan-clair:
           name: scan-clair-1.10.5-alpine3.10-onbuild
           airflow_version: 1.10.5
@@ -61,13 +91,14 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
       - build:
           name: build-1.10.5-buster
           airflow_version: 1.10.5
           distribution_name: buster
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.5
       - scan-clair:
           name: scan-clair-1.10.5-buster-onbuild
           airflow_version: 1.10.5
@@ -116,13 +147,14 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
       - build:
           name: build-1.10.5-rhel7
           airflow_version: 1.10.5
           distribution_name: rhel7
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.5
       - scan-clair:
           name: scan-clair-1.10.5-rhel7-onbuild
           airflow_version: 1.10.5
@@ -171,13 +203,42 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals- slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "1.10.7 Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-1.10.7
+          requires:
+            - slack/on-hold
+          type: approval
+
       - build:
           name: build-1.10.7-alpine3.10
           airflow_version: 1.10.7
           distribution_name: alpine3.10
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.7
       - scan-clair:
           name: scan-clair-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
@@ -226,13 +287,14 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
       - build:
           name: build-1.10.7-buster
           airflow_version: 1.10.7
           distribution_name: buster
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.7
       - scan-clair:
           name: scan-clair-1.10.7-buster-onbuild
           airflow_version: 1.10.7
@@ -281,13 +343,42 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals- slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "1.10.10 Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-1.10.10
+          requires:
+            - slack/on-hold
+          type: approval
+
       - build:
           name: build-1.10.10-alpine3.10
           airflow_version: 1.10.10
           distribution_name: alpine3.10
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.10
       - scan-clair:
           name: scan-clair-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
@@ -336,13 +427,14 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
       - build:
           name: build-1.10.10-buster
           airflow_version: 1.10.10
           distribution_name: buster
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.10
       - scan-clair:
           name: scan-clair-1.10.10-buster-onbuild
           airflow_version: 1.10.10
@@ -391,13 +483,42 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals- slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "1.10.12 Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-1.10.12
+          requires:
+            - slack/on-hold
+          type: approval
+
       - build:
           name: build-1.10.12-alpine3.10
           airflow_version: 1.10.12
           distribution_name: alpine3.10
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.12
       - scan-clair:
           name: scan-clair-1.10.12-alpine3.10-onbuild
           airflow_version: 1.10.12
@@ -446,13 +567,14 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
       - build:
           name: build-1.10.12-buster
           airflow_version: 1.10.12
           distribution_name: buster
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.12
       - scan-clair:
           name: scan-clair-1.10.12-buster-onbuild
           airflow_version: 1.10.12
@@ -501,13 +623,42 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals- slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "1.10.14 Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-1.10.14
+          requires:
+            - slack/on-hold
+          type: approval
+
       - build:
           name: build-1.10.14-buster
           airflow_version: 1.10.14
           distribution_name: buster
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-1.10.14
       - scan-clair:
           name: scan-clair-1.10.14-buster-onbuild
           airflow_version: 1.10.14
@@ -556,13 +707,42 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals- slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "2.0.0 Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-2.0.0
+          requires:
+            - slack/on-hold
+          type: approval
+
       - build:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
           dev_build: false
           requires:
-            - static-checks
+            - Need-Approval-2.0.0
       - scan-clair:
           name: scan-clair-2.0.0-buster-onbuild
           airflow_version: 2.0.0
@@ -611,6 +791,7 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,7 @@
 # Please edit config.yml.j2, and use the script generate_circleci_config.py
 version: 2.1
 
-orbs:
-    slack: circleci/slack@4.2.0 
-    
 workflows:
-  version: 2.1
   certified-airflow:
     jobs:
       - static-checks- slack/on-hold:
@@ -937,6 +933,7 @@ jobs:
           prod_core_docker_repo_quay_io: "<< parameters.prod_core_docker_repo_quay_io >>"
 
 orbs:
+  slack: circleci/slack@4.2.0
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ version: 2.1
 workflows:
   certified-airflow:
     jobs:
-      - static-checks- slack/on-hold:
+      - static-checks
+      - slack/on-hold:
+          name: SlackHold-1.10.5
           context: slack_ap-airflow
           custom: |
             {
@@ -25,13 +27,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-1.10.5
           requires:
-            - slack/on-hold
+            - SlackHold-1.10.5
           type: approval
 
       - build:
@@ -201,7 +203,9 @@ workflows:
             branches:
               only:
                 - master
-                - slack-build-approvals- slack/on-hold:
+                - slack-build-approvals
+      - slack/on-hold:
+          name: SlackHold-1.10.7
           context: slack_ap-airflow
           custom: |
             {
@@ -221,13 +225,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-1.10.7
           requires:
-            - slack/on-hold
+            - SlackHold-1.10.7
           type: approval
 
       - build:
@@ -341,7 +345,9 @@ workflows:
             branches:
               only:
                 - master
-                - slack-build-approvals- slack/on-hold:
+                - slack-build-approvals
+      - slack/on-hold:
+          name: SlackHold-1.10.10
           context: slack_ap-airflow
           custom: |
             {
@@ -361,13 +367,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-1.10.10
           requires:
-            - slack/on-hold
+            - SlackHold-1.10.10
           type: approval
 
       - build:
@@ -481,7 +487,9 @@ workflows:
             branches:
               only:
                 - master
-                - slack-build-approvals- slack/on-hold:
+                - slack-build-approvals
+      - slack/on-hold:
+          name: SlackHold-1.10.12
           context: slack_ap-airflow
           custom: |
             {
@@ -501,13 +509,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-1.10.12
           requires:
-            - slack/on-hold
+            - SlackHold-1.10.12
           type: approval
 
       - build:
@@ -621,7 +629,9 @@ workflows:
             branches:
               only:
                 - master
-                - slack-build-approvals- slack/on-hold:
+                - slack-build-approvals
+      - slack/on-hold:
+          name: SlackHold-1.10.14
           context: slack_ap-airflow
           custom: |
             {
@@ -641,13 +651,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-1.10.14
           requires:
-            - slack/on-hold
+            - SlackHold-1.10.14
           type: approval
 
       - build:
@@ -705,7 +715,9 @@ workflows:
             branches:
               only:
                 - master
-                - slack-build-approvals- slack/on-hold:
+                - slack-build-approvals
+      - slack/on-hold:
+          name: SlackHold-2.0.0
           context: slack_ap-airflow
           custom: |
             {
@@ -725,13 +737,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-2.0.0
           requires:
-            - slack/on-hold
+            - SlackHold-2.0.0
           type: approval
 
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,9 @@ workflows:
     jobs:
       - static-checks
       - slack/on-hold:
-          name: SlackHold-1.10.5
+          name: Slack_Notification-1.10.5
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -25,15 +26,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -42,7 +43,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },
@@ -238,8 +239,9 @@ workflows:
                 - master
                 - slack-build-approvals
       - slack/on-hold:
-          name: SlackHold-1.10.7
+          name: Slack_Notification-1.10.7
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -256,15 +258,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -273,7 +275,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },
@@ -413,8 +415,9 @@ workflows:
                 - master
                 - slack-build-approvals
       - slack/on-hold:
-          name: SlackHold-1.10.10
+          name: Slack_Notification-1.10.10
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -431,15 +434,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -448,7 +451,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },
@@ -588,8 +591,9 @@ workflows:
                 - master
                 - slack-build-approvals
       - slack/on-hold:
-          name: SlackHold-1.10.12
+          name: Slack_Notification-1.10.12
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -606,15 +610,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -623,7 +627,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },
@@ -763,8 +767,9 @@ workflows:
                 - master
                 - slack-build-approvals
       - slack/on-hold:
-          name: SlackHold-1.10.14
+          name: Slack_Notification-1.10.14
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -781,15 +786,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -798,7 +803,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },
@@ -882,8 +887,9 @@ workflows:
                 - master
                 - slack-build-approvals
       - slack/on-hold:
-          name: SlackHold-2.0.0
+          name: Slack_Notification-2.0.0
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -900,15 +906,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -917,7 +923,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.5
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "1.10.5 Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "1.10.5 Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:
@@ -207,25 +207,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.7
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "1.10.7 Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "1.10.7 Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:
@@ -349,25 +349,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.10
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "1.10.10 Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "1.10.10 Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:
@@ -491,25 +491,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.12
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "1.10.12 Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "1.10.12 Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:
@@ -633,25 +633,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-1.10.14
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "1.10.14 Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "1.10.14 Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:
@@ -719,25 +719,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-2.0.0
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "2.0.0 Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "2.0.0 Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1030,6 +1030,74 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
+      - slack/on-hold:
+          name: Slack_Notification-2.0.1
+          context: slack_ap-airflow
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
+                      }
+
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-2.0.1
+          requires:
+            - Slack_Notification-2.0.1
+          type: approval
+
       - build:
           name: build-2.0.1-buster
           airflow_version: 2.0.1
@@ -1037,7 +1105,7 @@ workflows:
           dev_build: true
           extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.1.build)"
           requires:
-            - static-checks
+            - Need-Approval-2.0.1
       - scan-clair:
           name: scan-clair-2.0.1-buster-onbuild
           airflow_version: 2.0.1
@@ -1086,6 +1154,7 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
   nightly:
     triggers:
       - schedule:
@@ -1149,7 +1218,6 @@ workflows:
             branches:
               only:
                 - master
-
 
 jobs:
   static-checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-1.10.5
           requires:
-            - SlackHold-1.10.5
+            - Slack_Notification-1.10.5
           type: approval
 
       - build:
@@ -299,7 +299,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-1.10.7
           requires:
-            - SlackHold-1.10.7
+            - Slack_Notification-1.10.7
           type: approval
 
       - build:
@@ -475,7 +475,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-1.10.10
           requires:
-            - SlackHold-1.10.10
+            - Slack_Notification-1.10.10
           type: approval
 
       - build:
@@ -651,7 +651,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-1.10.12
           requires:
-            - SlackHold-1.10.12
+            - Slack_Notification-1.10.12
           type: approval
 
       - build:
@@ -827,7 +827,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-1.10.14
           requires:
-            - SlackHold-1.10.14
+            - Slack_Notification-1.10.14
           type: approval
 
       - build:
@@ -947,7 +947,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-2.0.0
           requires:
-            - SlackHold-2.0.0
+            - Slack_Notification-2.0.0
           type: approval
 
       - build:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -8,8 +8,9 @@ workflows:
 {%- set airflow_version = ac_version | get_airflow_version -%}
 {%- set dev_build = "true" if "dev" in ac_version else "false" %}
       - slack/on-hold:
-          name: SlackHold-{{ airflow_version }}
+          name: Slack_Notification-{{ airflow_version }}
           context: slack_ap-airflow
+          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -26,15 +27,15 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                        "text": "*Project*:$CIRCLE_PROJECT_REPONAME"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                        "text": "*Branch*:$CIRCLE_BRANCH"
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                        "text": "*Author*:$CIRCLE_USERNAME"
                       }
                     ]
                   },
@@ -43,7 +44,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                        "text": "*Mentions*:"
                       }
                     ]
                   },

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -10,25 +10,58 @@ workflows:
       - slack/on-hold:
           name: SlackHold-{{ airflow_version }}
           context: slack_ap-airflow
-          # custom: |
-          #   {
-          #     "blocks": [
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "Current Job: $CIRCLE_JOB"
-          #         }
-          #       },
-          #       {
-          #         "type": "section",
-          #         "text": {
-          #           "type": "mrkdwn",
-          #           "text": "{{ airflow_version }} Version - Needs approval"
-          #         }
-          #       }
-          #     ]
-          #   }
+          custom: |
+            {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "$CIRCLE_JOB On Hold- Awaiting Approval :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*:\\n$CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*:\\n$CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*:\\n$CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Mentions*:\\n$SLACK_PARAM_MENTIONS"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
           requires:
             - static-checks
       - pause_workflow:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+    slack: circleci/slack@4.2.0  
 workflows:
   version: 2.1
   certified-airflow:
@@ -7,7 +9,34 @@ workflows:
 {%- for ac_version, distributions in image_map.items() %}
 {%- set airflow_version = ac_version | get_airflow_version -%}
 {%- set dev_build = "true" if "dev" in ac_version else "false" -%}
-
+      - slack/on-hold:
+          context: slack_ap-airflow
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Current Job: $CIRCLE_JOB"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "{{ airflow_version }} Version - Needs approval"
+                  }
+                }
+              ]
+              }
+          requires:
+            - static-checks
+      - pause_workflow:
+          name: Need-Approval-{{ airflow_version }}
+          requires:
+            - slack/on-hold
+          type: approval
 {% for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
@@ -18,7 +47,7 @@ workflows:
           extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)"
           {%- endif %}
           requires:
-            - static-checks
+            - Need-Approval-{{ airflow_version }}
       - scan-clair:
           name: scan-clair-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}
@@ -67,6 +96,7 @@ workflows:
             branches:
               only:
                 - master
+                - slack-build-approvals
 {%- endfor %}
 {%- endfor %}
 {%- if image_map.keys() | dev_releases | length > 0 %}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -6,8 +6,9 @@ workflows:
       - static-checks
 {%- for ac_version, distributions in image_map.items() %}
 {%- set airflow_version = ac_version | get_airflow_version -%}
-{%- set dev_build = "true" if "dev" in ac_version else "false" -%}
+{%- set dev_build = "true" if "dev" in ac_version else "false" %}
       - slack/on-hold:
+          name: SlackHold-{{ airflow_version }}
           context: slack_ap-airflow
           custom: |
             {
@@ -27,13 +28,13 @@ workflows:
                   }
                 }
               ]
-              }
+            }
           requires:
             - static-checks
       - pause_workflow:
           name: Need-Approval-{{ airflow_version }}
           requires:
-            - slack/on-hold
+            - SlackHold-{{ airflow_version }}
           type: approval
 {% for distribution in distributions %}
       - build:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -68,7 +68,7 @@ workflows:
       - pause_workflow:
           name: Need-Approval-{{ airflow_version }}
           requires:
-            - SlackHold-{{ airflow_version }}
+            - Slack_Notification-{{ airflow_version }}
           type: approval
 {% for distribution in distributions %}
       - build:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -1,6 +1,8 @@
 version: 2.1
+
 orbs:
-    slack: circleci/slack@4.2.0  
+    slack: circleci/slack@4.2.0 
+    
 workflows:
   version: 2.1
   certified-airflow:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -10,7 +10,6 @@ workflows:
       - slack/on-hold:
           name: Slack_Notification-{{ airflow_version }}
           context: slack_ap-airflow
-          mentions: "<@UHRPL613K>"
           custom: |
             {
                 "blocks": [
@@ -36,7 +35,12 @@ workflows:
                       {
                         "type": "mrkdwn",
                         "text": "*Author*:$CIRCLE_USERNAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Pull Request*:$CIRCLE_PULL_REQUEST"
                       }
+
                     ]
                   },
                   {

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -44,7 +44,7 @@ workflows:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*Mentions*:"
+                        "text": "*Mentions*:<@UHRPL613K>,<@U018NSS9G2Y>"
                       }
                     ]
                   },

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -1,10 +1,6 @@
 version: 2.1
 
-orbs:
-    slack: circleci/slack@4.2.0 
-    
 workflows:
-  version: 2.1
   certified-airflow:
     jobs:
       - static-checks
@@ -316,6 +312,7 @@ jobs:
           prod_core_docker_repo_quay_io: "<< parameters.prod_core_docker_repo_quay_io >>"
 
 orbs:
+  slack: circleci/slack@4.2.0
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -10,25 +10,25 @@ workflows:
       - slack/on-hold:
           name: SlackHold-{{ airflow_version }}
           context: slack_ap-airflow
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Current Job: $CIRCLE_JOB"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "{{ airflow_version }} Version - Needs approval"
-                  }
-                }
-              ]
-            }
+          # custom: |
+          #   {
+          #     "blocks": [
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "Current Job: $CIRCLE_JOB"
+          #         }
+          #       },
+          #       {
+          #         "type": "section",
+          #         "text": {
+          #           "type": "mrkdwn",
+          #           "text": "{{ airflow_version }} Version - Needs approval"
+          #         }
+          #       }
+          #     ]
+          #   }
           requires:
             - static-checks
       - pause_workflow:


### PR DESCRIPTION
**What this PR does / why we need it**:
Approvals Needed by the Team to generate new Docker Builds 
Now Notifications would be  sent to a specific Slack Channel for Build Approvals
Instead of generating docker images for all the releases everytime now we can restrict to a particular releases by manually approving

**Special notes for your reviewer**:
Please review the Jinja template which has majority of the changes.
