### PR TITLE
Fix CVE-2021-3156 by bursting Docker cache

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -128,7 +128,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.1/buster/Dockerfile
+++ b/2.0.1/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="4"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
Hopefully, upgrading all packages will fix this CVE: https://security-tracker.debian.org/tracker/CVE-2021-3156
