### PR TITLE
Add 1.10.15-2.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,7 +747,8 @@ workflows:
           name: build-1.10.15-buster
           airflow_version: 1.10.15
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
           requires:
             - Need-Approval-1.10.15
             - static-checks
@@ -766,8 +767,8 @@ workflows:
       - push:
           name: push-1.10.15-buster
           tag: "1.10.15-buster"
-          dev_build: false
-          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM},1.10.15-1-buster"
+          dev_build: true
+          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM},1.10.15-2.dev-buster"
           context:
             - quay.io
             - docker.io
@@ -781,8 +782,8 @@ workflows:
       - push:
           name: push-1.10.15-buster-onbuild
           tag: "1.10.15-buster-onbuild"
-          dev_build: false
-          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-1-buster-onbuild"
+          dev_build: true
+          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-2.dev-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1187,6 +1188,54 @@ workflows:
               only:
                 - master
     jobs:
+      - build:
+          name: build-1.10.15-buster
+          airflow_version: 1.10.15
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
+      - scan-trivy:
+          name: scan-trivy-1.10.15-buster-onbuild
+          airflow_version: 1.10.15
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-1.10.15-buster
+      - test:
+          name: test-1.10.15-buster-images
+          tag: "1.10.15-buster"
+          requires:
+            - build-1.10.15-buster
+      - push:
+          name: push-1.10.15-buster
+          tag: "1.10.15-buster"
+          dev_build: true
+          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - scan-trivy-1.10.15-buster-onbuild
+            - test-1.10.15-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-1.10.15-buster-onbuild
+          tag: "1.10.15-buster-onbuild"
+          dev_build: true
+          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-2.dev-buster-onbuild"
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - scan-trivy-1.10.15-buster-onbuild
+            - test-1.10.15-buster-images
+          filters:
+            branches:
+              only:
+                - master
       - build:
           name: build-2.0.0-buster
           airflow_version: 2.0.0

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -15,7 +15,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.10-8", ["alpine3.10", "buster"]),
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
-    ("1.10.15-1", ["buster"]),
+    ("1.10.15-2.dev", ["buster"]),
     ("2.0.0-7.dev", ["buster"]),
     ("2.0.2-3.dev", ["buster"]),
     ("2.1.0-2.dev", ["buster"]),
@@ -76,6 +76,7 @@ def replace_version_info():
     for ac_version, distros in IMAGE_MAP.items():
         dev_version = False
         airflow_version = get_airflow_version(ac_version)
+        ac_version_raw = ac_version
         for distro in distros:
             file_name = os.path.join(project_directory, airflow_version, distro, "Dockerfile")
 
@@ -104,7 +105,9 @@ def replace_version_info():
                 # Replace Moving Constraints Version to a tag for "non-dev" version (e.g constraints-2.1.0)
                 # For Dev versions we use a moving constraints branch (e.g constraints-2-1)
                 # We only do this for all buster images
-                if dev_version:
+                # If it is the first post-fix version in AC / Airflow series use constraints-branch, if not
+                # use the constraints from Airflow Version tag.
+                if dev_version and "-1.dev" in ac_version_raw:
                     branch = "-".join(airflow_version.split(".", 3)[0:2])
                     constraints_url = (
                         f'https://raw.githubusercontent.com/apache/airflow/constraints-{branch}/'

--- a/1.10.15/CHANGELOG.md
+++ b/1.10.15/CHANGELOG.md
@@ -8,6 +8,7 @@ Astronomer Certified 1.10.15-2.dev, TBC
 - KubernetesPodOperator should retry log tailing in case of interruption (#11325) ([commit](https://github.com/astronomer/airflow/commit/8848651ba))
 - Correctly parse (and copy) extras with python version to metadist ([commit](https://github.com/astronomer/airflow/commit/176a2a3ec))
 - Respect LogFormat when using ES logging with Json Format (#13310) ([commit](https://github.com/astronomer/airflow/commit/0dbd0f3a3))
+- Bump JS dependencies & remove unwanted deps ([commit](https://github.com/astronomer/airflow/commit/65a07cf73))
 
 Astronomer Certified 1.10.15-1, 2021-03-19
 ------------------------------------------

--- a/1.10.15/CHANGELOG.md
+++ b/1.10.15/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+Astronomer Certified 1.10.15-2.dev, TBC
+------------------------------------------
+
+## Bug Fixes
+
+- KubernetesPodOperator should retry log tailing in case of interruption (#11325) ([commit](https://github.com/astronomer/airflow/commit/8848651ba))
+- Correctly parse (and copy) extras with python version to metadist ([commit](https://github.com/astronomer/airflow/commit/176a2a3ec))
+- Respect LogFormat when using ES logging with Json Format (#13310) ([commit](https://github.com/astronomer/airflow/commit/0dbd0f3a3))
+
 Astronomer Certified 1.10.15-1, 2021-03-19
 ------------------------------------------
 

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-1"
+ARG VERSION="1.10.15-2.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
@@ -138,7 +138,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-1"
+ARG VERSION="1.10.15-2.*"
 ARG AIRFLOW_VERSION="1.10.15"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -3,12 +3,17 @@
 Astronomer Certified 2.0.0-7, TBC
 ----------------------------------------
 
+## Bugfixes
+
 - Update Kubernetes Provider to `1!1.2.1` to fix Pod hanging due to Istio container
 - Fill the "job_id" field for `airflow task run` without `--local`/`--raw` for KubeExecutor (#16108) ([commit](https://github.com/astronomer/airflow/commit/b84ded19b))
-- Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/ebb9c30ba))
 - Ensure that we don't try to mask empty string in logs (#16057) ([commit](https://github.com/astronomer/airflow/commit/a3e624ccf))
 - Don't die when masking `log.exception` when there is no exception (#16047) ([commit](https://github.com/astronomer/airflow/commit/ae8613d2e))
 - Ensure that secrets are masked no matter what logging config is in use (#15899) ([commit](https://github.com/astronomer/airflow/commit/aea4ad99e))
+
+## Improvements
+
+- Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/ebb9c30ba))
 
 Astronomer Certified 2.0.0-6, 2021-05-12
 -----------------------------------------

--- a/2.0.2/CHANGELOG.md
+++ b/2.0.2/CHANGELOG.md
@@ -3,12 +3,17 @@
 Astronomer Certified 2.0.2-3, TBC
 ----------------------------------------
 
+### Bugfixes
+
 - Update Kubernetes Provider to `1!1.2.1` to fix Pod hanging due to Istio container
 - Fill the "job_id" field for `airflow task run` without `--local`/`--raw` for KubeExecutor (#16108) ([commit](https://github.com/astronomer/airflow/commit/7a6492e70))
-- Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/cb21b0aca))
 - Ensure that we don't try to mask empty string in logs (#16057) ([commit](https://github.com/astronomer/airflow/commit/215758c0a))
 - Don't die when masking `log.exception` when there is no exception (#16047) ([commit](https://github.com/astronomer/airflow/commit/c4c2ab288))
 - Ensure that secrets are masked no matter what logging config is in use (#15899) ([commit](https://github.com/astronomer/airflow/commit/3e61ccddd))
+
+### Improvements
+
+- Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/cb21b0aca))
 
 Astronomer Certified 2.0.2-2, 2021-05-12
 ----------------------------------------

--- a/2.1.0/CHANGELOG.md
+++ b/2.1.0/CHANGELOG.md
@@ -3,12 +3,17 @@
 Astronomer Certified 2.1.0-2, TBC
 ----------------------------------------
 
+## Bugfixes
+
 - Update Kubernetes Provider to `1!1.2.1` to fix Pod hanging due to Istio container
-- Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/19b3f1bd8))
 - Don't die when masking `log.exception` when there is no exception (#16047) ([commit](https://github.com/astronomer/airflow/commit/e24040de6))
 - Ensure that we don't try to mask empty string in logs (#16057) ([commit](https://github.com/astronomer/airflow/commit/d20eaa86c))
 - Fill the "job_id" field for `airflow task run` without `--local`/`--raw` for KubeExecutor (#16108) ([commit](https://github.com/astronomer/airflow/commit/55fc6f6d8))
 - Fix auto-refresh in tree view When webserver ui is not in ``/`` (#16018) ([commit](https://github.com/astronomer/airflow/commit/0c1d91917))
+
+##Improvements
+
+- Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/19b3f1bd8))
 
 Astronomer Certified 2.1.0-1, 2021-05-21
 ----------------------------------------


### PR DESCRIPTION
Astronomer Certified 1.10.15-2.dev, TBC
------------------------------------------

## Bug Fixes

- KubernetesPodOperator should retry log tailing in case of interruption (#11325) ([commit](https://github.com/astronomer/airflow/commit/8848651ba))
- Correctly parse (and copy) extras with python version to metadist ([commit](https://github.com/astronomer/airflow/commit/176a2a3ec))
- Respect LogFormat when using ES logging with Json Format (#13310) ([commit](https://github.com/astronomer/airflow/commit/0dbd0f3a3))
