### PR TITLE
Release 2.0.2-5, 2.1.0-4 and 2.1.1-3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1001,8 +1001,7 @@ workflows:
           name: build-2.0.2-buster
           airflow_version: 2.0.2
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.0.2
             - static-checks
@@ -1021,8 +1020,8 @@ workflows:
       - push:
           name: push-2.0.2-buster
           tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-5.dev-buster"
+          dev_build: false
+          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM},2.0.2-5-buster"
           context:
             - quay.io
             - docker.io
@@ -1036,8 +1035,8 @@ workflows:
       - push:
           name: push-2.0.2-buster-onbuild
           tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-5.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-5-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1129,8 +1128,7 @@ workflows:
           name: build-2.1.0-buster
           airflow_version: 2.1.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.0.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.1.0
             - static-checks
@@ -1149,8 +1147,8 @@ workflows:
       - push:
           name: push-2.1.0-buster
           tag: "2.1.0-buster"
-          dev_build: true
-          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM},2.1.0-4.dev-buster"
+          dev_build: false
+          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM},2.1.0-4-buster"
           context:
             - quay.io
             - docker.io
@@ -1164,8 +1162,8 @@ workflows:
       - push:
           name: push-2.1.0-buster-onbuild
           tag: "2.1.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-4.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-4-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1257,8 +1255,7 @@ workflows:
           name: build-2.1.1-buster
           airflow_version: 2.1.1
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.1.build)"
+          dev_build: false
           requires:
             - Need-Approval-2.1.1
             - static-checks
@@ -1277,8 +1274,8 @@ workflows:
       - push:
           name: push-2.1.1-buster
           tag: "2.1.1-buster"
-          dev_build: true
-          extra_tags: "2.1.1-buster-${CIRCLE_BUILD_NUM},2.1.1-3.dev-buster"
+          dev_build: false
+          extra_tags: "2.1.1-buster-${CIRCLE_BUILD_NUM},2.1.1-3-buster"
           context:
             - quay.io
             - docker.io
@@ -1292,8 +1289,8 @@ workflows:
       - push:
           name: push-2.1.1-buster-onbuild
           tag: "2.1.1-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.1-3.dev-buster-onbuild"
+          dev_build: false
+          extra_tags: "2.1.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.1-3-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1569,150 +1566,6 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          name: build-2.0.2-buster
-          airflow_version: 2.0.2
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.0.2.build)"
-      - scan-trivy:
-          name: scan-trivy-2.0.2-buster-onbuild
-          airflow_version: 2.0.2
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.0.2-buster
-      - test:
-          name: test-2.0.2-buster-images
-          tag: "2.0.2-buster"
-          requires:
-            - build-2.0.2-buster
-      - push:
-          name: push-2.0.2-buster
-          tag: "2.0.2-buster"
-          dev_build: true
-          extra_tags: "2.0.2-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.0.2-buster-onbuild
-          tag: "2.0.2-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.0.2-buster-onbuild-${CIRCLE_BUILD_NUM},2.0.2-5.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.0.2-buster-onbuild
-            - test-2.0.2-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.1.0-buster
-          airflow_version: 2.1.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.0.build)"
-      - scan-trivy:
-          name: scan-trivy-2.1.0-buster-onbuild
-          airflow_version: 2.1.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.1.0-buster
-      - test:
-          name: test-2.1.0-buster-images
-          tag: "2.1.0-buster"
-          requires:
-            - build-2.1.0-buster
-      - push:
-          name: push-2.1.0-buster
-          tag: "2.1.0-buster"
-          dev_build: true
-          extra_tags: "2.1.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.0-buster-onbuild
-            - test-2.1.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.1.0-buster-onbuild
-          tag: "2.1.0-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.0-4.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.0-buster-onbuild
-            - test-2.1.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.1.1-buster
-          airflow_version: 2.1.1
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.1.1.build)"
-      - scan-trivy:
-          name: scan-trivy-2.1.1-buster-onbuild
-          airflow_version: 2.1.1
-          distribution: buster
-          distribution_name: buster-onbuild
-          requires:
-            - build-2.1.1-buster
-      - test:
-          name: test-2.1.1-buster-images
-          tag: "2.1.1-buster"
-          requires:
-            - build-2.1.1-buster
-      - push:
-          name: push-2.1.1-buster
-          tag: "2.1.1-buster"
-          dev_build: true
-          extra_tags: "2.1.1-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.1-buster-onbuild
-            - test-2.1.1-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.1.1-buster-onbuild
-          tag: "2.1.1-buster-onbuild"
-          dev_build: true
-          extra_tags: "2.1.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.1.1-3.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.1.1-buster-onbuild
-            - test-2.1.1-buster-images
-          filters:
-            branches:
-              only:
-                - master
       - build:
           name: build-2.2.0-buster
           airflow_version: 2.2.0

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -17,9 +17,9 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.14-4", ["buster"]),
     ("1.10.15-3", ["buster"]),
     ("2.0.0-9", ["buster"]),
-    ("2.0.2-5.dev", ["buster"]),
-    ("2.1.0-4.dev", ["buster"]),
-    ("2.1.1-3.dev", ["buster"]),
+    ("2.0.2-5", ["buster"]),
+    ("2.1.0-4", ["buster"]),
+    ("2.1.1-3", ["buster"]),
     ("2.1.3-1", ["buster"]),
     ("2.2.0-1.dev", ["buster"]),
 ])

--- a/2.0.0/CHANGELOG.md
+++ b/2.0.0/CHANGELOG.md
@@ -5,7 +5,9 @@ Astronomer Certified 2.0.0-9, 2021-09-08
 
 ## Bugfixes
 
-- Add missing permissions to varimport (#17468) ([commit](https://github.com/astronomer/airflow/commit/b1d28ec86))
+- Add missing permissions to `varimport` (#17468) ([commit](https://github.com/astronomer/airflow/commit/b1d28ec86))
+- Dockerfile: Pin `elasticsearch` python client version to `7.13.4` (#294)
+- Dockerfile: Update pip to latest version in buster images (#289)
 
 Astronomer Certified 2.0.0-8, 2021-07-13
 ----------------------------------------

--- a/2.0.2/CHANGELOG.md
+++ b/2.0.2/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-Astronomer Certified 2.0.2-5, TBD
----------------------------------
+Astronomer Certified 2.0.2-5, 2021-09-08
+----------------------------------------
 
 ### Bugfixes
 
-- Add missing permissions to varimport (#17468) ([commit](https://github.com/astronomer/airflow/commit/2bbaec8b7))
+- Add missing permissions to `varimport` (#17468) ([commit](https://github.com/astronomer/airflow/commit/2bbaec8b7))
+- Dockerfile: Pin `elasticsearch` python client version to `7.13.4` (#294)
+- Dockerfile: Update pip to latest version in buster images (#289)
 
 Astronomer Certified 2.0.2-4, 2021-07-13
 ----------------------------------------

--- a/2.0.2/buster/Dockerfile
+++ b/2.0.2/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-5.*"
+ARG VERSION="2.0.2-5"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.0.2"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.0.2-5.*"
+ARG VERSION="2.0.2-5"
 ARG AIRFLOW_VERSION="2.0.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.1.0/CHANGELOG.md
+++ b/2.1.0/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-Astronomer Certified 2.1.0-4, TBD
+Astronomer Certified 2.1.0-4, 2021-09-08
 ----------------------------------------
 
 ## Bugfixes
 
-- Add missing permissions to varimport (#17468) ([commit](https://github.com/astronomer/airflow/commit/57f1629f8))
+- Add missing permissions to `varimport` (#17468) ([commit](https://github.com/astronomer/airflow/commit/57f1629f8))
+- Dockerfile: Pin `elasticsearch` python client version to `7.13.4` (#294)
+- Dockerfile: Update pip to latest version in buster images (#289)
 
 Astronomer Certified 2.1.0-3, 2021-07-13
 ----------------------------------------

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-4.*"
+ARG VERSION="2.1.0-4"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.0"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-4.*"
+ARG VERSION="2.1.0-4"
 ARG AIRFLOW_VERSION="2.1.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.1.1/CHANGELOG.md
+++ b/2.1.1/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-Astronomer Certified 2.1.1-3, TBD
+Astronomer Certified 2.1.1-3, 2021-09-08
 ----------------------------------------
 
 ### Bugfixes
 
-
-- Add missing permissions to varimport (#17468) ([commit](https://github.com/astronomer/airflow/commit/f5c0a8db1))
+- Add missing permissions to `varimport` (#17468) ([commit](https://github.com/astronomer/airflow/commit/f5c0a8db1))
+- Dockerfile: Pin `elasticsearch` python client version to `7.13.4` (#294)
+- Dockerfile: Update pip to latest version in buster images (#289)
 
 Astronomer Certified 2.1.1-2, 2021-07-13
 ----------------------------------------

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.1-3.*"
+ARG VERSION="2.1.1-3"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.1"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.1-3.*"
+ARG VERSION="2.1.1-3"
 ARG AIRFLOW_VERSION="2.1.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
- Releases 2.0.2-5, 2.1.0-4 and 2.1.1-3

https://github.com/astronomer/airflow/releases/tag/v2.1.1%2Bastro.3
https://github.com/astronomer/airflow/releases/tag/v2.1.0%2Bastro.4
https://github.com/astronomer/airflow/releases/tag/v2.0.2%2Bastro.5


