### PR TITLE
Added missing docker context in the nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1097,6 +1097,7 @@ workflows:
           extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster-onbuild"
           context:
             - quay.io
+            - docker.io
           requires:
             - scan-trivy-2.0.2-buster-onbuild
             - test-2.0.2-buster-images

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -192,6 +192,7 @@ workflows:
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
           context:
             - quay.io
+            - docker.io
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of security issues all the environment variables using passwords have been moved to contexts instead of environment variables. Made change to use docker context.

