### PR TITLE
Use constraints file for 1.10.15rc1

### DIFF
--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -116,7 +116,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1-10/constraints-3.7.txt" \
+RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.15rc1/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.2, >=1.2.2"
 


### PR DESCRIPTION
We used `constraints-1-10` because 1.10.15rc1 was not published. Now that it is published we should use that as it will eventually become 1.10.15

Details: https://lists.apache.org/thread.html/r42b4555ca106e289f473afb78cbcf119d49503b8a2384f7bbb8a6d71%40%3Cdev.airflow.apache.org%3E


https://raw.githubusercontent.com/apache/airflow/constraints-1.10.15rc1/constraints-3.6.txt