### PR TITLE
Remove dev images push to astronomerio/ap-airflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1454,7 +1454,7 @@ commands:
       - store_test_results:
           path: /tmp/test-reports
   push:
-    description: "Push a Docker image to DockerHub"
+    description: "Push a Docker image to DockerHub "
     parameters:
       dev_release:
         description: "Indicate if this is a dev release"
@@ -1509,7 +1509,7 @@ commands:
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
-               
+
               else
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:${tag}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1334,10 +1334,6 @@ jobs:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "astronomerinc/ap-airflow"
         type: string
-      dev_docker_repo_docker_hub:
-        description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
-        default: "astronomerio/ap-airflow"
-        type: string
       prod_docker_repo_quay_io:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "quay.io/astronomer/ap-airflow"
@@ -1356,7 +1352,6 @@ jobs:
           extra_tags: "<< parameters.extra_tags >>"
           tag: "<< parameters.tag >>"
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"
-          dev_docker_repo_docker_hub: "<< parameters.dev_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
           prod_core_docker_repo_quay_io: "<< parameters.prod_core_docker_repo_quay_io >>"
@@ -1476,9 +1471,6 @@ commands:
       prod_docker_repo_docker_hub:
         default: astronomerinc/ap-airflow
         type: string
-      dev_docker_repo_docker_hub:
-        default: "astronomerio/ap-airflow"
-        type: string
       prod_docker_repo_quay_io:
         default: quay.io/astronomer/ap-airflow
         type: string
@@ -1517,10 +1509,7 @@ commands:
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
-
-                echo "Tagging and pushing image <<parameters.image_name>>:${tag} to << parameters.dev_docker_repo_docker_hub >>"
-                docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:$tag"
-                docker push "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
+               
               else
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:${tag}"
@@ -1538,9 +1527,6 @@ commands:
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
 
-                echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_docker_hub >>"
-                docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
-                docker push "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
               fi
             done
 
@@ -1562,10 +1548,6 @@ commands:
                 docker tag "$image" "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
                 docker push "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
               fi
-
-              echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_docker_hub >>"
-              docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
-              docker push "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
 
               echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_quay_io >>"
               docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:<< parameters.tag >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1454,7 +1454,7 @@ commands:
       - store_test_results:
           path: /tmp/test-reports
   push:
-    description: "Push a Docker image to DockerHub "
+    description: "Push a Docker image to DockerHub"
     parameters:
       dev_release:
         description: "Indicate if this is a dev release"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -443,7 +443,7 @@ commands:
       - store_test_results:
           path: /tmp/test-reports
   push:
-    description: "Push a Docker image to DockerHub "
+    description: "Push a Docker image to DockerHub"
     parameters:
       dev_release:
         description: "Indicate if this is a dev release"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -443,7 +443,7 @@ commands:
       - store_test_results:
           path: /tmp/test-reports
   push:
-    description: "Push a Docker image to DockerHub"
+    description: "Push a Docker image to DockerHub "
     parameters:
       dev_release:
         description: "Indicate if this is a dev release"
@@ -498,7 +498,7 @@ commands:
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
-               
+
               else
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:${tag}"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -323,10 +323,6 @@ jobs:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "astronomerinc/ap-airflow"
         type: string
-      dev_docker_repo_docker_hub:
-        description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
-        default: "astronomerio/ap-airflow"
-        type: string
       prod_docker_repo_quay_io:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "quay.io/astronomer/ap-airflow"
@@ -345,7 +341,6 @@ jobs:
           extra_tags: "<< parameters.extra_tags >>"
           tag: "<< parameters.tag >>"
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"
-          dev_docker_repo_docker_hub: "<< parameters.dev_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
           prod_core_docker_repo_quay_io: "<< parameters.prod_core_docker_repo_quay_io >>"
@@ -465,9 +460,6 @@ commands:
       prod_docker_repo_docker_hub:
         default: astronomerinc/ap-airflow
         type: string
-      dev_docker_repo_docker_hub:
-        default: "astronomerio/ap-airflow"
-        type: string
       prod_docker_repo_quay_io:
         default: quay.io/astronomer/ap-airflow
         type: string
@@ -506,10 +498,7 @@ commands:
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
-
-                echo "Tagging and pushing image <<parameters.image_name>>:${tag} to << parameters.dev_docker_repo_docker_hub >>"
-                docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:$tag"
-                docker push "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
+               
               else
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:${tag}"
@@ -527,9 +516,6 @@ commands:
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
 
-                echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_docker_hub >>"
-                docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
-                docker push "<< parameters.dev_docker_repo_docker_hub >>:${tag}"
               fi
             done
 
@@ -551,10 +537,6 @@ commands:
                 docker tag "$image" "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
                 docker push "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
               fi
-
-              echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_docker_hub >>"
-              docker tag "$image" "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
-              docker push "<< parameters.dev_docker_repo_docker_hub >>:<< parameters.tag >>"
 
               echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_quay_io >>"
               docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:<< parameters.tag >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
- We are no longer using astronomerio/ap-airflow for the dev images. 
- We plan to use to astronomerio only for one specific repo 


