### PR TITLE
Release AC 2.0.2-3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1003,8 +1003,7 @@ workflows:
           name: build-2.0.2-buster
           airflow_version: 2.0.2
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.2
             - static-checks
@@ -1023,8 +1022,8 @@ workflows:
       - push:
           name: push-2.0.2-buster
           tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-3.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-3-buster"
           context:
             - quay.io
             - docker.io
@@ -1038,8 +1037,8 @@ workflows:
       - push:
           name: push-2.0.2-buster-onbuild
           tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-3.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-3-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1279,54 +1278,6 @@ workflows:
           requires:
             - scan-trivy-2.0.0-buster-onbuild
             - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.0.2-buster
-          airflow_version: 2.0.2
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.2-buster-onbuild
-          airflow_version: 2.0.2
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.2-buster
-      - test:
-          name: test-2.0.2-buster-images
-          tag: "2.0.2-buster"
-          requires:
-            - build-2.0.2-buster
-      - push:
-          name: push-2.0.2-buster
-          tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.2-buster-onbuild
-          tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-3.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
           filters:
             branches:
               only:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -17,7 +17,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.14-3", ["buster"]),
     ("1.10.15-2.dev", ["buster"]),
     ("2.0.0-7.dev", ["buster"]),
-    ("2.0.2-3.dev", ["buster"]),
+    ("2.0.2-3", ["buster"]),
     ("2.1.0-2", ["buster"]),
 ])
 

--- a/2.0.2/CHANGELOG.md
+++ b/2.0.2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.0.2-3, TBC
+Astronomer Certified 2.0.2-3, 2021-06-03
 ----------------------------------------
 
 ### Bugfixes

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-3.*"
+ARG VERSION="2.0.2-3"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.2"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-3.*"
+ARG VERSION="2.0.2-3"
 ARG AIRFLOW_VERSION="2.0.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Tag: https://github.com/astronomer/airflow/releases/tag/v2.0.2%2Bastro.3

### Bugfixes

- Update Kubernetes Provider to `1!1.2.1` to fix Pod hanging due to Istio container
- Fill the "job_id" field for `airflow task run` without `--local`/`--raw` for KubeExecutor (#16108) ([commit](https://github.com/astronomer/airflow/commit/7a6492e70))
- Ensure that we don't try to mask empty string in logs (#16057) ([commit](https://github.com/astronomer/airflow/commit/215758c0a))
- Don't die when masking `log.exception` when there is no exception (#16047) ([commit](https://github.com/astronomer/airflow/commit/c4c2ab288))
- Ensure that secrets are masked no matter what logging config is in use (#15899) ([commit](https://github.com/astronomer/airflow/commit/3e61ccddd))
