### PR TITLE
upgrade fab sec manager to 1.6.0

### DIFF
--- a/1.10.10/alpine3.10/build-time-pip-constraints.txt
+++ b/1.10.10/alpine3.10/build-time-pip-constraints.txt
@@ -12,7 +12,7 @@ asn1crypto==0.24.0
 astroid==2.4.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 async-generator==1.10
 async-timeout==3.0.1
 atlasclient==1.0.0

--- a/1.10.10/buster/build-time-pip-constraints.txt
+++ b/1.10.10/buster/build-time-pip-constraints.txt
@@ -5,7 +5,7 @@ appdirs==1.4.4
 argcomplete==1.12.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 attrs==19.3.0
 azure-common==1.1.26
 azure-core==1.9.0

--- a/1.10.7/alpine3.10/build-time-pip-constraints.txt
+++ b/1.10.7/alpine3.10/build-time-pip-constraints.txt
@@ -12,7 +12,7 @@ asn1crypto==0.24.0
 astroid==2.4.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 async-generator==1.10
 async-timeout==3.0.1
 atlasclient==1.0.0

--- a/1.10.7/buster/build-time-pip-constraints.txt
+++ b/1.10.7/buster/build-time-pip-constraints.txt
@@ -5,7 +5,7 @@ appdirs==1.4.4
 argcomplete==1.12.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 attrs==19.3.0
 azure-common==1.1.26
 azure-core==1.9.0

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -130,7 +130,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 RUN pip install "${AIRFLOW_MODULE}" \
     --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.5"
+	&& pip install "astronomer-fab-security-manager~=1.6"
 
 
 ## move this to same layer as airflow because its from tag.

--- a/2.0.0/buster/build-time-pip-constraints.txt
+++ b/2.0.0/buster/build-time-pip-constraints.txt
@@ -24,7 +24,7 @@ appdirs==1.4.4
 argcomplete==1.12.2
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 async-timeout==3.0.1
 attrs==20.3.0
 azure-batch==10.0.0

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -130,7 +130,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 RUN pip install "${AIRFLOW_MODULE}" \
     --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.5"
+	&& pip install "astronomer-fab-security-manager~=1.6"
 
 
 ## move this to same layer as airflow because its from tag.

--- a/2.0.2/buster/build-time-pip-constraints.txt
+++ b/2.0.2/buster/build-time-pip-constraints.txt
@@ -23,7 +23,7 @@ appdirs==1.4.4
 argcomplete==1.12.3
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 attrs==20.3.0
 azure-batch==10.0.0
 azure-common==1.1.27

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -130,7 +130,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 RUN pip install "${AIRFLOW_MODULE}" \
     --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.5"
+       && pip install "astronomer-fab-security-manager~=1.6"
 
 
 ## move this to same layer as airflow because its from tag.

--- a/2.1.0/buster/build-time-pip-constraints.txt
+++ b/2.1.0/buster/build-time-pip-constraints.txt
@@ -22,7 +22,7 @@ appdirs==1.4.4
 argcomplete==1.12.3
 astronomer-airflow-scripts==0.0.5
 astronomer-airflow-version-check==1.0.7
-astronomer-fab-security-manager==1.5.0
+astronomer-fab-security-manager==1.6.0
 attrs==20.3.0
 azure-batch==10.0.0
 azure-common==1.1.27

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -130,7 +130,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 RUN pip install "${AIRFLOW_MODULE}" \
     --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.5"
+	&& pip install "astronomer-fab-security-manager~=1.6"
 
 
 ## move this to same layer as airflow because its from tag.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR pulls in the latest fab security manager version. The latest update resolves a security concern outlined in this issue https://app.zenhub.com/workspaces/astro-platform-board-602c68a458670000110dd641/issues/astronomer/issues/3053

