### PR TITLE
Fix values used for tests. Update kind/helm/k8s versions.

### DIFF
--- a/.circleci/bin/install-ci-tools
+++ b/.circleci/bin/install-ci-tools
@@ -4,10 +4,10 @@
 set -e
 
 if [[ -z "${KIND_VERSION}" ]]; then
-  KIND_VERSION="0.7.0"
+  KIND_VERSION="0.11.1"
 fi
 if [[ -z "${HELM_VERSION}" ]]; then
-  HELM_VERSION="3.3.4"
+  HELM_VERSION="3.7.1"
 fi
 
 OS=$(uname | tr '[:upper:]' '[:lower:]')

--- a/.circleci/bin/start-kind-cluster
+++ b/.circleci/bin/start-kind-cluster
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ -z "${KUBE_VERSION}" ]]; then
-  export KUBE_VERSION='v1.15.6'
+  export KUBE_VERSION='v1.21.1'
 fi
 
 set +e

--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -75,16 +75,16 @@ WATCH_PID=$!
 
 kubectl create namespace $NAMESPACE
 helm install --namespace $NAMESPACE \
-  --set defaultAirflowRepository=$REPOSITORY \
-  --set defaultAirflowTag=$TEST_TAG \
-  --set images.airflow.repository=$REPOSITORY \
-  --set images.airflow.tag=$TEST_TAG \
-  --set images.airflow.pullPolicy=Never \
-  --set images.flower.pullPolicy=Never \
-  --set executor=KubernetesExecutor \
-  --set airflowVersion=$AIRFLOW_VERSION \
-  --set uid=$IMAGE_UID \
-  --set gid=$IMAGE_GID \
+  --set airflow.defaultAirflowRepository=$REPOSITORY \
+  --set airflow.defaultAirflowTag=$TEST_TAG \
+  --set airflow.images.airflow.repository=$REPOSITORY \
+  --set airflow.images.airflow.tag=$TEST_TAG \
+  --set airflow.images.airflow.pullPolicy=Never \
+  --set airflow.images.flower.pullPolicy=Never \
+  --set airflow.executor=KubernetesExecutor \
+  --set airflow.airflowVersion=$AIRFLOW_VERSION \
+  --set airflow.uid=$IMAGE_UID \
+  --set airflow.gid=$IMAGE_GID \
   --version=$CHART_VERSION \
   $RELEASE_NAME astronomer/airflow
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new version of the `astronomer/airflow` chart use the OSS chart as a subchart, so all the values we pass needs to be under `airflow`.

I also updated the versions used for helm, kind, and k8s, as they were all old, and kind/k8s failed for me locally.

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or Airflow version is added, please add in .circleci/generate_circleci_config.py and run the script
- [ ] If a new distribution or Airflow version is added, there Dockerfile in all base image directories
- [ ] If a new distribution is added, it is supported by all Airflow versions
- [ ] If a new Airflow version is added, it supports all distributions
- [ ] If changing an image, add applicable test in .circleci/bin/test-airflow-image.py
