### PR TITLE
Remove 2.0.1 changelog from README (broken link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ All changes applied to available point releases will be documented in the `CHANG
 - [1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)
 - [1.10.14 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md)
 - [2.0.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)
-- [2.0.1 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.1/CHANGELOG.md)
 
 ## Testing
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I believe we decided to no longer support AC 2.0.1 in this repo, but I still see a link to a now-deprecated 2.0.1 changelog that is now broken:

https://github.com/astronomer/ap-airflow/blob/master/2.0.1/CHANGELOG.md
