### PR TITLE
Release AC 1.10.15-2 and 2.0.0-7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,8 +747,7 @@ workflows:
           name: build-1.10.15-buster
           airflow_version: 1.10.15
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
+          dev_build: false
           requires:
             - Need-Approval-1.10.15
             - static-checks
@@ -767,8 +766,8 @@ workflows:
       - push:
           name: push-1.10.15-buster
           tag: "1.10.15-buster"
-          dev_build: true
-          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM},1.10.15-2.dev-buster"
+          dev_build: false
+          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM},1.10.15-2-buster"
           context:
             - quay.io
             - docker.io
@@ -782,8 +781,8 @@ workflows:
       - push:
           name: push-1.10.15-buster-onbuild
           tag: "1.10.15-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-2.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-2-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -875,8 +874,7 @@ workflows:
           name: build-2.0.0-buster
           airflow_version: 2.0.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.0
             - static-checks
@@ -895,8 +893,8 @@ workflows:
       - push:
           name: push-2.0.0-buster
           tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-7.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM},2.0.0-7-buster"
           context:
             - quay.io
             - docker.io
@@ -910,8 +908,8 @@ workflows:
       - push:
           name: push-2.0.0-buster-onbuild
           tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-7.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-7-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1177,112 +1175,6 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          name: build-1.10.15-buster
-          airflow_version: 1.10.15
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-1.10.15.build)"
-      - scan-trivy:
-          name: scan-trivy-1.10.15-buster-onbuild
-          airflow_version: 1.10.15
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-1.10.15-buster
-      - test:
-          name: test-1.10.15-buster-images
-          tag: "1.10.15-buster"
-          requires:
-            - build-1.10.15-buster
-      - push:
-          name: push-1.10.15-buster
-          tag: "1.10.15-buster"
-          dev_build: true
-          extra_tags: "1.10.15-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-1.10.15-buster-onbuild
-            - test-1.10.15-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-1.10.15-buster-onbuild
-          tag: "1.10.15-buster-onbuild"
-          dev_build: true
-          extra_tags: "1.10.15-buster-onbuild-${CIRCLE_BUILD_NUM},1.10.15-2.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-1.10.15-buster-onbuild
-            - test-1.10.15-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.0.0-buster
-          airflow_version: 2.0.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.0.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.0-buster-onbuild
-          airflow_version: 2.0.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.0-buster
-      - test:
-          name: test-2.0.0-buster-images
-          tag: "2.0.0-buster"
-          requires:
-            - build-2.0.0-buster
-      - push:
-          name: push-2.0.0-buster
-          tag: "2.0.0-buster"
-          dev_build: true
-          extra_tags: "2.0.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.0-buster-onbuild
-          tag: "2.0.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.0-7.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.0-buster-onbuild
-            - test-2.0.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -15,8 +15,8 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.10-8", ["alpine3.10", "buster"]),
     ("1.10.12-4", ["alpine3.10", "buster"]),
     ("1.10.14-3", ["buster"]),
-    ("1.10.15-2.dev", ["buster"]),
-    ("2.0.0-7.dev", ["buster"]),
+    ("1.10.15-2", ["buster"]),
+    ("2.0.0-7", ["buster"]),
     ("2.0.2-3", ["buster"]),
     ("2.1.0-2", ["buster"]),
 ])

--- a/1.10.15/CHANGELOG.md
+++ b/1.10.15/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 1.10.15-2.dev, TBC
+Astronomer Certified 1.10.15-2, 2021-06-04
 ------------------------------------------
 
 ## Bug Fixes

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-2.*"
+ARG VERSION="1.10.15-2"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
@@ -138,7 +138,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-2.*"
+ARG VERSION="1.10.15-2"
 ARG AIRFLOW_VERSION="1.10.15"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.0.0-7, TBC
+Astronomer Certified 2.0.0-7, 2021-06-04
 ----------------------------------------
 
 ## Bugfixes

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-7.*"
+ARG VERSION="2.0.0-7"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.0"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.0-7.*"
+ARG VERSION="2.0.0-7"
 ARG AIRFLOW_VERSION="2.0.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Tag: https://github.com/astronomer/airflow/releases/tag/v2.0.0%2Bastro.7

Astronomer Certified 2.0.0-7, 2021-06-04
----------------------------------------

## Bugfixes

- Update Kubernetes Provider to `1!1.2.1` to fix Pod hanging due to Istio container
- Fill the "job_id" field for `airflow task run` without `--local`/`--raw` for KubeExecutor (#16108) ([commit](https://github.com/astronomer/airflow/commit/b84ded19b))
- Ensure that we don't try to mask empty string in logs (#16057) ([commit](https://github.com/astronomer/airflow/commit/a3e624ccf))
- Don't die when masking `log.exception` when there is no exception (#16047) ([commit](https://github.com/astronomer/airflow/commit/ae8613d2e))
- Ensure that secrets are masked no matter what logging config is in use (#15899) ([commit](https://github.com/astronomer/airflow/commit/aea4ad99e))

Tag: https://github.com/astronomer/airflow/releases/tag/v1.10.15%2Bastro.2

Astronomer Certified 1.10.15-2, 2021-06-04
------------------------------------------

## Bug Fixes

- KubernetesPodOperator should retry log tailing in case of interruption (#11325) ([commit](https://github.com/astronomer/airflow/commit/8848651ba))
- Correctly parse (and copy) extras with python version to metadist ([commit](https://github.com/astronomer/airflow/commit/176a2a3ec))
- Respect LogFormat when using ES logging with Json Format (#13310) ([commit](https://github.com/astronomer/airflow/commit/0dbd0f3a3))
- Bump JS dependencies & remove unwanted deps ([commit](https://github.com/astronomer/airflow/commit/65a07cf73))
