### PR TITLE
Use `1!2.0.1rc1` version of ES Provider for AC 2.1.1 dev image

### DIFF
--- a/2.1.1/buster/build-time-pip-constraints.txt
+++ b/2.1.1/buster/build-time-pip-constraints.txt
@@ -64,7 +64,7 @@ apache-airflow-providers-datadog==1.0.1
 apache-airflow-providers-dingding==1.0.2
 apache-airflow-providers-discord==1.0.1
 apache-airflow-providers-docker==1.2.0
-apache-airflow-providers-elasticsearch==1.0.4
+apache-airflow-providers-elasticsearch==1!2.0.1rc1
 apache-airflow-providers-exasol==1.1.1
 apache-airflow-providers-facebook==1.1.0
 apache-airflow-providers-ftp==1.1.0


### PR DESCRIPTION
This should fix following issue:

```
/usr/local/lib/python3.7/site-packages/airflow/configuration.py:346 DeprecationWarning: The default_queue option in [celery] has been moved to the default_queue option in [operators] - the old setting has been used, but please update your config.
Unable to load the config, contains a configuration error.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/logging/config.py", line 563, in configure
    handler = self.configure_handler(handlers[name])
  File "/usr/local/lib/python3.7/logging/config.py", line 736, in configure_handler
    result = factory(**kwargs)
TypeError: __init__() got an unexpected keyword argument 'host_field'

```
