### PR TITLE
Add 2.0.0-6.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -874,7 +874,8 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
           requires:
             - Need-Approval-2.0.0
             - static-checks
@@ -893,8 +894,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: false
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-5-buster"
+          dev_build: true
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-6.dev-buster"
           context:
             - quay.io
             - docker.io
@@ -908,8 +909,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: false
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-5-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-6.dev-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1186,6 +1187,54 @@ workflows:
               only:
                 - master
     jobs:
+      - build:
+          name: build-2.0.0-buster
+          airflow_version: 2.0.0
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+      - scan-trivy:
+          name: scan-trivy-2.0.0-buster-onbuild
+          airflow_version: 2.0.0
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-2.0.0-buster
+      - test:
+          name: test-2.0.0-buster-images
+          tag: "2.0.0-buster"
+          requires:
+            - build-2.0.0-buster
+      - push:
+          name: push-2.0.0-buster
+          tag: "2.0.0-buster"
+          dev_build: true
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - scan-trivy-2.0.0-buster-onbuild
+            - test-2.0.0-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-2.0.0-buster-onbuild
+          tag: "2.0.0-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-6.dev-buster-onbuild"
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - scan-trivy-2.0.0-buster-onbuild
+            - test-2.0.0-buster-images
+          filters:
+            branches:
+              only:
+                - master
       - build:
           name: build-2.0.2-buster
           airflow_version: 2.0.2

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -16,7 +16,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
     ("1.10.15-1", ["buster"]),
-    ("2.0.0-5", ["buster"]),
+    ("2.0.0-6.dev", ["buster"]),
     ("2.0.2-2.dev", ["buster"]),
     ("2.1.0-1.dev", ["buster"]),
 ])

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+Astronomer Certified 2.0.0-6, TBC
+-----------------------------------------
+
+## Bugfixes
+
+- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/1beedfa06))
+- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/e07b1d156))
+
 Astronomer Certified 2.0.0-5, 2021-04-26
 -----------------------------------------
 

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-5"
+ARG VERSION="2.0.0-6.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -144,7 +144,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-5"
+ARG VERSION="2.0.0-6.*"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.0.2/CHANGELOG.md
+++ b/2.0.2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+Astronomer Certified 2.0.2-2, TBC
+----------------------------------------
+
+- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/aa90ba95d))
+- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/76e3cc206))
+
 Astronomer Certified 2.0.2-1, 2021-04-26
 ----------------------------------------
 


### PR DESCRIPTION
This commit adds 2.0.0-6.dev image from
https://github.com/astronomer/airflow/commits/v2-0-0

## Bugfixes

- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/1beedfa06))
- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/e07b1d156))
