### PR TITLE
Use `apache-airflow-providers-elasticsearch==1.0.4` for AC 2.0.0

### DIFF
--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -9,6 +9,7 @@ Astronomer Certified 2.0.0-6, 2021-05-12
 - Bump stylelint to remove vulnerable sub-dependency (#15784) ([commit](https://github.com/astronomer/airflow/commit/c21820064))
 - Add resolution to force dependencies to use patched version of `lodash` (#15777) ([commit](https://github.com/astronomer/airflow/commit/3c48c0084))
 - Remove unused dependency (#15762) ([commit](https://github.com/astronomer/airflow/commit/15be415e5))
+- Docker: Bump `apache-airflow-providers-elasticsearch` to `1.0.4`
 
 Astronomer Certified 2.0.0-5, 2021-04-26
 -----------------------------------------

--- a/2.0.0/buster/build-time-pip-constraints.txt
+++ b/2.0.0/buster/build-time-pip-constraints.txt
@@ -3,7 +3,7 @@
 apache-airflow-providers-amazon==1.0.0
 apache-airflow-providers-celery==1.0.0
 apache-airflow-providers-cncf-kubernetes==1.0.1
-apache-airflow-providers-elasticsearch==1.0.1
+apache-airflow-providers-elasticsearch==1.0.4
 apache-airflow-providers-ftp==1.0.0
 apache-airflow-providers-google==1.0.0
 apache-airflow-providers-http==1.0.0


### PR DESCRIPTION
The new version of ES provider fixes few bugs which we also use in AC 2.0.2

http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow-providers-elasticsearch/latest/commits.html
