### PR TITLE
Fix pre-commit git diff exit code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,7 +687,7 @@ jobs:
           command: |
             pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
-            pre-commit run --all-files || git --no-pager diff
+            pre-commit run --all-files || { git --no-pager diff && false ; }
   build:
     executor: docker-executor
     description: Build Airflow images

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -152,7 +152,7 @@ jobs:
           command: |
             pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
-            pre-commit run --all-files || git --no-pager diff
+            pre-commit run --all-files || { git --no-pager diff && false ; }
   build:
     executor: docker-executor
     description: Build Airflow images


### PR DESCRIPTION
Make CI exit non-zero when `pre-commit run --all-files` fails. The `|| git diff` was causing it to return 0.