### PR TITLE
Fix issues with 2.1.3-1.dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1403,7 +1403,7 @@ workflows:
           name: push-2.1.3-buster
           tag: "2.1.3-buster"
           dev_build: true
-          extra_tags: "2.1.3-buster-${CIRCLE_BUILD_NUM},2.1.3-1-dev-buster"
+          extra_tags: "2.1.3-buster-${CIRCLE_BUILD_NUM},2.1.3-1.dev-buster"
           context:
             - quay.io
             - docker.io
@@ -1418,7 +1418,7 @@ workflows:
           name: push-2.1.3-buster-onbuild
           tag: "2.1.3-buster-onbuild"
           dev_build: true
-          extra_tags: "2.1.3-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.3-1-dev-buster-onbuild"
+          extra_tags: "2.1.3-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.3-1.dev-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1476,7 +1476,7 @@ workflows:
           name: push-2.1.3-buster-onbuild
           tag: "2.1.3-buster-onbuild"
           dev_build: true
-          extra_tags: "2.1.3-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.3-1-dev-buster-onbuild"
+          extra_tags: "2.1.3-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.3-1.dev-buster-onbuild"
           context:
             - quay.io
             - docker.io

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -20,7 +20,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.0.2-4", ["buster"]),
     ("2.1.0-3", ["buster"]),
     ("2.1.1-2", ["buster"]),
-    ("2.1.3-1-dev", ["buster"]),
+    ("2.1.3-1.dev", ["buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.1.3/buster/Dockerfile
+++ b/2.1.3/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.3-1-*"
+ARG VERSION="2.1.3-1.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.3"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.3-1-*"
+ARG VERSION="2.1.3-1.*"
 ARG AIRFLOW_VERSION="2.1.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.1.3/buster/build-time-pip-constraints.txt
+++ b/2.1.3/buster/build-time-pip-constraints.txt
@@ -225,7 +225,7 @@ google-api-core==1.31.2
 google-api-python-client==1.12.8
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.4.5
-google-auth==1.34.0
+google-auth==1.35.0
 google-cloud-appengine-logging==0.1.4
 google-cloud-audit-log==0.1.0
 google-cloud-automl==2.4.2
@@ -442,7 +442,7 @@ sentry-sdk==1.3.1
 setproctitle==1.2.2
 simple-salesforce==1.11.3
 six==1.16.0
-slack-sdk==3.9.0
+slack-sdk==3.9.1
 smmap==4.0.0
 snakebite-py3==3.0.5
 sniffio==1.2.0


### PR DESCRIPTION
There were some minor issues with `2.1.3-1.dev`

- Version should be `2.1.3-1.dev` instead of `2.1.3-1-dev`
- Updates latest constraints from https://github.com/apache/airflow/blob/constraints-2-1/constraints-3.6.txt

