### PR TITLE
Sync fab perms on web startup using airfl config

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -152,8 +152,6 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
-    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes

--- a/1.10.10/buster/include/entrypoint
+++ b/1.10.10/buster/include/entrypoint
@@ -44,9 +44,5 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
-if [[ $CMD == "webserver" ]]; then
-  airflow sync_perm
-fi
-
 # Run the original command
 exec "$@"

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -152,8 +152,6 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
-    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes

--- a/1.10.12/buster/include/entrypoint
+++ b/1.10.12/buster/include/entrypoint
@@ -44,9 +44,5 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
-if [[ $CMD == "webserver" ]]; then
-  airflow sync_perm
-fi
-
 # Run the original command
 exec "$@"

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -152,8 +152,6 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
-    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes

--- a/1.10.14/buster/include/entrypoint
+++ b/1.10.14/buster/include/entrypoint
@@ -44,9 +44,5 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
-if [[ $CMD == "webserver" ]]; then
-  airflow sync_perm
-fi
-
 # Run the original command
 exec "$@"

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -154,8 +154,6 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
-    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes

--- a/1.10.7/buster/include/entrypoint
+++ b/1.10.7/buster/include/entrypoint
@@ -44,9 +44,5 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
-if [[ $CMD == "webserver" ]]; then
-  airflow sync_perm
-fi
-
 # Run the original command
 exec "$@"

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -162,8 +162,6 @@ RUN sed -i \
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
     # Needed by astronomer-version-check-plugin
     -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
-    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg

--- a/2.0.0/buster/include/entrypoint
+++ b/2.0.0/buster/include/entrypoint
@@ -44,9 +44,5 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|celery worker
   done
 fi
 
-if [[ $CMD == "webserver" ]]; then
-  airflow sync-perm
-fi
-
 # Run the original command
 exec "$@"

--- a/2.0.1/buster/Dockerfile
+++ b/2.0.1/buster/Dockerfile
@@ -154,8 +154,6 @@ RUN sed -i \
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
     # Needed by astronomer-version-check-plugin
     -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
-    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg

--- a/2.0.1/buster/include/entrypoint
+++ b/2.0.1/buster/include/entrypoint
@@ -44,9 +44,5 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|celery worker
   done
 fi
 
-if [[ $CMD == "webserver" ]]; then
-  airflow sync-perm
-fi
-
 # Run the original command
 exec "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

Because of the custom fab security manager, permissions need to be synced in Airflow on webserver startup. This has up until now been done in the `entrypoint.sh` script.

Now that we are actively promoting our Astronomer Core image and promising it to be the same (but better!) as the OSS one, we'll hopefully see more users attempting to quickly run our containers. It's probable that some of these users will be evaluating the feasibility of migrating from whatever they are using to ours.

Something a lot of people do when first evaluating a container is to pull it and run it in interactive mode. This action overrides
the docker entrypoint, which means the permissions don't get synced. When they run the webserver and login, they are
stuck in an infinite loop. It's won't be apparent as to why, especially since they are likely not to know about the Astro custom fab security manager. If they then try the same action in the OSS image, it will work and they are likely not to return to our image. 

There is an Airflow configuration called `update_fab_perms` that can sync permissions automatically when the webserver starts. Easiest way to provide flexibility and meet users where they are without losing features when using gen1 platform is to leverage this instead.

**Special notes for your reviewer**:

On a not so random note: The `entrypoint.sh` script can also easily get overridden when people quickly try to scaffold an environment for an Airflow ldap integration tutorial 🤣 This may or may not have happened to me this morning. But it's mostly about the first thing!



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/test-airflow-image.py
