### PR TITLE
CVE-2021-20305 is a minor/low risk for use

### DIFF
--- a/cve-allowlist.yaml
+++ b/cve-allowlist.yaml
@@ -35,3 +35,6 @@ generalwhitelist:
 
   # This affects only the server.Look at #2738
   CVE-2021-27928: mariadb-10.3
+
+  # Debian triaged as "minor" issue https://security-tracker.debian.org/tracker/CVE-2021-20305
+  CVE-2021-20305: nettle


### PR DESCRIPTION
nettle is a low-level crypto library mostly used by apt (via gnutls) --
however openssl is much more widely used by libraries in Airflow so I
agree with this low risk triage.