### PR TITLE
Revert "Require new security manager on Airflow 2.2 (#311)"

### DIFF
--- a/2.2.0/buster/Dockerfile
+++ b/2.2.0/buster/Dockerfile
@@ -130,7 +130,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 RUN pip install "${AIRFLOW_MODULE}" celery flower \
     --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.7"
+	&& pip install "astronomer-fab-security-manager~=1.6"
 
 
 ## move this to same layer as airflow because its from tag.


### PR DESCRIPTION
This reverts commit 43b89bf7d50f605ab9a42bb86b50b7336d2e6e55.

The new security manager appears to not function properly. It causes a redirect to `/{deployment}/airflow/access-denied/`, which 404's.