### PR TITLE
2.2.0: Keep Celery 5

### DIFF
--- a/2.2.0/buster/Dockerfile
+++ b/2.2.0/buster/Dockerfile
@@ -111,7 +111,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION="2.2.0-1.*"
-ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
+ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.0"
 
@@ -127,7 +127,7 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 
 # Pip install airflow and astro security manager
-RUN pip install "${AIRFLOW_MODULE}" \
+RUN pip install "${AIRFLOW_MODULE}" celery flower \
     --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager~=1.6"

--- a/2.2.0/buster/build-time-pip-constraints.txt
+++ b/2.2.0/buster/build-time-pip-constraints.txt
@@ -41,7 +41,7 @@ alabaster==0.7.12
 alembic==1.6.5
 aliyun-python-sdk-core==2.13.35
 aliyun-python-sdk-kms==2.15.0
-amqp==2.6.1
+amqp==5.0.6
 analytics-python==1.4.0
 ansiwrap==0.8.4
 anyio==3.3.0
@@ -165,7 +165,7 @@ cached-property==1.5.2
 cachetools==4.2.2
 cassandra-driver==3.25.0
 cattrs==1.5.0
-celery==4.4.7
+celery==5.1.2
 certifi==2020.12.5
 cffi==1.14.6
 cfgv==3.3.0
@@ -174,6 +174,9 @@ chardet==4.0.0
 charset-normalizer==2.0.4
 click==7.1.2
 clickclick==20.10.2
+click-didyoumean==0.0.3
+click-plugins==1.1.1
+click-repl==0.2.0
 cloudant==2.14.0
 cloudpickle==1.4.1
 colorama==0.4.4
@@ -211,7 +214,7 @@ fissix==21.6.6
 flake8-colors==0.1.9
 flake8==3.9.2
 flaky==3.7.0
-flower==0.9.7
+flower==1.0.0
 freezegun==1.1.0
 fsspec==2021.7.0
 future==0.18.2
@@ -299,7 +302,7 @@ jupyter-client==7.0.1
 jupyter-core==4.7.1
 jwcrypto==1.0
 keyring==23.1.0
-kombu==4.6.11
+kombu==5.1.0
 kubernetes==11.0.0
 kylinpy==2.8.4
 lazy-object-proxy==1.4.3
@@ -506,7 +509,7 @@ unicodecsv==0.14.1
 uritemplate==3.0.1
 urllib3==1.26.6
 vertica-python==1.0.1
-vine==1.3.0
+vine==5.0.0
 virtualenv==20.7.2
 volatile==2.1.0
 watchtower==1.0.6


### PR DESCRIPTION
**What this PR does / why we need it**:

2.2.0 core needs celery 5, but the newest release of the celery provider wants 4 (but it should run with 5). Update constraints and avoid installing the celery provider so we have celery 5 in the image.

This is only needed until we have a version of the provider that supports celery 5.

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/bin/test-airflow-image.py
