### PR TITLE
Adding Celery `operation_timeout` to prevent task publishing timeout on >=2.0.0

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -265,6 +265,11 @@ def test_airflow_configs(scheduler, docker_client):
             "grep '^auth_backend' | awk '{print $3}'"
         ) == "astronomer.flask_appbuilder.current_user_backend", \
             "[api] auth_backend needs to be set to 'astronomer.flask_appbuilder.current_user_backend' for Platform"
+
+        assert scheduler.check_output(
+            f"cat {config_file_path} | "
+            "grep '^operation_timeout' | awk '{print $3}'"
+        ) == "10.0", "[celery] operation_timeout needs to be set for AC >= 2.0.0"
     else:
         # Confirm that run_as_user is the UID for astro user (and not root) for AC images
         assert scheduler.check_output(
@@ -276,7 +281,6 @@ def test_airflow_configs(scheduler, docker_client):
             f"cat {config_file_path} | "
             "grep '^update_fab_perms' | awk '{print $3}'"
         ) == "False", "[webserver] update_fab_perms needs to be False for AC >= 1.10.10"
-
 
 def test_labels_for_onbuild_image(docker_client):
     """ Ensure correct labels exists on onbuild image """

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -166,6 +166,8 @@ RUN sed -i \
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
+    # The number of seconds to wait before timing out send_task_to_executor or fetch_celery_task_state operations.
+    -e 's/^operation_timeout =.*/operation_timeout = 10.0/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -158,6 +158,8 @@ RUN sed -i \
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
+    # The number of seconds to wait before timing out send_task_to_executor or fetch_celery_task_state operations.
+    -e 's/^operation_timeout =.*/operation_timeout = 10.0/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Create logs directory, so we can own it when we mount volumes


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently some of the tasks are failing because of concurrent tasks. Adding this environment variable reduced the task time out failures
https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#operation-timeout