### PR TITLE
Remove slack approvals for checks for other branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,11 +68,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-1.10.5
           requires:
             - Slack_Notification-1.10.5
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-1.10.5-alpine3.10
@@ -304,11 +312,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-1.10.7
           requires:
             - Slack_Notification-1.10.7
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-1.10.7-alpine3.10
@@ -484,11 +500,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-1.10.10
           requires:
             - Slack_Notification-1.10.10
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-1.10.10-alpine3.10
@@ -664,11 +688,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-1.10.12
           requires:
             - Slack_Notification-1.10.12
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-1.10.12-alpine3.10
@@ -844,11 +876,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-1.10.14
           requires:
             - Slack_Notification-1.10.14
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-1.10.14-buster
@@ -968,11 +1008,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-1.10.15
           requires:
             - Slack_Notification-1.10.15
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-1.10.15-buster
@@ -1093,11 +1141,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-2.0.0
           requires:
             - Slack_Notification-2.0.0
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-2.0.0-buster
@@ -1217,11 +1273,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-2.0.1
           requires:
             - Slack_Notification-2.0.1
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 
       - build:
           name: build-2.0.1-buster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.5
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.5-alpine3.10-onbuild
           airflow_version: 1.10.5
@@ -145,6 +146,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.5
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.5-buster-onbuild
           airflow_version: 1.10.5
@@ -201,6 +203,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.5
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.5-rhel7-onbuild
           airflow_version: 1.10.5
@@ -333,6 +336,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.7
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.7-alpine3.10-onbuild
           airflow_version: 1.10.7
@@ -389,6 +393,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.7
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.7-buster-onbuild
           airflow_version: 1.10.7
@@ -521,6 +526,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.10
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.10-alpine3.10-onbuild
           airflow_version: 1.10.10
@@ -577,6 +583,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.10
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.10-buster-onbuild
           airflow_version: 1.10.10
@@ -709,6 +716,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.12
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.12-alpine3.10-onbuild
           airflow_version: 1.10.12
@@ -765,6 +773,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.12
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.12-buster-onbuild
           airflow_version: 1.10.12
@@ -897,6 +906,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-1.10.14
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.14-buster-onbuild
           airflow_version: 1.10.14
@@ -1030,6 +1040,7 @@ workflows:
           extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
           requires:
             - Need-Approval-1.10.15
+            - static-checks
       - scan-clair:
           name: scan-clair-1.10.15-buster-onbuild
           airflow_version: 1.10.15
@@ -1162,6 +1173,7 @@ workflows:
           dev_build: false
           requires:
             - Need-Approval-2.0.0
+            - static-checks
       - scan-clair:
           name: scan-clair-2.0.0-buster-onbuild
           airflow_version: 2.0.0
@@ -1295,6 +1307,7 @@ workflows:
           extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.1.build)"
           requires:
             - Need-Approval-2.0.1
+            - static-checks
       - scan-clair:
           name: scan-clair-2.0.1-buster-onbuild
           airflow_version: 2.0.1

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -93,6 +93,7 @@ workflows:
           {%- endif %}
           requires:
             - Need-Approval-{{ airflow_version }}
+            - static-checks
       - scan-clair:
           name: scan-clair-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -69,11 +69,19 @@ workflows:
               }
           requires:
             - static-checks
+          filters:
+            branches:
+              only:
+                - master
       - pause_workflow:
           name: Need-Approval-{{ airflow_version }}
           requires:
             - Slack_Notification-{{ airflow_version }}
           type: approval
+          filters:
+            branches:
+              only:
+                - master
 {% for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when a PR is created, the circleci job is triggered but slack approvals block running the complete build process. This is making the reviewer difficult to check the status. This PR will remove the slack approvals while checking the PRs from other branches. 
Now slack approvals will run only on master.
