### PR TITLE
Ignore `CVE-2020-1747` on 2.2.0

### DIFF
--- a/2.2.0/buster/trivyignore
+++ b/2.2.0/buster/trivyignore
@@ -15,3 +15,8 @@ CVE-2021-27290
 
 #pollution vulnerability
 CVE-2020-7774
+
+# False Positive - We are using PyYaml version that is not vulnerable
+# and Kubernetes Python client is already using safe_load
+# Details: https://github.com/astronomer/issues-airflow/issues/39
+CVE-2020-1747


### PR DESCRIPTION
closes https://github.com/astronomer/issues-airflow/issues/39
