### PR TITLE
Release AC 2.2.1-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1666,8 +1666,7 @@ workflows:
           name: build-2.2.1-bullseye
           airflow_version: 2.2.1
           distribution_name: bullseye
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.1.build)"
+          dev_build: false
           image_name: "ap-airflow:2.2.1"
           requires:
             - Need-Approval-2.2.1
@@ -1687,9 +1686,9 @@ workflows:
             - build-2.2.1-bullseye
       - push:
           name: push-2.2.1-bullseye
-          dev_build: true
+          dev_build: false
           tag: "2.2.1"
-          extra_tags: "2.2.1-${CIRCLE_BUILD_NUM},2.2.1-1.dev"
+          extra_tags: "2.2.1-${CIRCLE_BUILD_NUM},2.2.1-1"
           context:
             - quay.io
             - docker.io
@@ -1702,9 +1701,9 @@ workflows:
                 - master
       - push:
           name: push-2.2.1-bullseye-onbuild
-          dev_build: true
+          dev_build: false
           tag: "2.2.1-onbuild"
-          extra_tags: "2.2.1-onbuild-${CIRCLE_BUILD_NUM},2.2.1-1.dev-onbuild"
+          extra_tags: "2.2.1-onbuild-${CIRCLE_BUILD_NUM},2.2.1-1-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1720,8 +1719,7 @@ workflows:
           name: build-2.2.1-buster
           airflow_version: 2.2.1
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.1.build)"
+          dev_build: false
           image_name: "ap-airflow:2.2.1-buster"
           requires:
             - Need-Approval-2.2.1
@@ -1741,9 +1739,9 @@ workflows:
             - build-2.2.1-buster
       - push:
           name: push-2.2.1-buster
-          dev_build: true
+          dev_build: false
           tag: "2.2.1-buster"
-          extra_tags: "2.2.1-buster-${CIRCLE_BUILD_NUM},2.2.1-1.dev-buster"
+          extra_tags: "2.2.1-buster-${CIRCLE_BUILD_NUM},2.2.1-1-buster"
           context:
             - quay.io
             - docker.io
@@ -1756,9 +1754,9 @@ workflows:
                 - master
       - push:
           name: push-2.2.1-buster-onbuild
-          dev_build: true
+          dev_build: false
           tag: "2.2.1-buster-onbuild"
-          extra_tags: "2.2.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.2.1-1.dev-buster-onbuild"
+          extra_tags: "2.2.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.2.1-1-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1875,106 +1873,6 @@ workflows:
           requires:
             - scan-trivy-2.2.0-buster-onbuild
             - test-2.2.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.2.1-bullseye
-          airflow_version: 2.2.1
-          distribution_name: bullseye
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.1.build)"
-          image_name: "ap-airflow:2.2.1"
-      - scan-trivy:
-          name: scan-trivy-2.2.1-bullseye-onbuild
-          airflow_version: 2.2.1
-          distribution: bullseye
-          distribution_name: bullseye-onbuild
-          image_name: "ap-airflow:2.2.1"
-          requires:
-            - build-2.2.1-bullseye
-      - test:
-          name: test-2.2.1-bullseye-images
-          tag: "2.2.1"
-          requires:
-            - build-2.2.1-bullseye
-      - push:
-          name: push-2.2.1-bullseye
-          dev_build: true
-          tag: "2.2.1"
-          extra_tags: "2.2.1-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.1-bullseye-onbuild
-            - test-2.2.1-bullseye-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.2.1-bullseye-onbuild
-          dev_build: true
-          tag: "2.2.1-onbuild"
-          extra_tags: "2.2.1-onbuild-${CIRCLE_BUILD_NUM},2.2.1-1.dev-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.1-bullseye-onbuild
-            - test-2.2.1-bullseye-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.2.1-buster
-          airflow_version: 2.2.1
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.1.build)"
-          image_name: "ap-airflow:2.2.1-buster"
-      - scan-trivy:
-          name: scan-trivy-2.2.1-buster-onbuild
-          airflow_version: 2.2.1
-          distribution: buster
-          distribution_name: buster-onbuild
-          image_name: "ap-airflow:2.2.1-buster"
-          requires:
-            - build-2.2.1-buster
-      - test:
-          name: test-2.2.1-buster-images
-          tag: "2.2.1-buster"
-          requires:
-            - build-2.2.1-buster
-      - push:
-          name: push-2.2.1-buster
-          dev_build: true
-          tag: "2.2.1-buster"
-          extra_tags: "2.2.1-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.1-buster-onbuild
-            - test-2.2.1-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.2.1-buster-onbuild
-          dev_build: true
-          tag: "2.2.1-buster-onbuild"
-          extra_tags: "2.2.1-buster-onbuild-${CIRCLE_BUILD_NUM},2.2.1-1.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.1-buster-onbuild
-            - test-2.2.1-buster-images
           filters:
             branches:
               only:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -22,7 +22,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.3-2", ["buster"]),
     ("2.1.4-2", ["buster"]),
     ("2.2.0-3.dev", ["bullseye", "buster"]),
-    ("2.2.1-1.dev", ["bullseye", "buster"]),
+    ("2.2.1-1", ["bullseye", "buster"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.2.1/CHANGELOG.md
+++ b/2.2.1/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-Astronomer Certified 2.2.1-1, TBD
+Astronomer Certified 2.2.1-1, 2021-11-02
 ----------------------------------------
 
 User-facing CHANGELOG for AC 2.2.1+astro.1 from Airflow 2.2.1:
 
 ### Bugfixes
 
-- Bugfix: Check next run exists before reading data interval (#19307) ([commit](https://github.com/astronomer/airflow/commit/0cca4bfb6922e54f940ae8e8fd415c9cf96e21ef))
+- Add `DagRun.logical_date` as a property (apache#19198) ([commit](https://github.com/astronomer/airflow/commit/77140e981405ab5d732f9b0b82f666d4c26e5886))
+- Fix Unexpected commit error in `SchedulerJob` (apache#19213) ([commit](https://github.com/astronomer/airflow/commit/fdb0aefcffd0e2a966c33ee6641987aa8f8fa33b))
+- Bugfix: Check next run exists before reading data interval (apache#19307) ([commit](https://github.com/astronomer/airflow/commit/0cca4bfb6922e54f940ae8e8fd415c9cf96e21ef))
+- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods ([commit](https://github.com/astronomer/airflow/commit/d56ba747a8b7263d0bfe83e3ac46b77a4ec0d113))
 - [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/98f53fa7ccf0c441b04e223d8ce6f4f365965eb9))
-- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/d56ba747a8b7263d0bfe83e3ac46b77a4ec0d113))
 - [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/15c339b563e5d93e79c0bc4534c05e44aface42a))

--- a/2.2.1/bullseye/Dockerfile
+++ b/2.2.1/bullseye/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.1-1.*"
+ARG VERSION="2.2.1-1"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.1"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.1-1.*"
+ARG VERSION="2.2.1-1"
 ARG AIRFLOW_VERSION="2.2.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v2.2.1%2Bastro.1

# Changelog

Astronomer Certified 2.2.1-1, 2021-11-02
----------------------------------------

User-facing CHANGELOG for AC 2.2.1+astro.1 from Airflow 2.2.1:

### Bugfixes

- Add `DagRun.logical_date` as a property (apache#19198) ([commit](https://github.com/astronomer/airflow/commit/77140e981405ab5d732f9b0b82f666d4c26e5886))
- Fix Unexpected commit error in `SchedulerJob` (apache#19213) ([commit](https://github.com/astronomer/airflow/commit/fdb0aefcffd0e2a966c33ee6641987aa8f8fa33b))
- Bugfix: Check next run exists before reading data interval (apache#19307) ([commit](https://github.com/astronomer/airflow/commit/0cca4bfb6922e54f940ae8e8fd415c9cf96e21ef))
- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods ([commit](https://github.com/astronomer/airflow/commit/d56ba747a8b7263d0bfe83e3ac46b77a4ec0d113))
- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/98f53fa7ccf0c441b04e223d8ce6f4f365965eb9))
- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/15c339b563e5d93e79c0bc4534c05e44aface42a))

