### PR TITLE
Use latest stable version of the Helm Chart

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -24,7 +24,7 @@ source $DIR/install-ci-tools
 source $DIR/start-kind-cluster
 
 helm repo add stable https://charts.helm.sh/stable/
-helm repo add astronomer https://internal-helm.astronomer.io/
+helm repo add astronomer https://helm.astronomer.io/
 helm repo update
 
 set +e
@@ -54,6 +54,22 @@ AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronome
 export AIRFLOW_VERSION
 echo "Airflow Version: $AIRFLOW_VERSION"
 
+# Find alpine or debian
+DISTRO=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.distro" }}' "$REPOSITORY:$TEST_TAG")
+# This is handled by Houston for the platform: https://github.com/astronomer/houston-api/pull/581
+if [[ "$DISTRO" == "alpine" ]]; then
+  export IMAGE_UID="100"
+  export IMAGE_GID="101"
+else
+  export IMAGE_UID="50000"
+  export IMAGE_GID="50000"
+fi
+echo "Distro: $DISTRO - Setting UID to $IMAGE_UID and GID to $IMAGE_GID"
+
+CHART_VERSION=$(helm search repo astronomer/airflow | grep astronomer/airflow | awk '{print $2}')
+export CHART_VERSION
+echo "Chart Version: $CHART_VERSION"
+
 kubectl get pods -n $NAMESPACE -w &
 WATCH_PID=$!
 
@@ -67,6 +83,9 @@ helm install --namespace $NAMESPACE \
   --set images.flower.pullPolicy=Never \
   --set executor=KubernetesExecutor \
   --set airflowVersion=$AIRFLOW_VERSION \
+  --set uid=$IMAGE_UID \
+  --set gid=$IMAGE_GID \
+  --version=$CHART_VERSION \
   $RELEASE_NAME astronomer/airflow
 
 if [ ! $? -eq 0 ]; then


### PR DESCRIPTION
Currently we are using latest development version which is failing because it is a major version (1.0.0) and looks like alpine images are not working with that chat.

This is similar to https://github.com/astronomer/issues/issues/1491

Current failure (link: https://app.circleci.com/pipelines/github/astronomer/ap-airflow/1688/workflows/65626bd6-8423-48e5-84d6-57fcd8a16ec0/jobs/40780)
```
+ set +x
=======================
=======================
+ kubectl logs --all-containers -n airflow-14273 airflow-14273-webserver-cb86585f8-h9nst
+ tail -n 30
Error from server (BadRequest): container "webserver" in pod "airflow-14273-webserver-cb86585f8-h9nst" is waiting to start: PodInitializing
Waiting for host: airflow-14273-postgresql.airflow-14273.svc.cluster.local. 5432
Traceback (most recent call last):
  File "/usr/bin/airflow-migration-spinner", line 5, in <module>
    from astronomer.migration_spinner.command_line import main
  File "/usr/lib/python3.7/site-packages/astronomer/migration_spinner/command_line.py", line 7, in <module>
    from airflow import settings, version
  File "/usr/lib/python3.7/site-packages/airflow/__init__.py", line 31, in <module>
    from airflow.utils.log.logging_mixin import LoggingMixin
  File "/usr/lib/python3.7/site-packages/airflow/utils/__init__.py", line 24, in <module>
    from .decorators import apply_defaults as _apply_defaults
  File "/usr/lib/python3.7/site-packages/airflow/utils/decorators.py", line 36, in <module>
    from airflow import settings
  File "/usr/lib/python3.7/site-packages/airflow/settings.py", line 37, in <module>
    from airflow.configuration import conf, AIRFLOW_HOME, WEBSERVER_CONFIG  # NOQA F401
  File "/usr/lib/python3.7/site-packages/airflow/configuration.py", line 715, in <module>
    with open(TEST_CONFIG_FILE, 'w') as f:
PermissionError: [Errno 13] Permission denied: '/usr/local/airflow/unittests.cfg'
+ set +x
=======================
```
