### PR TITLE
Release AC 2.0.0-5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1032,8 +1032,7 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.0
             - static-checks
@@ -1052,8 +1051,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-5.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-5-buster"
           context:
             - quay.io
           requires:
@@ -1066,8 +1065,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-5.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-5-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -1213,52 +1212,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          name: build-2.0.0-buster
-          airflow_version: 2.0.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - test:
-          name: test-2.0.0-buster-images
-          tag: "2.0.0-buster"
-          requires:
-            - build-2.0.0-buster
-      - push:
-          name: push-2.0.0-buster
-          tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.0-buster-onbuild
-          tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-5.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
       - build:
           name: build-2.0.2-buster
           airflow_version: 2.0.2

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -17,7 +17,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
     ("1.10.15-1", ["buster"]),
-    ("2.0.0-5.dev", ["buster"]),
+    ("2.0.0-5", ["buster"]),
     ("2.0.2-1.dev", ["buster"]),
 ])
 

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+Astronomer Certified 2.0.0-5, 2021-04-26
+-----------------------------------------
+
+User-facing CHANGELOG for AC 2.0.0+astro.5 from AC 2.0.0+astro.4:
+
+## Bugfixes
+
+- Bugfix: `TypeError` when Serializing & sorting iterables (#15395) ([commit](https://github.com/astronomer/airflow/commit/14f18b3fd))
+- Add Traceback in LogRecord in `JSONFormatter` (#15414) ([commit](https://github.com/astronomer/airflow/commit/7787ede4d))
+- Fix Task adoption in Kubernetes Executor ([commit](https://github.com/astronomer/airflow/commit/b7b73ac12))
+- Further fix trimmed `pod_id` for `KubernetesPodOperator` (#15445) ([commit](https://github.com/astronomer/airflow/commit/4fef61621))
+- Bugfix: Invalid name when trimmed `pod_id` ends with hyphen in `KubernetesPodOperator` (#15443) ([commit](https://github.com/astronomer/airflow/commit/07a191f90))
+- Fix to ensure 100vh min plays nicely w/ Linux+Chrome (#13857) ([commit](https://github.com/astronomer/airflow/commit/540eda273))
+- Fix `used_group_ids` in partial_subset (#13700) (#15308) ([commit](https://github.com/astronomer/airflow/commit/c68ea977f))
+- Fix password masking in CLI `action_logging` (#15143) ([commit](https://github.com/astronomer/airflow/commit/477de9407))
+- Change default of `[kubernetes] enable_tcp_keepalive` to `True` (#15338) ([commit](https://github.com/astronomer/airflow/commit/4c3803aaf))
+- Adds missing LDAP "extra" dependencies to ldap provider. (apache#13308) ([commit](https://github.com/astronomer/airflow/commit/674bd98))
+- Add missing Azure Storage libraries ([commit](https://github.com/astronomer/airflow/commit/206c6a6))
+
 Astronomer Certified 2.0.0-4, 2021-04-13
 -----------------------------------------
 

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-5.*"
+ARG VERSION="2.0.0-5"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -144,7 +144,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-5.*"
+ARG VERSION="2.0.0-5"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Astronomer Certified 2.0.0-5, 2021-04-26
-----------------------------------------

## Bugfixes

- Bugfix: `TypeError` when Serializing & sorting iterables (#15395) ([commit](https://github.com/astronomer/airflow/commit/14f18b3fd))
- Add Traceback in LogRecord in `JSONFormatter` (#15414) ([commit](https://github.com/astronomer/airflow/commit/7787ede4d))
- Fix Task adoption in Kubernetes Executor ([commit](https://github.com/astronomer/airflow/commit/b7b73ac12))
- Further fix trimmed `pod_id` for `KubernetesPodOperator` (#15445) ([commit](https://github.com/astronomer/airflow/commit/4fef61621))
- Bugfix: Invalid name when trimmed `pod_id` ends with hyphen in `KubernetesPodOperator` (#15443) ([commit](https://github.com/astronomer/airflow/commit/07a191f90))
- Fix to ensure 100vh min plays nicely w/ Linux+Chrome (#13857) ([commit](https://github.com/astronomer/airflow/commit/540eda273))
- Fix `used_group_ids` in partial_subset (#13700) (#15308) ([commit](https://github.com/astronomer/airflow/commit/c68ea977f))
- Fix password masking in CLI `action_logging` (#15143) ([commit](https://github.com/astronomer/airflow/commit/477de9407))
- Change default of `[kubernetes] enable_tcp_keepalive` to `True` (#15338) ([commit](https://github.com/astronomer/airflow/commit/4c3803aaf))
- Add missing Azure Storage libraries ([commit](https://github.com/astronomer/airflow/commit/206c6a6))

