### PR TITLE
Burst Package Cache to fix CVE-2021-23840

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -128,7 +128,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -134,7 +134,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.1/buster/Dockerfile
+++ b/2.0.1/buster/Dockerfile
@@ -126,7 +126,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the vulnerability based on https://security-tracker.debian.org/tracker/CVE-2021-23840


+-----------+------------------+----------+-------------------+------------------+---------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                 TITLE                 |
+-----------+------------------+----------+-------------------+------------------+---------------------------------------+
| libssl1.1 | CVE-2021-23840   | HIGH     | 1.1.1d-0+deb10u4  | 1.1.1d-0+deb10u5 | openssl: integer                      |
|           |                  |          |                   |                  | overflow in CipherUpdate              |
|           |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2021-23840 |
+-----------+                  +          +                   +                  +                                       +
| openssl   |                  |          |                   |                  |                                       |
|           |                  |          |                   |                  |                                       |
|           |                  |          |                   |                  |                                       |
+-----------+------------------+----------+-------------------+------------------+---------------------------------------+


 