### PR TITLE
Remove distro name from 2.3.0+ image tags

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -125,7 +125,7 @@ workflows:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           dev_build: {{ dev_build }}
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}{% if airflow_version.split('.') | map('int') | list < '2.3.0'.split('.') | map('int') | list %}-{{ distribution }}{% endif %}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}{% if airflow_version.split('.') | map('int') | list < '2.3.0'.split('.') | map('int') | list %}-{{ distribution }}{% endif %}-onbuild"
           context:
             - quay.io
             - docker.io
@@ -188,9 +188,9 @@ workflows:
                 - master
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
-          tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          tag: "{{ airflow_version }}{% if airflow_version.split('.') | map('int') | list < '2.3.0'.split('.') | map('int') | list %}-{{ distribution }}{% endif %}-onbuild"
           dev_build: true
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}{% if airflow_version.split('.') | map('int') | list < '2.3.0'.split('.') | map('int') | list %}-{{ distribution }}{% endif %}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}{% if airflow_version.split('.') | map('int') | list < '2.3.0'.split('.') | map('int') | list %}-{{ distribution }}{% endif %}-onbuild"
           context:
             - quay.io
             - docker.io


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the `-buster` substring from image tags for 2.3.0 and beyond:

```diff
diff --git a/.circleci/config.yml.before b/.circleci/config.yml.after
index 4903987..3c69b30 100644
--- a/.circleci/config.yml.before
+++ b/.circleci/config.yml.after
@@ -1620,7 +1620,7 @@ workflows:
           name: push-2.3.0-bullseye-onbuild
           tag: "2.3.0-bullseye-onbuild"
           dev_build: false
-          extra_tags: "2.3.0-bullseye-onbuild-${CIRCLE_BUILD_NUM},2.3.0-1-bullseye-onbuild"
+          extra_tags: "2.3.0-onbuild-${CIRCLE_BUILD_NUM},2.3.0-1-onbuild"
           context:
             - quay.io
             - docker.io
```

**Special notes for your reviewer**:

This doesn't change any existing distributions or Airflow versions. And I wasn't sure how I should gate the new tag name logic, so I did it by Airflow version. If there's a better way, please let me know.
