### PR TITLE
Pin `elasticsearch` python client version to `7.13.4`

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -101,6 +101,8 @@ def test_elasticsearch_version(webserver):
     version = elasticsearch_module['version']
     assert semantic_version(version) >= semantic_version('5.5.3'), \
         "elasticsearch module must be version 5.5.3 or greater"
+    assert semantic_version(version) < semantic_version('7.14'), \
+        "elasticsearch module must be less than 7.14 until https://github.com/astronomer/issues/issues/3347 is fixed"
 
 
 @pytest.mark.skipif(airflow_2, reason="Not needed for Airflow>=2")

--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -27,4 +27,4 @@ pyOpenSSL<20.0
 kubernetes<12.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.10/alpine3.10/include/pip-constraints.txt
+++ b/1.10.10/alpine3.10/include/pip-constraints.txt
@@ -25,3 +25,6 @@ pyOpenSSL<20.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.10/buster/include/pip-constraints.txt
+++ b/1.10.10/buster/include/pip-constraints.txt
@@ -12,3 +12,6 @@ azure-storage<0.37.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.10/buster/include/pip-constraints.txt
+++ b/1.10.10/buster/include/pip-constraints.txt
@@ -14,4 +14,4 @@ azure-storage<0.37.0
 kubernetes<12.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.12/alpine3.10/include/pip-constraints.txt
+++ b/1.10.12/alpine3.10/include/pip-constraints.txt
@@ -27,4 +27,4 @@ pyOpenSSL<20.0
 kubernetes<12.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.12/alpine3.10/include/pip-constraints.txt
+++ b/1.10.12/alpine3.10/include/pip-constraints.txt
@@ -25,3 +25,6 @@ pyOpenSSL<20.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.12/buster/include/pip-constraints.txt
+++ b/1.10.12/buster/include/pip-constraints.txt
@@ -7,3 +7,6 @@ azure-storage<0.37.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.12/buster/include/pip-constraints.txt
+++ b/1.10.12/buster/include/pip-constraints.txt
@@ -9,4 +9,4 @@ azure-storage<0.37.0
 kubernetes<12.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.14/buster/include/pip-constraints.txt
+++ b/1.10.14/buster/include/pip-constraints.txt
@@ -6,4 +6,4 @@ redis!=3.4.0
 azure-storage<0.37.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.14/buster/include/pip-constraints.txt
+++ b/1.10.14/buster/include/pip-constraints.txt
@@ -4,3 +4,6 @@ redis!=3.4.0
 
 # Details: https://github.com/apache/airflow/pull/8833
 azure-storage<0.37.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.15/buster/include/pip-constraints.txt
+++ b/1.10.15/buster/include/pip-constraints.txt
@@ -6,4 +6,4 @@ redis!=3.4.0
 azure-storage<0.37.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.15/buster/include/pip-constraints.txt
+++ b/1.10.15/buster/include/pip-constraints.txt
@@ -4,3 +4,6 @@ redis!=3.4.0
 
 # Details: https://github.com/apache/airflow/pull/8833
 azure-storage<0.37.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -28,4 +28,4 @@ pyOpenSSL<20.0
 kubernetes<12.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/1.10.7/alpine3.10/include/pip-constraints.txt
+++ b/1.10.7/alpine3.10/include/pip-constraints.txt
@@ -26,3 +26,6 @@ pyOpenSSL<20.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.7/buster/include/pip-constraints.txt
+++ b/1.10.7/buster/include/pip-constraints.txt
@@ -13,3 +13,6 @@ azure-storage<0.37.0
 
 # https://github.com/apache/airflow/pull/11974
 kubernetes<12.0
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/1.10.7/buster/include/pip-constraints.txt
+++ b/1.10.7/buster/include/pip-constraints.txt
@@ -15,4 +15,4 @@ azure-storage<0.37.0
 kubernetes<12.0
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/2.0.0/buster/include/pip-constraints.txt
+++ b/2.0.0/buster/include/pip-constraints.txt
@@ -1,4 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/2.0.0/buster/include/pip-constraints.txt
+++ b/2.0.0/buster/include/pip-constraints.txt
@@ -1,1 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/2.0.2/buster/include/pip-constraints.txt
+++ b/2.0.2/buster/include/pip-constraints.txt
@@ -1,4 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/2.0.2/buster/include/pip-constraints.txt
+++ b/2.0.2/buster/include/pip-constraints.txt
@@ -1,1 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/2.1.0/buster/include/pip-constraints.txt
+++ b/2.1.0/buster/include/pip-constraints.txt
@@ -1,4 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/2.1.0/buster/include/pip-constraints.txt
+++ b/2.1.0/buster/include/pip-constraints.txt
@@ -1,1 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/2.1.1/buster/include/pip-constraints.txt
+++ b/2.1.1/buster/include/pip-constraints.txt
@@ -1,4 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/2.1.1/buster/include/pip-constraints.txt
+++ b/2.1.1/buster/include/pip-constraints.txt
@@ -1,1 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4

--- a/2.1.3/buster/build-time-pip-constraints.txt
+++ b/2.1.3/buster/build-time-pip-constraints.txt
@@ -199,7 +199,7 @@ docutils==0.16
 ecdsa==0.17.0
 elasticsearch-dbapi==0.2.4
 elasticsearch-dsl==7.4.0
-elasticsearch==7.14.0
+elasticsearch==7.13.4
 email-validator==1.1.3
 entrypoints==0.3
 eventlet==0.31.1

--- a/2.1.3/buster/include/pip-constraints.txt
+++ b/2.1.3/buster/include/pip-constraints.txt
@@ -1,4 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
 
 # https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
-elasticsearch<7.13.4
+elasticsearch<7.14

--- a/2.1.3/buster/include/pip-constraints.txt
+++ b/2.1.3/buster/include/pip-constraints.txt
@@ -1,1 +1,4 @@
 # Constraint the version pip will install, if it ever needs to install a module
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.13.4


### PR DESCRIPTION
related to astronomer/issues#3347

Our images currently don't work with elasticsearch>=7.14 due to https://elasticsearch-py.readthedocs.io/en/v7.14.0/transports.html#product-check-on-first-request check.

The symptoms of the error are you won't see logs in the Webserver and if you inspect (in Dev mode) in your browser, it should show you this stacktrace: https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
Remediation for now, use `elasticsearch<=7.13.4`
