### PR TITLE
Release AC 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1128,8 +1128,7 @@ workflows:
           name: build-2.1.0-buster
           airflow_version: 2.1.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.0.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.1.0
             - static-checks
@@ -1148,8 +1147,8 @@ workflows:
       - push:
           name: push-2.1.0-buster
           tag: "2.1.0-buster"
-          dev_build: true
-          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM},2.1.0-1.dev-buster"
+          dev_build: false
+          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM},2.1.0-1-buster"
           context:
             - quay.io
             - docker.io
@@ -1163,8 +1162,8 @@ workflows:
       - push:
           name: push-2.1.0-buster-onbuild
           tag: "2.1.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-1.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-1-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1176,64 +1175,6 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          name: build-2.1.0-buster
-          airflow_version: 2.1.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.0.build)"
-      - scan-trivy:
-          name: scan-trivy-2.1.0-buster-onbuild
-          airflow_version: 2.1.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.1.0-buster
-      - test:
-          name: test-2.1.0-buster-images
-          tag: "2.1.0-buster"
-          requires:
-            - build-2.1.0-buster
-      - push:
-          name: push-2.1.0-buster
-          tag: "2.1.0-buster"
-          dev_build: true
-          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.0-buster-onbuild
-            - test-2.1.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.1.0-buster-onbuild
-          tag: "2.1.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-1.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.0-buster-onbuild
-            - test-2.1.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -18,7 +18,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.15-1", ["buster"]),
     ("2.0.0-6", ["buster"]),
     ("2.0.2-2", ["buster"]),
-    ("2.1.0-1.dev", ["buster"]),
+    ("2.1.0-1", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.1.0/CHANGELOG.md
+++ b/2.1.0/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
-Astronomer Certified 2.1.0-1, dev
+Astronomer Certified 2.1.0-1, 2021-05-21
 ----------------------------------------
+User-facing CHANGELOG for AC 2.1.0+astro.1 from Airflow 2.1.0:
 
+## Bugfixes
 
-### Bugfixes
+- [astro] Continually check if we should shut down istio contaner when running K8sPodOperator ([commit](https://github.com/astronomer/airflow/commit/40a852bda))
+- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/47528ff07))
+- [astro-new]Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/3d3e35e7d))

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -108,7 +108,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-1.*"
+ARG VERSION="2.1.0-1"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.0"
@@ -119,7 +119,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2-0/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
+RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.5"
 
@@ -136,7 +136,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-1.*"
+ARG VERSION="2.1.0-1"
 ARG AIRFLOW_VERSION="2.1.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All changes applied to available point releases will be documented in the `CHANG
 - [1.10.14 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md)
 - [2.0.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)
 - [2.0.2 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)
+- [2.1.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)
 
 ## Testing
 


### PR DESCRIPTION
Tag: https://github.com/astronomer/airflow/releases/tag/v2.1.0%2Bastro.1

Astronomer Certified 2.1.0-1, 2021-05-21
----------------------------------------
User-facing CHANGELOG for AC 2.1.0+astro.1 from Airflow 2.1.0:

## Bugfixes

- [astro] Continually check if we should shut down istio contaner when running K8sPodOperator ([commit](https://github.com/astronomer/airflow/commit/40a852bda))
- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/47528ff07))
- [astro-new]Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/3d3e35e7d))

