### PR TITLE
Add test for Postfix Version

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -71,6 +71,16 @@ def test_version(webserver, docker_client):
     ac_version = get_label(docker_client, 'io.astronomer.docker.ac.version')
     assert airflow_ver in ac_version
 
+    ac_version_output = webserver.check_output("pip show apache-airflow | grep Version | sed -e  's|Version: ||'")
+    assert ac_version_output
+    assert "+astro." in ac_version_output
+    ac_version_postfix_output = ac_version_output.rsplit('+astro.')[-1]
+
+    # Example: 1.10.10-8 will give '8'
+    post_fix_version_astro = ac_version.rsplit('-')[-1]
+    assert post_fix_version_astro == ac_version_postfix_output, \
+        f"Incorrect post-fix version in {ac_version_output}"
+
 
 def test_elasticsearch_version(webserver):
     """ Astronomer runs a version of ElasticSearch that requires

--- a/1.10.10/alpine3.10/build-time-pip-constraints.txt
+++ b/1.10.10/alpine3.10/build-time-pip-constraints.txt
@@ -5,7 +5,6 @@ alembic==1.4.3
 amqp==2.6.1
 analytics-python==1.2.9
 ansiwrap==0.8.4
-apache-airflow==1!1.10.10+astro.7
 apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.12.2
@@ -13,7 +12,6 @@ asn1crypto==0.24.0
 astroid==2.4.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-certified==1.10.10.post7
 astronomer-fab-security-manager==1.5.0
 async-generator==1.10
 async-timeout==3.0.1

--- a/1.10.10/buster/build-time-pip-constraints.txt
+++ b/1.10.10/buster/build-time-pip-constraints.txt
@@ -1,12 +1,10 @@
 alembic==1.4.3
 amqp==2.6.1
-apache-airflow==1!1.10.10+astro.7
 apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.12.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-certified==1.10.10.post7
 astronomer-fab-security-manager==1.5.0
 attrs==19.3.0
 azure-common==1.1.26

--- a/1.10.7/alpine3.10/build-time-pip-constraints.txt
+++ b/1.10.7/alpine3.10/build-time-pip-constraints.txt
@@ -5,7 +5,6 @@ alembic==1.4.3
 amqp==2.6.1
 analytics-python==1.2.9
 ansiwrap==0.8.4
-apache-airflow==1!1.10.7+astro.17
 apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.12.2
@@ -13,7 +12,6 @@ asn1crypto==0.24.0
 astroid==2.4.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-certified==1.10.7.post17
 astronomer-fab-security-manager==1.5.0
 async-generator==1.10
 async-timeout==3.0.1

--- a/1.10.7/buster/build-time-pip-constraints.txt
+++ b/1.10.7/buster/build-time-pip-constraints.txt
@@ -1,12 +1,10 @@
 alembic==1.4.3
 amqp==2.6.1
-apache-airflow==1!1.10.7+astro.17
 apispec==1.3.3
 appdirs==1.4.4
 argcomplete==1.12.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-certified==1.10.7.post17
 astronomer-fab-security-manager==1.5.0
 attrs==19.3.0
 azure-common==1.1.26


### PR DESCRIPTION
This commit adds tests for Postfix Version to avoid situation like https://github.com/astronomer/ap-airflow/pull/251 where I added apache-airflow and astronomer-certified version in constraints, hence instead of installing newer version it installed old version and it went by undetected.

I have fixed that issue by manually building and pushing those images.
