### PR TITLE
Remove quay.io/astronomer/core push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1346,10 +1346,6 @@ jobs:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "quay.io/astronomer/ap-airflow-dev"
         type: string
-      prod_core_docker_repo_quay_io:
-        description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
-        default: quay.io/astronomer/core
-        type: string
     steps:
       - push:
           dev_release: "<< parameters.dev_build >>"
@@ -1359,7 +1355,6 @@ jobs:
           dev_docker_repo_docker_hub: "<< parameters.dev_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
-          prod_core_docker_repo_quay_io: "<< parameters.prod_core_docker_repo_quay_io >>"
 
 orbs:
   slack: circleci/slack@4.2.0
@@ -1485,9 +1480,6 @@ commands:
       dev_docker_repo_quay_io:
         default: "quay.io/astronomer/ap-airflow-dev"
         type: string
-      prod_core_docker_repo_quay_io:
-        default: quay.io/astronomer/core
-        type: string
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -1530,10 +1522,6 @@ commands:
                 docker tag "$image" "<< parameters.prod_docker_repo_docker_hub >>:${tag}"
                 docker push "<< parameters.prod_docker_repo_docker_hub >>:${tag}"
 
-                echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_core_docker_repo_quay_io >>"
-                docker tag "$image" "<< parameters.prod_core_docker_repo_quay_io >>:${tag}"
-                docker push "<< parameters.prod_core_docker_repo_quay_io >>:${tag}"
-
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
@@ -1557,10 +1545,6 @@ commands:
                 echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_docker_repo_docker_hub >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
                 docker push "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
-
-                echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_core_docker_repo_quay_io >>"
-                docker tag "$image" "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
-                docker push "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
               fi
 
               echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_docker_hub >>"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -335,10 +335,6 @@ jobs:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "quay.io/astronomer/ap-airflow-dev"
         type: string
-      prod_core_docker_repo_quay_io:
-        description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
-        default: quay.io/astronomer/core
-        type: string
     steps:
       - push:
           dev_release: "<< parameters.dev_build >>"
@@ -348,7 +344,6 @@ jobs:
           dev_docker_repo_docker_hub: "<< parameters.dev_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
-          prod_core_docker_repo_quay_io: "<< parameters.prod_core_docker_repo_quay_io >>"
 
 orbs:
   slack: circleci/slack@4.2.0
@@ -474,9 +469,6 @@ commands:
       dev_docker_repo_quay_io:
         default: "quay.io/astronomer/ap-airflow-dev"
         type: string
-      prod_core_docker_repo_quay_io:
-        default: quay.io/astronomer/core
-        type: string
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -519,10 +511,6 @@ commands:
                 docker tag "$image" "<< parameters.prod_docker_repo_docker_hub >>:${tag}"
                 docker push "<< parameters.prod_docker_repo_docker_hub >>:${tag}"
 
-                echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_core_docker_repo_quay_io >>"
-                docker tag "$image" "<< parameters.prod_core_docker_repo_quay_io >>:${tag}"
-                docker push "<< parameters.prod_core_docker_repo_quay_io >>:${tag}"
-
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
@@ -546,10 +534,6 @@ commands:
                 echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_docker_repo_docker_hub >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
                 docker push "<< parameters.prod_docker_repo_docker_hub >>:<< parameters.tag >>"
-
-                echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.prod_core_docker_repo_quay_io >>"
-                docker tag "$image" "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
-                docker push "<< parameters.prod_core_docker_repo_quay_io >>:<< parameters.tag >>"
               fi
 
               echo "Tagging and pushing image <<parameters.image_name>>:<< parameters.tag >> to << parameters.dev_docker_repo_docker_hub >>"


### PR DESCRIPTION
## What this PR does / why we need it

Remove push to quay.io/astronomer/core because this is handled by another repo as per @ernest-kr 

Closes https://github.com/astronomer/issues/issues/2655