### PR TITLE
Use Debian Buster Explicitly

### DIFF
--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 

--- a/2.1.3/buster/Dockerfile
+++ b/2.1.3/buster/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
-ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 


### PR DESCRIPTION
Debian released Bullseye - https://www.zdnet.com/article/linux-stable-debian-11-bullseye-arrives-with-five-years-of-support/ yday and the default python images now use bullseye instead of buster:

```
root@d5c073a24b9a:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
root@d5c073a24b9a:/#airflow
```

This PR for now makes the default as buster explicitly:

```
❯ docker run -it python:3.7-slim-buster bash
root@cd0c5a29b1b5:/# cat etc/os-release
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

