### PR TITLE
Add Dev image for AC 2.1.0-3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1128,7 +1128,8 @@ workflows:
           name: build-2.1.0-buster
           airflow_version: 2.1.0
           distribution_name: buster
-          dev_build: false
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.0.build)"
           requires:
             - Need-Approval-2.1.0
             - static-checks
@@ -1147,8 +1148,8 @@ workflows:
       - push:
           name: push-2.1.0-buster
           tag: "2.1.0-buster"
-          dev_build: false
-          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM},2.1.0-2-buster"
+          dev_build: true
+          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM},2.1.0-3.dev-buster"
           context:
             - quay.io
             - docker.io
@@ -1162,8 +1163,8 @@ workflows:
       - push:
           name: push-2.1.0-buster-onbuild
           tag: "2.1.0-buster-onbuild"
-          dev_build: false
-          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-2-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-3.dev-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1312,6 +1313,54 @@ workflows:
               only:
                 - master
     jobs:
+      - build:
+          name: build-2.1.0-buster
+          airflow_version: 2.1.0
+          distribution_name: buster
+          dev_build: true
+          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.0.build)"
+      - scan-trivy:
+          name: scan-trivy-2.1.0-buster-onbuild
+          airflow_version: 2.1.0
+          distribution: buster
+          distribution_name: buster-onbuild
+          requires:
+            - build-2.1.0-buster
+      - test:
+          name: test-2.1.0-buster-images
+          tag: "2.1.0-buster"
+          requires:
+            - build-2.1.0-buster
+      - push:
+          name: push-2.1.0-buster
+          tag: "2.1.0-buster"
+          dev_build: true
+          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM}"
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - scan-trivy-2.1.0-buster-onbuild
+            - test-2.1.0-buster-images
+          filters:
+            branches:
+              only:
+                - master
+      - push:
+          name: push-2.1.0-buster-onbuild
+          tag: "2.1.0-buster-onbuild"
+          dev_build: true
+          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-3.dev-buster-onbuild"
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - scan-trivy-2.1.0-buster-onbuild
+            - test-2.1.0-buster-images
+          filters:
+            branches:
+              only:
+                - master
       - build:
           name: build-2.1.1-buster
           airflow_version: 2.1.1

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -18,7 +18,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.15-2", ["buster"]),
     ("2.0.0-7", ["buster"]),
     ("2.0.2-3", ["buster"]),
-    ("2.1.0-2", ["buster"]),
+    ("2.1.0-3.dev", ["buster"]),
     ("2.1.1-1.dev", ["buster"]),
 ])
 

--- a/2.1.0/CHANGELOG.md
+++ b/2.1.0/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+Astronomer Certified 2.1.0-3.dev, TBC
+----------------------------------------
+
+## Bugfixes
+
+- Avoid recursing too deep when redacting logs (#16491) ([commit](https://github.com/astronomer/airflow/commit/5398eb5ab))
+- Switch to built-in data structures in SecretsMasker (#16424) ([commit](https://github.com/astronomer/airflow/commit/7e5968aaa))
+- Don't fail to log if we can't redact something (#16118) ([commit](https://github.com/astronomer/airflow/commit/41ae7090d))
+- Don't show stale Serialized DAGs if they are deleted in DB (#16368) ([commit](https://github.com/astronomer/airflow/commit/9d14b1d6d))
+- fix: change graph focus to top of view instead of center (#16484) ([commit](https://github.com/astronomer/airflow/commit/9eca94bb6))
+- Fix Orphaned tasks stuck in CeleryExecutor as running (#16550) ([commit](https://github.com/astronomer/airflow/commit/83fb4bf9e))
+- Redact conn secrets in webserver logs (#16579) ([commit](https://github.com/astronomer/airflow/commit/9ac87a9cf))
+- Don't crash attempting to mask secrets in dict with non-string keys (#16601) ([commit](https://github.com/astronomer/airflow/commit/6af516b29))
+- Fix Dag Details start date bug (#16206) ([commit](https://github.com/astronomer/airflow/commit/8d40ce481))
+- Tree View UI for larger DAGs & more consistent spacing in Tree View (#16522) ([commit](https://github.com/astronomer/airflow/commit/f3fb06ce5))
+- Make task ID on legend have enough width and width of line chart to be 100%.  (#15915) ([commit](https://github.com/astronomer/airflow/commit/8b2a7b75c))
+- Fix normalize-url vulnerability (#16375) ([commit](https://github.com/astronomer/airflow/commit/58357b578))
+- Clean Markdown with dedent to respect indents (#16414) ([commit](https://github.com/astronomer/airflow/commit/26abb8d37))
+- add num_runs query param for tree refresh (#16437) ([commit](https://github.com/astronomer/airflow/commit/71feed690))
+- set max tree width to 1200px (#16067) ([commit](https://github.com/astronomer/airflow/commit/9bcfd97d7))
+- Exclude ``yarn.lock`` from built Python wheel file (#16577) ([commit](https://github.com/astronomer/airflow/commit/8fcc68d88))
+- Bump version to 2.1.0.dev1+astro.3 ([commit](https://github.com/astronomer/airflow/commit/2700c8cf3))
+- Add `passphrase` and `private_key` to default sensitive fileld names (#16392) ([commit](https://github.com/astronomer/airflow/commit/5917abf11))
+- Dockerfile: Add constraint for installed Airflow version (#274) ([commit](https://github.com/astronomer/ap-airflow/commit/60174ec))
+- Dockerfile: Upgrade Fab Security manager to 1.6.0 (#272) ([commit](https://github.com/astronomer/ap-airflow/commit/417fd5993982e49424fb427941552d0d42ed567e))
+
 Astronomer Certified 2.1.0-2, 2021-06-03
 ----------------------------------------
 
@@ -11,7 +37,7 @@ Astronomer Certified 2.1.0-2, 2021-06-03
 - Fill the "job_id" field for `airflow task run` without `--local`/`--raw` for KubeExecutor (#16108) ([commit](https://github.com/astronomer/airflow/commit/55fc6f6d8))
 - Fix auto-refresh in tree view When webserver ui is not in ``/`` (#16018) ([commit](https://github.com/astronomer/airflow/commit/0c1d91917))
 
-##Improvements
+## Improvements
 
 - Parse recently modified files even if just parsed (#16075) ([commit](https://github.com/astronomer/airflow/commit/19b3f1bd8))
 

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-2"
+ARG VERSION="2.1.0-3.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.0"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-2"
+ARG VERSION="2.1.0-3.*"
 ARG AIRFLOW_VERSION="2.1.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
This commit/PR adds a nightly build for AC 2.1.0-3

https://github.com/astronomer/airflow/commits/v2-1-0/



# Changelog

Astronomer Certified 2.1.0-3.dev, TBC
----------------------------------------

## Bugfixes

- Avoid recursing too deep when redacting logs (#16491) ([commit](https://github.com/astronomer/airflow/commit/5398eb5ab))
- Switch to built-in data structures in SecretsMasker (#16424) ([commit](https://github.com/astronomer/airflow/commit/7e5968aaa))
- Don't fail to log if we can't redact something (#16118) ([commit](https://github.com/astronomer/airflow/commit/41ae7090d))
- Don't show stale Serialized DAGs if they are deleted in DB (#16368) ([commit](https://github.com/astronomer/airflow/commit/9d14b1d6d))
- fix: change graph focus to top of view instead of center (#16484) ([commit](https://github.com/astronomer/airflow/commit/9eca94bb6))
- Fix Orphaned tasks stuck in CeleryExecutor as running (#16550) ([commit](https://github.com/astronomer/airflow/commit/83fb4bf9e))
- Redact conn secrets in webserver logs (#16579) ([commit](https://github.com/astronomer/airflow/commit/9ac87a9cf))
- Don't crash attempting to mask secrets in dict with non-string keys (#16601) ([commit](https://github.com/astronomer/airflow/commit/6af516b29))
- Fix Dag Details start date bug (#16206) ([commit](https://github.com/astronomer/airflow/commit/8d40ce481))
- Tree View UI for larger DAGs & more consistent spacing in Tree View (#16522) ([commit](https://github.com/astronomer/airflow/commit/f3fb06ce5))
- Make task ID on legend have enough width and width of line chart to be 100%.  (#15915) ([commit](https://github.com/astronomer/airflow/commit/8b2a7b75c))
- Fix normalize-url vulnerability (#16375) ([commit](https://github.com/astronomer/airflow/commit/58357b578))
- Clean Markdown with dedent to respect indents (#16414) ([commit](https://github.com/astronomer/airflow/commit/26abb8d37))
- add num_runs query param for tree refresh (#16437) ([commit](https://github.com/astronomer/airflow/commit/71feed690))
- set max tree width to 1200px (#16067) ([commit](https://github.com/astronomer/airflow/commit/9bcfd97d7))
- Exclude ``yarn.lock`` from built Python wheel file (#16577) ([commit](https://github.com/astronomer/airflow/commit/8fcc68d88))
- Bump version to 2.1.0.dev1+astro.3 ([commit](https://github.com/astronomer/airflow/commit/2700c8cf3))
- Add `passphrase` and `private_key` to default sensitive fileld names (#16392) ([commit](https://github.com/astronomer/airflow/commit/5917abf11))
- Dockerfile: Add constraint for installed Airflow version (#274) ([commit](https://github.com/astronomer/ap-airflow/commit/60174ec))
- Dockerfile: Upgrade Fab Security manager to 1.6.0 (#272) ([commit](https://github.com/astronomer/ap-airflow/commit/417fd5993982e49424fb427941552d0d42ed567e))