### PR TITLE
Use 2.0.2 version of Kubernetes Provider for 2.1.3

### DIFF
--- a/2.1.3/buster/build-time-pip-constraints.txt
+++ b/2.1.3/buster/build-time-pip-constraints.txt
@@ -61,7 +61,7 @@ apache-airflow-providers-apache-sqoop==1!2.0.1
 apache-airflow-providers-asana==1!1.0.0
 apache-airflow-providers-celery==1!2.0.0
 apache-airflow-providers-cloudant==1!2.0.0
-apache-airflow-providers-cncf-kubernetes==1!2.0.1
+apache-airflow-providers-cncf-kubernetes==1!2.0.2
 apache-airflow-providers-databricks==1!2.0.0
 apache-airflow-providers-datadog==1!2.0.0
 apache-airflow-providers-dingding==1!2.0.0


### PR DESCRIPTION
This version includes https://github.com/apache/airflow/pull/17798 + Istio patch from https://github.com/astronomer/airflow/tree/providers-cncf-kubernetes-astro/2.0.2
