### PR TITLE
Fix the builds for 1.10.5

### DIFF
--- a/1.10.5/alpine3.10/Dockerfile
+++ b/1.10.5/alpine3.10/Dockerfile
@@ -66,6 +66,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 		linux-headers \
 		nodejs \
 		nodejs-npm \
+		openssl-dev \
 		python3-dev \
 		tzdata \
 	&& apk add --no-cache \
@@ -102,7 +103,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& cd /usr/lib/python3.7/site-packages/airflow/www_rbac \
 	&& npm install \
 	&& npm run build \
-	&& rm -rf node_modules \
+	&& rm -rf node_modules package.json yarn.lock package-lock.json \
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \

--- a/1.10.5/alpine3.10/include/pip-constraints.txt
+++ b/1.10.5/alpine3.10/include/pip-constraints.txt
@@ -28,3 +28,9 @@ pyOpenSSL<20.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# Compat fix for other SQLA versions
+flask-admin~=1.5.7
+
+# Older versions of Airflow don't work with 1.4
+SQLAlchemy~=1.3

--- a/1.10.5/buster/Dockerfile
+++ b/1.10.5/buster/Dockerfile
@@ -128,7 +128,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 RUN cd usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/www_rbac \
   && npm install \
   && npm run prod \
-  && rm -rf node_modules
+  && rm -rf node_modules package.json yarn.lock package-lock.json
 
 
 ################################

--- a/1.10.5/buster/include/pip-constraints.txt
+++ b/1.10.5/buster/include/pip-constraints.txt
@@ -15,3 +15,9 @@ azure-storage<0.37.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# Compat fix for other SQLA versions
+flask-admin~=1.5.7
+
+# Older versions of Airflow don't work with 1.4
+SQLAlchemy~=1.3


### PR DESCRIPTION
The version of flask-admin didn't even _load_ -- meaning migrations wouldn't run.

The removal of packages.lock etc is to avoid false-positives of
vulnerabilities that only apply at build-time, not run time

(We may not release another 1.10.5 image, but we should be _able_ to.)