### PR TITLE
Bump epoch for buster images to fix CVEs

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -260,11 +260,13 @@ def test_airflow_trigger_dags(scheduler):
 def test_airflow_configs(scheduler, docker_client):
     """Verify certain Airflow configurations"""
     distro = get_label(docker_client, "io.astronomer.docker.distro")
-    relative_config_path = "config_templates/default_airflow.cfg"
-    airflow_dir = str(scheduler.check_output(
-        'python -c "import airflow; import os; print(os.path.dirname(airflow.__file__))"'
+    relative_config_path = "site-packages/airflow/config_templates/default_airflow.cfg"
+    python_install_dir = str(scheduler.check_output(
+        'python -c "import os; print(os.path.dirname(os.__file__))"'
     )).strip()
-    config_file_path = f"{airflow_dir}/{relative_config_path}"
+    config_file_path = f"{python_install_dir}/{relative_config_path}"
+
+    assert scheduler.file(config_file_path).exists, f"{relative_config_path} does not exist !"
 
     if distro == "debian":
         expected_run_as_user = "50000"

--- a/1.10.10/buster/Dockerfile
+++ b/1.10.10/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint "https://raw.githubusercontent.
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/1.10.7/buster/Dockerfile
+++ b/1.10.7/buster/Dockerfile
@@ -137,7 +137,7 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.0/buster/Dockerfile
+++ b/2.0.0/buster/Dockerfile
@@ -138,7 +138,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -138,7 +138,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -138,7 +138,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -138,7 +138,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \

--- a/2.1.3/buster/Dockerfile
+++ b/2.1.3/buster/Dockerfile
@@ -138,7 +138,7 @@ RUN pip install "${AIRFLOW_MODULE}" \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="8"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="9"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
fixes `CVE-2021-3711`. This does not affect 2.2.0

