### PR TITLE
Ignore pollution vulnerability CVE-2020-7774 in trivyignore file

### DIFF
--- a/1.10.10/alpine3.10/trivyignore
+++ b/1.10.10/alpine3.10/trivyignore
@@ -21,3 +21,6 @@ CVE-2019-10747
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.10/buster/trivyignore
+++ b/1.10.10/buster/trivyignore
@@ -24,3 +24,6 @@ CVE-2020-25696
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.12/alpine3.10/trivyignore
+++ b/1.10.12/alpine3.10/trivyignore
@@ -21,3 +21,6 @@ CVE-2019-10747
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.12/buster/trivyignore
+++ b/1.10.12/buster/trivyignore
@@ -24,3 +24,6 @@ CVE-2020-25696
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.14/buster/trivyignore
+++ b/1.10.14/buster/trivyignore
@@ -24,3 +24,6 @@ CVE-2020-25696
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.15/buster/trivyignore
+++ b/1.10.15/buster/trivyignore
@@ -24,3 +24,6 @@ CVE-2020-25696
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.7/alpine3.10/trivyignore
+++ b/1.10.7/alpine3.10/trivyignore
@@ -33,3 +33,6 @@ CVE-2018-20834
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/1.10.7/buster/trivyignore
+++ b/1.10.7/buster/trivyignore
@@ -36,3 +36,6 @@ CVE-2020-25696
 
 # dev sub dependencies(#2708)
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/2.0.0/buster/trivyignore
+++ b/2.0.0/buster/trivyignore
@@ -12,3 +12,6 @@ CVE-2020-25696
 # dev sub dependencies(#2708)
 CVE-2021-28092
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774

--- a/2.0.2/buster/trivyignore
+++ b/2.0.2/buster/trivyignore
@@ -12,3 +12,6 @@ CVE-2020-25696
 # dev sub dependencies(#2708)
 CVE-2021-28092
 CVE-2021-27290
+
+#pollution vulnerability
+CVE-2020-7774


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignore pollution vulnerability CVE-2020-7774 in trivyignore file
Modified versions
2.0.2
2.0.0
1.10.15
1.10.14
1.10.12
1.10.10
1.10.7
