### PR TITLE
Constrain versions for Providers during docker build for 2.0.0

### DIFF
--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -9,6 +9,15 @@ Astronomer Certified 2.0.0-3.dev
 - BugFix: Dag-level Callback Requests were not run ([commit](https://github.com/astronomer/airflow/commit/4412aba55))
 - Increase the default ``min_file_process_interval`` to decrease CPU Usage ([commit](https://github.com/astronomer/airflow/commit/6de02157f))
 - Stop creating duplicate Dag File Processors ([commit](https://github.com/astronomer/airflow/commit/4ced807ab))
+- Fix drop_user_and_chart migration rule for MySQL ([commit](https://github.com/astronomer/airflow/commit/ebbbc62b542c32b791dd265338d253ed1c1c19f9))
+- Bugfix: Import error when using custom backend and `sql_alchemy_conn_secret` ([commit](https://github.com/astronomer/airflow/commit/ebbbc62b542c32b791dd265338d253ed1c1c19f9))
+- Fix broken SLA Mechanism ([commit](https://github.com/astronomer/airflow/commit/7036fda8ca5735d85c35a565b436e53259670146))
+- Make v1/config endpoint respect webserver `expose_config` setting ([commit](https://github.com/astronomer/airflow/commit/3b45503b5da56a4c9ed9a135102851cfc1969e6b))
+- Fix DB Migration for SQLite to upgrade to 2.0 ([commit](https://github.com/astronomer/airflow/commit/7ca3915ba16cead50d1dfdd93d55170cc84ece56))
+- Add authentication to lineage endpoint for experimental API ([commit](https://github.com/astronomer/airflow/commit/a181b9034ea797cd250245d45e3af682547a6430))
+- Only compare updated time when Serialized DAG exists ([commit](https://github.com/astronomer/airflow/commit/c14f467478118df1fe20e343fece967b7addc11d))
+- Fix race condition when using Dynamic DAGs ([commit](https://github.com/astronomer/airflow/commit/7441ce155582e249cced79272300b30aa8f160d1))
+- Upgrade azure blob to v12 ([commit](https://github.com/astronomer/airflow/commit/6960757562f149d4ed40dd59f66d7b3ac16ceba4))
 
 Astronomer Certified 2.0.0-2, 2020-12-23
 -----------------------------------------

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -115,8 +115,16 @@ ARG AIRFLOW_VERSION="2.0.0"
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# This constraints will be only used during docker-build
+# and won't be included in the final image
+# It is useful to install airflow-providers that work but still allow users to
+# install providers of their choice (as opposed to entries in astronomer-pip-constraints.txt)
+COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
+
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt" \
+RUN pip install "${AIRFLOW_MODULE}" \
+    --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-3.7.txt" \
+    --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.5"
 

--- a/2.0.0/buster/build-time-pip-constraints.txt
+++ b/2.0.0/buster/build-time-pip-constraints.txt
@@ -1,0 +1,17 @@
+# Constraint the version pip will install during docker build
+
+apache-airflow-providers-amazon==1.0.0
+apache-airflow-providers-celery==1.0.0
+apache-airflow-providers-cncf-kubernetes==1.0.1
+apache-airflow-providers-elasticsearch==1.0.1
+apache-airflow-providers-ftp==1.0.0
+apache-airflow-providers-google==1.0.0
+apache-airflow-providers-http==1.0.0
+apache-airflow-providers-imap==1.0.0
+apache-airflow-providers-microsoft-azure==1.1.0
+apache-airflow-providers-mysql==1.0.0
+apache-airflow-providers-postgres==1.0.0
+apache-airflow-providers-redis==1.0.0
+apache-airflow-providers-slack==1.0.0
+apache-airflow-providers-sqlite==1.0.0
+apache-airflow-providers-ssh==1.0.0


### PR DESCRIPTION
Since we are planning to cut 2.0.0-3 we should release the same set of Providers except for few exceptions:

`apache-airflow-providers-elasticsearch==1.0.1` -- contains our logging fix
`apache-airflow-providers-cncf-kubernetes==1.0.1 `-- contains a bug fix for K8s Operator
`apache-airflow-providers-microsoft-azure==1.1.0` -- Will allow installing snowflake provider (includes https://github.com/apache/airflow/pull/12188)

Since these constraint sare only used in docker build time and not included in Dockerfile users are free to upgrade to a major version for providers like google. This is the main different between this constraints file vs `pip-constraints.txt`.

Without this change, new versions of providers would be installed (even the major ones)
