### PR TITLE
Release AC 2.0.0-4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1112,8 +1112,7 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.0
             - static-checks
@@ -1138,8 +1137,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-4.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-4-buster"
           context:
             - quay.io
           requires:
@@ -1153,8 +1152,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-4.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-4-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -1309,60 +1308,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          name: build-2.0.0-buster
-          airflow_version: 2.0.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
-      - scan-clair:
-          name: scan-clair-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - scan-trivy:
-          name: scan-trivy-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - test:
-          name: test-2.0.0-buster-images
-          tag: "2.0.0-buster"
-          requires:
-            - build-2.0.0-buster
-      - push:
-          name: push-2.0.0-buster
-          tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-2.0.0-buster-onbuild
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.0-buster-onbuild
-          tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-4.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-clair-2.0.0-buster-onbuild
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
       - build:
           name: build-2.0.2-buster
           airflow_version: 2.0.2

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -17,7 +17,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
     ("1.10.15-1", ["buster"]),
-    ("2.0.0-4.dev", ["buster"]),
+    ("2.0.0-4", ["buster"]),
     ("2.0.2-1.dev", ["buster"]),
 ])
 

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+Astronomer Certified 2.0.0-4, 2021-04-13
+-----------------------------------------
+
+## Bugfixes
+
+- Change the default celery worker_concurrency to 16 ([commit](https://github.com/astronomer/airflow/commit/924ba1c4f))
+- Fix backfill crash on task retry or reschedule ([commit](https://github.com/astronomer/airflow/commit/a0407d2d9))
+- Disables provider's manager warning for source-installed prod image. ([commit](https://github.com/astronomer/airflow/commit/66078273f))
+- Setting `max_tis_per_query` to 0 now correctly removes the limit ([commit](https://github.com/astronomer/airflow/commit/1f96b4c0c))
+- Add __repr__ for Executors ([commit](https://github.com/astronomer/airflow/commit/779030136))
+- Fix SQL syntax to check duplicate connections ([commit](https://github.com/astronomer/airflow/commit/db0296264))
+- Fix `TaskNotFound` in log endpoint ([commit](https://github.com/astronomer/airflow/commit/fedf636dc))
+- Fix dag run type enum query for mysqldb driver ([commit](https://github.com/astronomer/airflow/commit/88221df57))
+- Bugfix: Don't try to create a duplicate Dag Run in Scheduler ([commit](https://github.com/astronomer/airflow/commit/f492f79e8))
+- Bugfix: Scheduler fails if task is removed at runtime ([commit](https://github.com/astronomer/airflow/commit/cfb562184))
+- Bugfix: Manual DagRun trigger should not skip scheduled runs ([commit](https://github.com/astronomer/airflow/commit/6eca58d94))
+- Unable to trigger backfill or manual jobs with Kubernetes executor. ([commit](https://github.com/astronomer/airflow/commit/217aa1c1b))
+- Bugfix: Fix overriding `pod_template_file` in KubernetesExecutor ([commit](https://github.com/astronomer/airflow/commit/6076fb5f7))
+- Pass queue to `BaseExecutor.execute_async` like in airflow 1.10 ([commit](https://github.com/astronomer/airflow/commit/e8d858569))
+- Scheduler: Remove TIs from starved pools from the critical path. ([commit](https://github.com/astronomer/airflow/commit/aa995b59a))
+- Remove extra/needless deprecation warnings from airflow.contrib module ([commit](https://github.com/astronomer/airflow/commit/1d87b16f2))
+- Fix support for long dag_id and task_id in KubernetesExecutor ([commit](https://github.com/astronomer/airflow/commit/4641f8e73))
+- Bugfix: resources in `executor_config` breaks Graph View in UI ([commit](https://github.com/astronomer/airflow/commit/a74efa2fd))
+- Fix invalid value error caused by long k8s pod name ([commit](https://github.com/astronomer/airflow/commit/b0276e5b2))
+- Fix `KubernetesExecutor` issue with deleted pending pods ([commit](https://github.com/astronomer/airflow/commit/44d305944))
+- Avoid scheduler/parser manager deadlock by using non-blocking IO ([commit](https://github.com/astronomer/airflow/commit/9746f5171))
+- Add different modes to sort dag files for parsing ([commit](https://github.com/astronomer/airflow/commit/66dc00c92))
+- Remove duplicate call to sync_metadata inside DagFileProcessorManager ([commit](https://github.com/astronomer/airflow/commit/19a21d218))
+- Bump Redoc to resolve vulnerability in sub-dependency ([commit](https://github.com/astronomer/airflow/commit/b00b845bb))
+- Bump dompurify from 2.0.12 to 2.2.6 in /airflow/www ([commit](https://github.com/astronomer/airflow/commit/66830abd7))
+- Scheduler should not fail when invalid executor_config is passed ([commit](https://github.com/astronomer/airflow/commit/bf5e385f3))
+- BugFix: Fix taskInstance API call fails if a task is removed from running DAG ([commit](https://github.com/astronomer/airflow/commit/5f416f4a1))
+- Fix crash when user clicks on  "Task Instance Details" caused by start_date being None ([commit](https://github.com/astronomer/airflow/commit/432fff9e4))
+- Gracefully handle missing start_date and end_date for DagRun ([commit](https://github.com/astronomer/airflow/commit/587123326))
+- Fix logging error with task error when JSON logging is enabled ([commit](https://github.com/astronomer/airflow/commit/8f2e99d52))
+- BugFix: TypeError in `monitor_pod` ([commit](https://github.com/astronomer/airflow/commit/b0e334bfb))
+- Bugfix: Plugins endpoint was unauthenticated ([commit](https://github.com/astronomer/airflow/commit/a87a20d5d))
+- Pin SQLAlchemy to <1.4 due to breakage of sqlalchemy-utils ([commit](https://github.com/astronomer/airflow/commit/ce2849ed0))
+- Disable row level locking for Mariadb and MySQL <8 ([commit](https://github.com/astronomer/airflow/commit/a1af062bc))
+- Compare string values, not if strings are the same object ([commit](https://github.com/astronomer/airflow/commit/c6e10c1b1))
+- Sort lists, sets and tuples in Serialized DAGs ([commit](https://github.com/astronomer/airflow/commit/e8f872849))
+- Simplify cleaning string passed to origin param (#14738) ([commit](https://github.com/astronomer/airflow/commit/3c61a3b81))
+- BugFix: Serialize `max_retry_delay` as a timedelta ([commit](https://github.com/astronomer/airflow/commit/c1136e05c))
+- Fix `sync-perm` to work correctly when update_fab_perms = False ([commit](https://github.com/astronomer/airflow/commit/471c95cee))
+- Webserver: Sanitize string passed to origin param ([commit](https://github.com/astronomer/airflow/commit/a5b18475a))
+- AC Docker: Fix CVEs for `curl`: CVE-2020-8169, CVE-2020-8177, CVE-2020-8231, CVE-2020-8285, CVE-2020-8286, CVE-2020-8169, CVE-2020-8177, CVE-2020-8285, CVE-2020-8286
+
 Astronomer Certified 2.0.0-3, 2021-02-16
 -----------------------------------------
 

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-4.*"
+ARG VERSION="2.0.0-4"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -144,7 +144,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-4.*"
+ARG VERSION="2.0.0-4"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Release/Tag: https://github.com/astronomer/airflow/releases/tag/v2.0.0%2Bastro.4

Astronomer Certified 2.0.0-4, 2021-04-13
-----------------------------------------

## Bugfixes

- Change the default celery worker_concurrency to 16 ([commit](https://github.com/astronomer/airflow/commit/924ba1c4f))
- Fix backfill crash on task retry or reschedule ([commit](https://github.com/astronomer/airflow/commit/a0407d2d9))
- Disables provider's manager warning for source-installed prod image. ([commit](https://github.com/astronomer/airflow/commit/66078273f))
- Setting `max_tis_per_query` to 0 now correctly removes the limit ([commit](https://github.com/astronomer/airflow/commit/1f96b4c0c))
- Add __repr__ for Executors ([commit](https://github.com/astronomer/airflow/commit/779030136))
- Fix SQL syntax to check duplicate connections ([commit](https://github.com/astronomer/airflow/commit/db0296264))
- Fix `TaskNotFound` in log endpoint ([commit](https://github.com/astronomer/airflow/commit/fedf636dc))
- Fix dag run type enum query for mysqldb driver ([commit](https://github.com/astronomer/airflow/commit/88221df57))
- Bugfix: Don't try to create a duplicate Dag Run in Scheduler ([commit](https://github.com/astronomer/airflow/commit/f492f79e8))
- Bugfix: Scheduler fails if task is removed at runtime ([commit](https://github.com/astronomer/airflow/commit/cfb562184))
- Bugfix: Manual DagRun trigger should not skip scheduled runs ([commit](https://github.com/astronomer/airflow/commit/6eca58d94))
- Unable to trigger backfill or manual jobs with Kubernetes executor. ([commit](https://github.com/astronomer/airflow/commit/217aa1c1b))
- Bugfix: Fix overriding `pod_template_file` in KubernetesExecutor ([commit](https://github.com/astronomer/airflow/commit/6076fb5f7))
- Pass queue to `BaseExecutor.execute_async` like in airflow 1.10 ([commit](https://github.com/astronomer/airflow/commit/e8d858569))
- Scheduler: Remove TIs from starved pools from the critical path. ([commit](https://github.com/astronomer/airflow/commit/aa995b59a))
- Remove extra/needless deprecation warnings from airflow.contrib module ([commit](https://github.com/astronomer/airflow/commit/1d87b16f2))
- Fix support for long dag_id and task_id in KubernetesExecutor ([commit](https://github.com/astronomer/airflow/commit/4641f8e73))
- Bugfix: resources in `executor_config` breaks Graph View in UI ([commit](https://github.com/astronomer/airflow/commit/a74efa2fd))
- Fix invalid value error caused by long k8s pod name ([commit](https://github.com/astronomer/airflow/commit/b0276e5b2))
- Fix `KubernetesExecutor` issue with deleted pending pods ([commit](https://github.com/astronomer/airflow/commit/44d305944))
- Avoid scheduler/parser manager deadlock by using non-blocking IO ([commit](https://github.com/astronomer/airflow/commit/9746f5171))
- Add different modes to sort dag files for parsing ([commit](https://github.com/astronomer/airflow/commit/66dc00c92))
- Remove duplicate call to sync_metadata inside DagFileProcessorManager ([commit](https://github.com/astronomer/airflow/commit/19a21d218))
- Bump Redoc to resolve vulnerability in sub-dependency ([commit](https://github.com/astronomer/airflow/commit/b00b845bb))
- Bump dompurify from 2.0.12 to 2.2.6 in /airflow/www ([commit](https://github.com/astronomer/airflow/commit/66830abd7))
- Scheduler should not fail when invalid executor_config is passed ([commit](https://github.com/astronomer/airflow/commit/bf5e385f3))
- BugFix: Fix taskInstance API call fails if a task is removed from running DAG ([commit](https://github.com/astronomer/airflow/commit/5f416f4a1))
- Fix crash when user clicks on  "Task Instance Details" caused by start_date being None ([commit](https://github.com/astronomer/airflow/commit/432fff9e4))
- Gracefully handle missing start_date and end_date for DagRun ([commit](https://github.com/astronomer/airflow/commit/587123326))
- Fix logging error with task error when JSON logging is enabled ([commit](https://github.com/astronomer/airflow/commit/8f2e99d52))
- BugFix: TypeError in `monitor_pod` ([commit](https://github.com/astronomer/airflow/commit/b0e334bfb))
- Bugfix: Plugins endpoint was unauthenticated ([commit](https://github.com/astronomer/airflow/commit/a87a20d5d))
- Pin SQLAlchemy to <1.4 due to breakage of sqlalchemy-utils ([commit](https://github.com/astronomer/airflow/commit/ce2849ed0))
- Disable row level locking for Mariadb and MySQL <8 ([commit](https://github.com/astronomer/airflow/commit/a1af062bc))
- Compare string values, not if strings are the same object ([commit](https://github.com/astronomer/airflow/commit/c6e10c1b1))
- Sort lists, sets and tuples in Serialized DAGs ([commit](https://github.com/astronomer/airflow/commit/e8f872849))
- Simplify cleaning string passed to origin param (#14738) ([commit](https://github.com/astronomer/airflow/commit/3c61a3b81))
- BugFix: Serialize `max_retry_delay` as a timedelta ([commit](https://github.com/astronomer/airflow/commit/c1136e05c))
- Fix `sync-perm` to work correctly when update_fab_perms = False ([commit](https://github.com/astronomer/airflow/commit/471c95cee))
- Webserver: Sanitize string passed to origin param ([commit](https://github.com/astronomer/airflow/commit/a5b18475a))
- AC Docker: Fix CVEs for `curl`: CVE-2020-8169, CVE-2020-8177, CVE-2020-8231, CVE-2020-8285, CVE-2020-8286, CVE-2020-8169, CVE-2020-8177, CVE-2020-8285, CVE-2020-8286