### PR TITLE
Release AC 1.10.15-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1036,8 +1036,7 @@ workflows:
           name: build-1.10.15-buster
           airflow_version: 1.10.15
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
+          dev_build: false
           requires:
             - Need-Approval-1.10.15
             - static-checks
@@ -1062,8 +1061,8 @@ workflows:
       - push:
           name: push-1.10.15-buster
           tag: "1.10.15-buster"
-          dev_build: true
-          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM},1.10.15-1.dev-buster"
+          dev_build: false
+          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM},1.10.15-1-buster"
           context:
             - quay.io
           requires:
@@ -1077,8 +1076,8 @@ workflows:
       - push:
           name: push-1.10.15-buster-onbuild
           tag: "1.10.15-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-1.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-1-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -1366,60 +1365,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          name: build-1.10.15-buster
-          airflow_version: 1.10.15
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
-      - scan-clair:
-          name: scan-clair-1.10.15-buster-onbuild
-          airflow_version: 1.10.15
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.15-buster
-      - scan-trivy:
-          name: scan-trivy-1.10.15-buster-onbuild
-          airflow_version: 1.10.15
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.15-buster
-      - test:
-          name: test-1.10.15-buster-images
-          tag: "1.10.15-buster"
-          requires:
-            - build-1.10.15-buster
-      - push:
-          name: push-1.10.15-buster
-          tag: "1.10.15-buster"
-          dev_build: true
-          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.15-buster-onbuild
-            - scan-trivy-1.10.15-buster-onbuild
-            - test-1.10.15-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-1.10.15-buster-onbuild
-          tag: "1.10.15-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-1.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-1.10.15-buster-onbuild
-            - scan-trivy-1.10.15-buster-onbuild
-            - test-1.10.15-buster-images
-          filters:
-            branches:
-              only:
-                - master
       - build:
           name: build-2.0.1-buster
           airflow_version: 2.0.1

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -16,7 +16,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.10-7", ["alpine3.10", "buster"]),
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
-    ("1.10.15-1.dev", ["buster"]),
+    ("1.10.15-1", ["buster"]),
     ("2.0.0-3", ["buster"]),
     ("2.0.1-1.dev", ["buster"]),
 ])

--- a/1.10.15/CHANGELOG.md
+++ b/1.10.15/CHANGELOG.md
@@ -1,21 +1,20 @@
 # Changelog
 
-Astronomer Certified 1.10.15-1.dev
------------------------------------------------
+Astronomer Certified 1.10.15-1, 2021-03-19
+------------------------------------------
 
-### Bug Fixes
+User-facing CHANGELOG for AC `1.10.15+astro.1` from Airflow `1.10.15`:
 
-- Fix-duplicate-Code ([commit](https://github.com/apache/airflow/00fff8d90bf0e8142f2d0a3dd794bf58e6cc557a))
-- BugFix-fix-the-delete_dag-function-of-json_client-14441 ([commit](https://github.com/apache/airflow/2ea5881e696ef7738d135067bf78e6012d4e4a99))
-- Fixed-deprecation-message-for-variables-command-14457 ([commit](https://github.com/apache/airflow/75b2fa22b75b9879bafe607b15f900b46c4828bc))
-- Add-airflow-variables-list-command-for-1.10.x-transition-version-14462 ([commit](https://github.com/apache/airflow/7a5f0e1cd1cb0651a8306580088626f4303f6ab9))
-Fix-permission-error-on-non-POSIX-filesystem-13121-14383 ([commit](https://github.com/apache/airflow/e8008f5f67f448c280935320471606d6a6a84a73))
-- Fix-airflow-tasks-clear-cli-command-wirh-yes-14188 ([commit](https://github.com/apache/airflow/3709503ecf180bd8c85190bcc7e5e755b60d9bfb))
-- Ensure-all-statsd-timers-use-millisecond-values.-10633 ([commit](https://github.com/apache/airflow/48daabce99476c218b6d0d1a5ed5c6941074497c))
-- StreamLogWriter-Provide-no-op-close-method-10885 ([commit](https://github.com/apache/airflow/07f6f30153a5c842e854043389e10faea290bd36))
-- KubernetesExecutor-should-accept-images-from-executor_config-13074 ([commit](https://github.com/apache/airflow/ee88f5f46ef32d2eb5e9be56e723de58b6736375))
-- Scheduler-should-acknowledge-active-runs-properly-13803 ([commit](https://github.com/apache/airflow/b4de6beb47d2de777e371bfb20321c3feedd6bbd))
-- Moved-boto3-limitation-to-snowflake-13286 ([commit](https://github.com/apache/airflow/022f9e2234e22ea556013bc7b6e5cb15d41cbf11))
-- Fix-airflow-db-upgrade-to-upgrade-db-as-intended-13267 ([commit](https://github.com/apache/airflow/a1f5b08dbd40d38fce066b13f8d6998bc4d185df))
-- Fix-broken-airflow-upgrade_check-command-14137 ([commit](https://github.com/apache/airflow/e76c7433c9a32c752ab9ed94f0dfe5cec5031758))
-- Include-airflow-contrib-executors-in-the-dist-package ([commit](https://github.com/apache/airflow/60ac8df046f34e23f9abba82516baf5d6314b880))
+## Bug Fixes
+
+- Fix `sync-perm` to work correctly when update_fab_perms = False ([commit](https://github.com/astronomer/airflow/commit/950028f93e1220d49629aea10dfbaf1173b8910b))
+- Pin SQLAlchemy to <1.4 due to breakage of sqlalchemy-utils ([commit](https://github.com/astronomer/airflow/commit/331f0d23260a77212e7b15707e04bee02bdab1f2))
+
+## Improvements
+
+- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/cd1961873783389ee51748f7f2a481900cce85b9))
+- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/a386fd542fe1c46bd3e345371eed10a9c230f690))
+- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/16461c3c8dcb1d1d2766844d32f3cdec31c89e69))
+
+## New Features
+- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/apache/airflow/commit/c037d48c9e383a6fd0b1b0d88407489d0ed02194))

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-1.*"
+ARG VERSION="1.10.15-1"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
@@ -119,7 +119,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.15rc1/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
+RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.2, >=1.2.2"
 
@@ -136,7 +136,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-1.*"
+ARG VERSION="1.10.15-1"
 ARG AIRFLOW_VERSION="1.10.15"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Tag: https://github.com/astronomer/airflow/releases/tag/v1.10.15%2Bastro.1

# Changelog

Astronomer Certified 1.10.15-1, 2021-03-19
------------------------------------------

User-facing CHANGELOG for AC `1.10.15+astro.1` from Airflow `1.10.15`:

## Bug Fixes

- Fix `sync-perm` to work correctly when update_fab_perms = False ([commit](https://github.com/astronomer/airflow/commit/950028f93e1220d49629aea10dfbaf1173b8910b))
- Pin SQLAlchemy to <1.4 due to breakage of sqlalchemy-utils ([commit](https://github.com/astronomer/airflow/commit/331f0d23260a77212e7b15707e04bee02bdab1f2))

## Improvements

- Enable DAG Serialization by default ([commit](https://github.com/apache/airflow/commit/cd1961873783389ee51748f7f2a481900cce85b9))
- Stop showing Import Errors for Plugins in Webserver ([commit](https://github.com/apache/airflow/commit/a386fd542fe1c46bd3e345371eed10a9c230f690))
- Add role-based authentication backend ([commit](https://github.com/apache/airflow/commit/16461c3c8dcb1d1d2766844d32f3cdec31c89e69))

## New Features
- Show "Warning" to Users with Duplicate Connections ([commit](https://github.com/apache/airflow/commit/c037d48c9e383a6fd0b1b0d88407489d0ed02194))

