### PR TITLE
Release AC 2.0.2-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -983,8 +983,7 @@ workflows:
           name: build-2.0.2-buster
           airflow_version: 2.0.2
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.2
             - static-checks
@@ -1003,8 +1002,8 @@ workflows:
       - push:
           name: push-2.0.2-buster
           tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-1.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-1-buster"
           context:
             - quay.io
           requires:
@@ -1017,8 +1016,8 @@ workflows:
       - push:
           name: push-2.0.2-buster-onbuild
           tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-1.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-1-buster-onbuild"
           context:
             - quay.io
           requires:
@@ -1029,62 +1028,6 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          name: build-2.0.2-buster
-          airflow_version: 2.0.2
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.2-buster-onbuild
-          airflow_version: 2.0.2
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.2-buster
-      - test:
-          name: test-2.0.2-buster-images
-          tag: "2.0.2-buster"
-          requires:
-            - build-2.0.2-buster
-      - push:
-          name: push-2.0.2-buster
-          tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.2-buster-onbuild
-          tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-1.dev-buster-onbuild"
-          context:
-            - quay.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
-
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -17,7 +17,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.14-3", ["buster"]),
     ("1.10.15-1", ["buster"]),
     ("2.0.0-5", ["buster"]),
-    ("2.0.2-1.dev", ["buster"]),
+    ("2.0.2-1", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.0.2/CHANGELOG.md
+++ b/2.0.2/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
-Astronomer Certified 2.0.2-1.dev, TBD
--------------------------------------
+Astronomer Certified 2.0.2-1, 2021-04-26
+----------------------------------------
 
-No User-facing CHANGELOG for AC 2.0.2+astro.1 from Airflow 2.0.2:
+User-facing CHANGELOG for AC 2.0.2+astro.1 from Airflow 2.0.2:
+
+### Bugfixes
+
+- Fix critical CeleryKubernetesExecutor bug (#13247) ([commit](https://github.com/astronomer/airflow/commit/02f780295))
+- Fix deprecated provider aliases (#15465) ([commit](https://github.com/astronomer/airflow/commit/b3664d9a0))
+- Further fix trimmed `pod_id` for `KubernetesPodOperator` (#15445) ([commit](https://github.com/astronomer/airflow/commit/085bfc3f9))
+- Bugfix: Invalid name when trimmed `pod_id` ends with hyphen in ``KubernetesPodOperator`` (#15443) ([commit](https://github.com/astronomer/airflow/commit/cdfe3b0b6))
+- Fix `sync-perm` to work correctly when update_fab_perms = False (#14847) ([commit](https://github.com/astronomer/airflow/commit/06c3630ad))
+- [astro] Continually check if we should shut down istio contaner when running K8sPodOperator ([commit](https://github.com/astronomer/airflow/commit/ff080c3fd))
+- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/baeb8367e))
+- [astro] Fix logs downloading for tasks (#63) ([commit](https://github.com/astronomer/airflow/commit/e31d293da))
+- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/aa876183e))
+
+### Improvements
+
+- Skip DAG perm sync during parsing if possible (#15464) ([commit](https://github.com/astronomer/airflow/commit/ab297b731))
+- Sync DAG specific permissions when parsing (#15311) ([commit](https://github.com/astronomer/airflow/commit/4bedb7b1f))
+- Finish refactor of DAG resource name helper (#15511) ([commit](https://github.com/astronomer/airflow/commit/fd86869a8))
+- Elasticsearch: Add Traceback in LogRecord in ``JSONFormatter`` (#15414) ([commit](https://github.com/astronomer/airflow/commit/9a913fe97))
+
+### New Features
+
+- Add different modes to sort dag files for parsing (#15046) ([commit](https://github.com/astronomer/airflow/commit/60c71b7cd))

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-1.*"
+ARG VERSION="2.0.2-1"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.2"
@@ -136,7 +136,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-1.*"
+ARG VERSION="2.0.2-1"
 ARG AIRFLOW_VERSION="2.0.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All changes applied to available point releases will be documented in the `CHANG
 - [1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)
 - [1.10.14 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md)
 - [2.0.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)
+- [2.0.2 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)
 
 ## Testing
 


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v2.0.2%2Bastro.1

Astronomer Certified 2.0.2-1, 2021-04-26
----------------------------------------

User-facing CHANGELOG for AC 2.0.2+astro.1 from Airflow 2.0.2:

### Bugfixes

- Fix critical CeleryKubernetesExecutor bug (#13247) ([commit](https://github.com/astronomer/airflow/commit/02f780295))
- Fix deprecated provider aliases (#15465) ([commit](https://github.com/astronomer/airflow/commit/b3664d9a0))
- Further fix trimmed `pod_id` for `KubernetesPodOperator` (#15445) ([commit](https://github.com/astronomer/airflow/commit/085bfc3f9))
- Bugfix: Invalid name when trimmed `pod_id` ends with hyphen in ``KubernetesPodOperator`` (#15443) ([commit](https://github.com/astronomer/airflow/commit/cdfe3b0b6))
- Fix `sync-perm` to work correctly when update_fab_perms = False (#14847) ([commit](https://github.com/astronomer/airflow/commit/06c3630ad))
- [astro] Continually check if we should shut down istio contaner when running K8sPodOperator ([commit](https://github.com/astronomer/airflow/commit/ff080c3fd))
- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/baeb8367e))
- [astro] Fix logs downloading for tasks (#63) ([commit](https://github.com/astronomer/airflow/commit/e31d293da))
- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/aa876183e))

### Improvements

- Skip DAG perm sync during parsing if possible (#15464) ([commit](https://github.com/astronomer/airflow/commit/ab297b731))
- Sync DAG specific permissions when parsing (#15311) ([commit](https://github.com/astronomer/airflow/commit/4bedb7b1f))
- Finish refactor of DAG resource name helper (#15511) ([commit](https://github.com/astronomer/airflow/commit/fd86869a8))
- Elasticsearch: Add Traceback in LogRecord in ``JSONFormatter`` (#15414) ([commit](https://github.com/astronomer/airflow/commit/9a913fe97))

### New Features

- Add different modes to sort dag files for parsing (#15046) ([commit](https://github.com/astronomer/airflow/commit/60c71b7cd))