### PR TITLE
Release AC 2.0.2-2 & 2.0.0-6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -874,8 +874,7 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.0
             - static-checks
@@ -894,8 +893,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-6.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-6-buster"
           context:
             - quay.io
             - docker.io
@@ -909,8 +908,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-6.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-6-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1002,8 +1001,7 @@ workflows:
           name: build-2.0.2-buster
           airflow_version: 2.0.2
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.2
             - static-checks
@@ -1022,8 +1020,8 @@ workflows:
       - push:
           name: push-2.0.2-buster
           tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-2-buster"
           context:
             - quay.io
             - docker.io
@@ -1037,8 +1035,8 @@ workflows:
       - push:
           name: push-2.0.2-buster-onbuild
           tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-2-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1187,102 +1185,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          name: build-2.0.0-buster
-          airflow_version: 2.0.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - test:
-          name: test-2.0.0-buster-images
-          tag: "2.0.0-buster"
-          requires:
-            - build-2.0.0-buster
-      - push:
-          name: push-2.0.0-buster
-          tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.0-buster-onbuild
-          tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-6.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.0.2-buster
-          airflow_version: 2.0.2
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.2-buster-onbuild
-          airflow_version: 2.0.2
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.2-buster
-      - test:
-          name: test-2.0.2-buster-images
-          tag: "2.0.2-buster"
-          requires:
-            - build-2.0.2-buster
-      - push:
-          name: push-2.0.2-buster
-          tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.2-buster-onbuild
-          tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-2.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
       - build:
           name: build-2.1.0-buster
           airflow_version: 2.1.0

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -16,8 +16,8 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
     ("1.10.15-1", ["buster"]),
-    ("2.0.0-6.dev", ["buster"]),
-    ("2.0.2-2.dev", ["buster"]),
+    ("2.0.0-6", ["buster"]),
+    ("2.0.2-2", ["buster"]),
     ("2.1.0-1.dev", ["buster"]),
 ])
 

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-Astronomer Certified 2.0.0-6, TBC
+Astronomer Certified 2.0.0-6, 2021-05-12
 -----------------------------------------
 
 ## Bugfixes
 
-- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/1beedfa06))
-- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/e07b1d156))
+- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/2f88ffc41))
+- Bump stylelint to remove vulnerable sub-dependency (#15784) ([commit](https://github.com/astronomer/airflow/commit/c21820064))
+- Add resolution to force dependencies to use patched version of `lodash` (#15777) ([commit](https://github.com/astronomer/airflow/commit/3c48c0084))
+- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/15be415e5))
 
 Astronomer Certified 2.0.0-5, 2021-04-26
 -----------------------------------------

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-6.*"
+ARG VERSION="2.0.0-6"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -144,7 +144,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-6.*"
+ARG VERSION="2.0.0-6"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.0.2/CHANGELOG.md
+++ b/2.0.2/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-Astronomer Certified 2.0.2-2, TBC
+Astronomer Certified 2.0.2-2, 2021-05-12
 ----------------------------------------
 
-- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/aa90ba95d))
-- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/76e3cc206))
+- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/7378d458d))
+- Bump stylelint to remove vulnerable sub-dependency (#15784) ([commit](https://github.com/astronomer/airflow/commit/838ace342))
+- Add resolution to force dependencies to use patched version of lodash (#15777) ([commit](https://github.com/astronomer/airflow/commit/05757577f))
+- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/25cd6b6ed))
+- Docker: Bump `apache-airflow-providers-cncf-kubernetes` to `1.2.0`
+- Docker: Bump `apache-airflow-providers-elasticsearch` to `1.0.4`
 
 Astronomer Certified 2.0.2-1, 2021-04-26
 ----------------------------------------

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-2.*"
+ARG VERSION="2.0.2-2"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.2"
@@ -118,8 +118,16 @@ ARG AIRFLOW_VERSION="2.0.2"
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# This constraints will be only used during docker-build
+# and won't be included in the final image
+# It is useful to install airflow-providers that work but still allow users to
+# install providers of their choice (as opposed to entries in astronomer-pip-constraints.txt)
+COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
+
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2-0/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
+RUN pip install "${AIRFLOW_MODULE}" \
+    --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
+    --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.5"
 
@@ -136,7 +144,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-2.*"
+ARG VERSION="2.0.2-2"
 ARG AIRFLOW_VERSION="2.0.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.0.2/buster/build-time-pip-constraints.txt
+++ b/2.0.2/buster/build-time-pip-constraints.txt
@@ -1,0 +1,17 @@
+# Constraint the version pip will install during docker build
+
+apache-airflow-providers-amazon==1.3.0
+apache-airflow-providers-celery==1.0.1
+apache-airflow-providers-cncf-kubernetes==1.2.0
+apache-airflow-providers-elasticsearch==1.0.4
+apache-airflow-providers-ftp==1.0.1
+apache-airflow-providers-google==2.2.0
+apache-airflow-providers-http==1.1.1
+apache-airflow-providers-imap==1.0.1
+apache-airflow-providers-microsoft-azure==1.3.0
+apache-airflow-providers-mysql==1.1.0
+apache-airflow-providers-postgres==1.0.1
+apache-airflow-providers-redis==1.0.1
+apache-airflow-providers-slack==3.0.0
+apache-airflow-providers-sqlite==1.0.2
+apache-airflow-providers-ssh==1.3.0


### PR DESCRIPTION
Astronomer Certified 2.0.2-2, 2021-05-12
----------------------------------------
### Bugfixes
- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/7378d458d))
- Bump stylelint to remove vulnerable sub-dependency (#15784) ([commit](https://github.com/astronomer/airflow/commit/838ace342))
- Add resolution to force dependencies to use patched version of lodash (#15777) ([commit](https://github.com/astronomer/airflow/commit/05757577f))
- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/25cd6b6ed))
- Docker: Bump `apache-airflow-providers-cncf-kubernetes` to `1.2.0`
- Docker: Bump `apache-airflow-providers-elasticsearch` to `1.0.4`

Astronomer Certified 2.0.0-6, 2021-05-12
-----------------------------------------

### Bugfixes

- Mask passwords and sensitive info in task logs and UI (#15599) ([commit](https://github.com/astronomer/airflow/commit/2f88ffc41))
- Bump stylelint to remove vulnerable sub-dependency (#15784) ([commit](https://github.com/astronomer/airflow/commit/c21820064))
- Add resolution to force dependencies to use patched version of `lodash` (#15777) ([commit](https://github.com/astronomer/airflow/commit/3c48c0084))
- Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/15be415e5))


