### PR TITLE
Fix CVE-2020-25694/2020-25695 burst Docker Cache

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -128,7 +128,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.1/buster/Dockerfile
+++ b/2.0.1/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="5"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
Security Scans Failed

```
+---------+------------------+----------+-------------------+-----------------+---------------------------------------+
| LIBRARY | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION  |                 TITLE                 |
+---------+------------------+----------+-------------------+-----------------+---------------------------------------+
| libpq5  | CVE-2020-25694   | HIGH     | 11.9-0+deb10u1    | 11.10-0+deb10u1 | postgresql: Reconnection              |
|         |                  |          |                   |                 | can downgrade connection              |
|         |                  |          |                   |                 | security settings                     |
|         |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2020-25694 |
+         +------------------+          +                   +                 +---------------------------------------+
|         | CVE-2020-25695   |          |                   |                 | postgresql: Multiple                  |
|         |                  |          |                   |                 | features escape "security             |
|         |                  |          |                   |                 | restricted operation" sandbox         |
|         |                  |          |                   |                 | -->avd.aquasec.com/nvd/cve-2020-25695 |
+---------+------------------+----------+-------------------+-----------------+---------------------------------------+
```
Fixing the scan by bursting docker caches. Here is the link

https://security-tracker.debian.org/tracker/CVE-2020-25694