### PR TITLE
Add 2.0.2-2.dev

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -76,8 +76,13 @@ def test_version(webserver, docker_client):
     assert "+astro." in ac_version_output
     ac_version_postfix_output = ac_version_output.rsplit('+astro.')[-1]
 
-    # Example: 1.10.10-8 will give '8'
-    post_fix_version_astro = ac_version.rsplit('-')[-1]
+    # Example: 2.0.2.post2.dev2
+    if "dev" in ac_version:
+        ac_version = ac_version.rsplit('.dev')[0]
+        post_fix_version_astro = ac_version.rsplit('.post')[-1]
+    else:
+        # Example: 1.10.10-8 will give '8'
+        post_fix_version_astro = ac_version.rsplit('-')[-1]
     assert post_fix_version_astro == ac_version_postfix_output, \
         f"Incorrect post-fix version in {ac_version_output}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1001,7 +1001,8 @@ workflows:
           name: build-2.0.2-buster
           airflow_version: 2.0.2
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
           requires:
             - Need-Approval-2.0.2
             - static-checks
@@ -1020,8 +1021,8 @@ workflows:
       - push:
           name: push-2.0.2-buster
           tag: "2.0.2-buster"
-          dev_build: false
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-1-buster"
+          dev_build: true
+          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster"
           context:
             - quay.io
             - docker.io
@@ -1035,8 +1036,8 @@ workflows:
       - push:
           name: push-2.0.2-buster-onbuild
           tag: "2.0.2-buster-onbuild"
-          dev_build: false
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-1-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1048,6 +1049,62 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          name: build-2.0.2-buster
+          airflow_version: 2.0.2
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
+      - scan-trivy:
+          name: scan-trivy-2.0.2-buster-onbuild
+          airflow_version: 2.0.2
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-2.0.2-buster
+      - test:
+          name: test-2.0.2-buster-images
+          tag: "2.0.2-buster"
+          requires:
+            - build-2.0.2-buster
+      - push:
+          name: push-2.0.2-buster
+          tag: "2.0.2-buster"
+          dev_build: true
+          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+          requires:
+            - scan-trivy-2.0.2-buster-onbuild
+            - test-2.0.2-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-2.0.2-buster-onbuild
+          tag: "2.0.2-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster-onbuild"
+          context:
+            - quay.io
+          requires:
+            - scan-trivy-2.0.2-buster-onbuild
+            - test-2.0.2-buster-images
+          filters:
+            branches:
+              only:
+                - master
+
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -17,7 +17,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.14-3", ["buster"]),
     ("1.10.15-1", ["buster"]),
     ("2.0.0-5", ["buster"]),
-    ("2.0.2-1", ["buster"]),
+    ("2.0.2-2.dev", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-1"
+ARG VERSION="2.0.2-2.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.2"
@@ -136,7 +136,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-1"
+ARG VERSION="2.0.2-2.*"
 ARG AIRFLOW_VERSION="2.0.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
This commit adds 2.0.2-2.dev image from https://github.com/astronomer/airflow/commits/v2-0-2 so that we can publish daily DEV images 

