### PR TITLE
Ignore CVE-2019-25013

### DIFF
--- a/cve-allowlist.yaml
+++ b/cve-allowlist.yaml
@@ -1,10 +1,14 @@
 generalwhitelist:
+
+
   # False Positive - we have installed the fixed package, but clair is confused about it.
   CVE-2020-29363: p11-kit
 
   CVE-2020-14155: pcre3
 
   # These are minor issues for Buster images
+  CVE-2019-25013: glibc
+
   CVE-2020-10878: perl
   CVE-2020-10543: perl
 


### PR DESCRIPTION
As mentioned in https://security-tracker.debian.org/tracker/CVE-2019-25013 , CVE-2019-25013 is a minor issue for buster image and has not been fixed and marked as "no-dsa" (postponed / ignored)


