### PR TITLE
Bump Epoch to fix CVEs

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -129,7 +129,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -129,7 +129,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -129,7 +129,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -129,7 +129,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -140,7 +140,7 @@ RUN cd usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/w
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -131,7 +131,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -129,7 +129,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="6"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="7"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
This should take care of the following CVEs:

```
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |  FIXED VERSION   |                TITLE                 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
| curl     | CVE-2020-8169    | HIGH     | 7.64.0-4+deb10u1  | 7.64.0-4+deb10u2 | libcurl: partial password            |
|          |                  |          |                   |                  | leak over DNS on HTTP redirect       |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8169 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8177    |          |                   |                  | curl: Incorrect argument             |
|          |                  |          |                   |                  | check can allow remote servers       |
|          |                  |          |                   |                  | to overwrite local files...          |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8177 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8231    |          |                   |                  | curl: Expired pointer                |
|          |                  |          |                   |                  | dereference via multi API with       |
|          |                  |          |                   |                  | `CURLOPT_CONNECT_ONLY` option set    |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8231 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8285    |          |                   |                  | curl: malicious FTP server can       |
|          |                  |          |                   |                  | trigger stack overflow when          |
|          |                  |          |                   |                  | CURLOPT_CHUNK_BGN_FUNCTION           |
|          |                  |          |                   |                  | is used...                           |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8285 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8286    |          |                   |                  | curl: inferior OCSP verification     |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8286 |
+----------+------------------+          +                   +                  +--------------------------------------+
| libcurl4 | CVE-2020-8169    |          |                   |                  | libcurl: partial password            |
|          |                  |          |                   |                  | leak over DNS on HTTP redirect       |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8169 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8177    |          |                   |                  | curl: Incorrect argument             |
|          |                  |          |                   |                  | check can allow remote servers       |
|          |                  |          |                   |                  | to overwrite local files...          |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8177 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8231    |          |                   |                  | curl: Expired pointer                |
|          |                  |          |                   |                  | dereference via multi API with       |
|          |                  |          |                   |                  | `CURLOPT_CONNECT_ONLY` option set    |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8231 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8285    |          |                   |                  | curl: malicious FTP server can       |
|          |                  |          |                   |                  | trigger stack overflow when          |
|          |                  |          |                   |                  | CURLOPT_CHUNK_BGN_FUNCTION           |
|          |                  |          |                   |                  | is used...                           |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8285 |
+          +------------------+          +                   +                  +--------------------------------------+
|          | CVE-2020-8286    |          |                   |                  | curl: inferior OCSP verification     |
|          |                  |          |                   |                  | -->avd.aquasec.com/nvd/cve-2020-8286 |
+----------+------------------+----------+-------------------+------------------+--------------------------------------+
```

