### PR TITLE
Add constraint for installed Airflow version

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -297,6 +297,7 @@ def test_airflow_configs(scheduler, docker_client):
             "grep '^update_fab_perms' | awk '{print $3}'"
         ) == "False", "[webserver] update_fab_perms needs to be False for AC >= 1.10.10"
 
+
 def test_labels_for_onbuild_image(docker_client):
     """ Ensure correct labels exists on onbuild image """
     labels = get_labels(docker_client, ImageType.ONBUILD.value)
@@ -328,10 +329,28 @@ def test_apache_airflow_in_requirements(tmp_path):
         assert output.returncode == 1
         assert b"Do not upgrade by specifying 'apache-airflow' in your requirements.txt" in output.stderr
 
-    # Test that you can still use backport-packages that start with "apache-airflow"
-    (test_project / "requirements.txt").write_text("apache-airflow-backport-providers-amazon")
-    output = subprocess.run(['docker', 'build', '-t', 'testimage', test_project.resolve()], capture_output=True)
+    # Test that you can still use Provider (or backport providers) packages that start with "apache-airflow"
+    if airflow_2:
+        (test_project / "requirements.txt").write_text("apache-airflow-providers-amazon")
+        output = subprocess.run(
+            ['docker', 'build', '-t', 'testimage', test_project.resolve()], capture_output=True
+        )
+    else:
+        (test_project / "requirements.txt").write_text("apache-airflow-backport-providers-amazon")
+        output = subprocess.run(
+            ['docker', 'build', '-t', 'testimage', test_project.resolve()], capture_output=True
+        )
     assert output.returncode == 0
+
+
+def test_airflow_in_constraints(scheduler):
+    """
+    Test that the installed Airflow version is added in constraints file to avoid accidental upgrades
+    """
+    installed_airflow_version = scheduler.pip_package.get_packages()["apache-airflow"]["version"]
+    pip_constraints_file = scheduler.file("/usr/local/share/astronomer-pip-constraints.txt").content_string
+
+    assert installed_airflow_version in pip_constraints_file
 
 
 @pytest.fixture(scope='session')

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -340,7 +340,7 @@ def test_apache_airflow_in_requirements(tmp_path):
         output = subprocess.run(
             ['docker', 'build', '-t', 'testimage', test_project.resolve()], capture_output=True
         )
-    assert output.returncode == 0
+    assert output.returncode == 0, output.stderr
 
 
 def test_airflow_in_constraints(scheduler):

--- a/.circleci/test-requirements.txt
+++ b/.circleci/test-requirements.txt
@@ -1,3 +1,3 @@
 pre-commit==2.4.0
-testinfra==3.2.1
+testinfra==6.0.0
 docker==4.1.0

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -115,7 +115,7 @@ RUN sed -i \
     /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip3 freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.10/alpine3.10/Dockerfile
+++ b/1.10.10/alpine3.10/Dockerfile
@@ -114,6 +114,9 @@ RUN sed -i \
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs
 

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -158,7 +158,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -157,6 +157,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -108,6 +108,9 @@ RUN sed -i \
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs
 

--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -109,7 +109,7 @@ RUN sed -i \
     /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip3 freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -151,6 +151,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -152,7 +152,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -151,6 +151,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -152,7 +152,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -151,6 +151,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -152,7 +152,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -113,7 +113,7 @@ RUN sed -i \
     /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip3 freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs

--- a/1.10.7/alpine3.10/Dockerfile
+++ b/1.10.7/alpine3.10/Dockerfile
@@ -112,6 +112,9 @@ RUN sed -i \
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/lib/python3.7/site-packages/airflow/config_templates/default_airflow.cfg
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 # Create logs directory so we can own it when we mount volumes
 RUN mkdir -p ${AIRFLOW_HOME}/logs
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -158,7 +158,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -157,6 +157,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -158,6 +158,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -159,7 +159,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -158,6 +158,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -159,7 +159,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -158,6 +158,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -159,7 +159,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -158,6 +158,9 @@ COPY --from=devel /usr/local/bin /usr/local/bin
 COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
+# Pin apache-airflow version to avoid accidental upgrade
+RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -159,7 +159,7 @@ COPY include/pip.conf /etc/pip.conf
 COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Pin apache-airflow version to avoid accidental upgrade
-RUN echo "apache-airflow==1!${VERSION}" >>  /usr/local/share/astronomer-pip-constraints.txt
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
 RUN sed -i \
     # Run pods spun up by Kubernetes Executor as astro user


### PR DESCRIPTION
To avoid accidental Airflow upgrades, this commit/PR adds "apache-airflow==INSTALLED_VERSION" to the constraints file that is baked in the docker image.

