### PR TITLE
Release AC 2.1.1-1

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -54,10 +54,6 @@ AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronome
 export AIRFLOW_VERSION
 echo "Airflow Version: $AIRFLOW_VERSION"
 
-CHART_VERSION=$(helm show chart astronomer/airflow --devel)
-export CHART_VERSION
-echo "Chart Version: $CHART_VERSION"
-
 kubectl get pods -n $NAMESPACE -w &
 WATCH_PID=$!
 
@@ -71,8 +67,6 @@ helm install --namespace $NAMESPACE \
   --set images.flower.pullPolicy=Never \
   --set executor=KubernetesExecutor \
   --set airflowVersion=$AIRFLOW_VERSION \
-  --devel \
-  --version 0.18.0-build6 \
   $RELEASE_NAME astronomer/airflow
 
 if [ ! $? -eq 0 ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1258,8 +1258,7 @@ workflows:
           name: build-2.1.1-buster
           airflow_version: 2.1.1
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.1.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.1.1
             - static-checks
@@ -1278,8 +1277,8 @@ workflows:
       - push:
           name: push-2.1.1-buster
           tag: "2.1.1-buster"
-          dev_build: true
-          extra_tags: "2.1.1-buster-${CIRCLE_BUILD_NUM},2.1.1-1.dev-buster"
+          dev_build: false
+          extra_tags: "2.1.1-buster-${CIRCLE_BUILD_NUM},2.1.1-1-buster"
           context:
             - quay.io
             - docker.io
@@ -1293,8 +1292,8 @@ workflows:
       - push:
           name: push-2.1.1-buster-onbuild
           tag: "2.1.1-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.1-1.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.1.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.1-1-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1455,54 +1454,6 @@ workflows:
           requires:
             - scan-trivy-2.1.0-buster-onbuild
             - test-2.1.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.1.1-buster
-          airflow_version: 2.1.1
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.1.build)"
-      - scan-trivy:
-          name: scan-trivy-2.1.1-buster-onbuild
-          airflow_version: 2.1.1
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.1.1-buster
-      - test:
-          name: test-2.1.1-buster-images
-          tag: "2.1.1-buster"
-          requires:
-            - build-2.1.1-buster
-      - push:
-          name: push-2.1.1-buster
-          tag: "2.1.1-buster"
-          dev_build: true
-          extra_tags: "2.1.1-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.1-buster-onbuild
-            - test-2.1.1-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.1.1-buster-onbuild
-          tag: "2.1.1-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.1-1.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.1-buster-onbuild
-            - test-2.1.1-buster-images
           filters:
             branches:
               only:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -19,7 +19,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.0.0-8.dev", ["buster"]),
     ("2.0.2-4.dev", ["buster"]),
     ("2.1.0-3.dev", ["buster"]),
-    ("2.1.1-1.dev", ["buster"]),
+    ("2.1.1-1", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.1.1/CHANGELOG.md
+++ b/2.1.1/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
 
-Astronomer Certified 2.1.1-dev,
+Astronomer Certified 2.1.1-1, 2021-07-02
 ----------------------------------------
+
+User-facing CHANGELOG for AC 2.1.1+astro.1 from Airflow 2.1.1:
+
+### Bugfixes
+
+- Fix TI success/failure links ([commit](https://github.com/astronomer/airflow/commit/8f598f6fa))
+- Fix TI success confirm page (#16650) ([commit](https://github.com/astronomer/airflow/commit/b0aaf266f))
+- Fail tasks in scheduler when executor reports they failed (#15929) ([commit](https://github.com/astronomer/airflow/commit/fa7a14daa))
+- Fix bug in mark TI success api (#16524) ([commit](https://github.com/astronomer/airflow/commit/ebae41f0e))
+- Fix TI success/failure links (#16233) ([commit](https://github.com/astronomer/airflow/commit/1fb970f90))
+- [astro] Continually check if we should shut down istio contaner when running K8sPodOperator ([commit](https://github.com/astronomer/airflow/commit/5c5dee67b))
+- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/320675746))

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.1-1.*"
+ARG VERSION="2.1.1-1"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.1"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.1-1.*"
+ARG VERSION="2.1.1-1"
 ARG AIRFLOW_VERSION="2.1.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
Tag: https://github.com/astronomer/airflow/releases/tag/v2.1.1%2Bastro.1

Astronomer Certified 2.1.1-1, 2021-07-02
----------------------------------------

User-facing CHANGELOG for AC 2.1.1+astro.1 from Airflow 2.1.1:

### Bugfixes

- Fix TI success/failure links ([commit](https://github.com/astronomer/airflow/commit/8f598f6fa))
- Fix TI success confirm page (#16650) ([commit](https://github.com/astronomer/airflow/commit/b0aaf266f))
- Fail tasks in scheduler when executor reports they failed (#15929) ([commit](https://github.com/astronomer/airflow/commit/fa7a14daa))
- Fix bug in mark TI success api (#16524) ([commit](https://github.com/astronomer/airflow/commit/ebae41f0e))
- Fix TI success/failure links (#16233) ([commit](https://github.com/astronomer/airflow/commit/1fb970f90))
- [astro] Continually check if we should shut down istio contaner when running K8sPodOperator ([commit](https://github.com/astronomer/airflow/commit/5c5dee67b))
- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/320675746))
