### PR TITLE
Release AC 2.2.0-3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1482,8 +1482,7 @@ workflows:
           name: build-2.2.0-bullseye
           airflow_version: 2.2.0
           distribution_name: bullseye
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.0.build)"
+          dev_build: false
           image_name: "ap-airflow:2.2.0"
           requires:
             - Need-Approval-2.2.0
@@ -1503,9 +1502,9 @@ workflows:
             - build-2.2.0-bullseye
       - push:
           name: push-2.2.0-bullseye
-          dev_build: true
+          dev_build: false
           tag: "2.2.0"
-          extra_tags: "2.2.0-${CIRCLE_BUILD_NUM},2.2.0-3.dev"
+          extra_tags: "2.2.0-${CIRCLE_BUILD_NUM},2.2.0-3"
           context:
             - quay.io
             - docker.io
@@ -1518,9 +1517,9 @@ workflows:
                 - master
       - push:
           name: push-2.2.0-bullseye-onbuild
-          dev_build: true
+          dev_build: false
           tag: "2.2.0-onbuild"
-          extra_tags: "2.2.0-onbuild-${CIRCLE_BUILD_NUM},2.2.0-3.dev-onbuild"
+          extra_tags: "2.2.0-onbuild-${CIRCLE_BUILD_NUM},2.2.0-3-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1536,8 +1535,7 @@ workflows:
           name: build-2.2.0-buster
           airflow_version: 2.2.0
           distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.0.build)"
+          dev_build: false
           image_name: "ap-airflow:2.2.0-buster"
           requires:
             - Need-Approval-2.2.0
@@ -1557,9 +1555,9 @@ workflows:
             - build-2.2.0-buster
       - push:
           name: push-2.2.0-buster
-          dev_build: true
+          dev_build: false
           tag: "2.2.0-buster"
-          extra_tags: "2.2.0-buster-${CIRCLE_BUILD_NUM},2.2.0-3.dev-buster"
+          extra_tags: "2.2.0-buster-${CIRCLE_BUILD_NUM},2.2.0-3-buster"
           context:
             - quay.io
             - docker.io
@@ -1572,9 +1570,9 @@ workflows:
                 - master
       - push:
           name: push-2.2.0-buster-onbuild
-          dev_build: true
+          dev_build: false
           tag: "2.2.0-buster-onbuild"
-          extra_tags: "2.2.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.2.0-3.dev-buster-onbuild"
+          extra_tags: "2.2.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.2.0-3-buster-onbuild"
           context:
             - quay.io
             - docker.io
@@ -1768,116 +1766,6 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          name: build-2.2.0-bullseye
-          airflow_version: 2.2.0
-          distribution_name: bullseye
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.0.build)"
-          image_name: "ap-airflow:2.2.0"
-      - scan-trivy:
-          name: scan-trivy-2.2.0-bullseye-onbuild
-          airflow_version: 2.2.0
-          distribution: bullseye
-          distribution_name: bullseye-onbuild
-          image_name: "ap-airflow:2.2.0"
-          requires:
-            - build-2.2.0-bullseye
-      - test:
-          name: test-2.2.0-bullseye-images
-          tag: "2.2.0"
-          requires:
-            - build-2.2.0-bullseye
-      - push:
-          name: push-2.2.0-bullseye
-          dev_build: true
-          tag: "2.2.0"
-          extra_tags: "2.2.0-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.0-bullseye-onbuild
-            - test-2.2.0-bullseye-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.2.0-bullseye-onbuild
-          dev_build: true
-          tag: "2.2.0-onbuild"
-          extra_tags: "2.2.0-onbuild-${CIRCLE_BUILD_NUM},2.2.0-3.dev-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.0-bullseye-onbuild
-            - test-2.2.0-bullseye-images
-          filters:
-            branches:
-              only:
-                - master
-      - build:
-          name: build-2.2.0-buster
-          airflow_version: 2.2.0
-          distribution_name: buster
-          dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-2.2.0.build)"
-          image_name: "ap-airflow:2.2.0-buster"
-      - scan-trivy:
-          name: scan-trivy-2.2.0-buster-onbuild
-          airflow_version: 2.2.0
-          distribution: buster
-          distribution_name: buster-onbuild
-          image_name: "ap-airflow:2.2.0-buster"
-          requires:
-            - build-2.2.0-buster
-      - test:
-          name: test-2.2.0-buster-images
-          tag: "2.2.0-buster"
-          requires:
-            - build-2.2.0-buster
-      - push:
-          name: push-2.2.0-buster
-          dev_build: true
-          tag: "2.2.0-buster"
-          extra_tags: "2.2.0-buster-${CIRCLE_BUILD_NUM}"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.0-buster-onbuild
-            - test-2.2.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-      - push:
-          name: push-2.2.0-buster-onbuild
-          dev_build: true
-          tag: "2.2.0-buster-onbuild"
-          extra_tags: "2.2.0-buster-onbuild-${CIRCLE_BUILD_NUM},2.2.0-3.dev-buster-onbuild"
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy-2.2.0-buster-onbuild
-            - test-2.2.0-buster-images
-          filters:
-            branches:
-              only:
-                - master
-
 jobs:
   static-checks:
     executor: machine-executor

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -21,7 +21,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.1-4", ["buster"]),
     ("2.1.3-2", ["buster"]),
     ("2.1.4-2", ["buster"]),
-    ("2.2.0-3.dev", ["bullseye", "buster"]),
+    ("2.2.0-3", ["bullseye", "buster"]),
     ("2.2.1-1", ["bullseye", "buster"]),
 ])
 

--- a/2.2.0/CHANGELOG.md
+++ b/2.2.0/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.2.0-3, TBD
+Astronomer Certified 2.2.0-3, 2021-11-02
 ----------------------------------------
 
 ### Bugfixes

--- a/2.2.0/bullseye/Dockerfile
+++ b/2.2.0/bullseye/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.0-3.*"
+ARG VERSION="2.2.0-3"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.0"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.0-3.*"
+ARG VERSION="2.2.0-3"
 ARG AIRFLOW_VERSION="2.2.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
https://github.com/astronomer/airflow/releases/tag/v2.2.0%2Bastro.3

# Changelog

Astronomer Certified 2.2.0-3, 2021-11-02
----------------------------------------

### Bugfixes

- Bugfix: Check next run exists before reading data interval (apache#19307) ([commit](https://github.com/astronomer/airflow/commit/c6dea7c7bb911c6863fee1a3a6fe21c9f5106eb2))
- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/3b6b0da59983bbdd68686f7dd172ee951b0d66e5))
- Try to move "dangling" rows in upgradedb (apache#18953) ([commit](https://github.com/astronomer/airflow/commit/e0584063d2cd4a8a93e7d83df620f4c6b6dc1adc))
- Revert "Handle DagRuns with no execution_date or dag_id." ([commit](https://github.com/astronomer/airflow/commit/2b0bc063f03b2378d7db52aa8717ab0bbe06e89c))
- Revert "Try to move "dangling" rows in upgradedb" ([commit](https://github.com/astronomer/airflow/commit/be7a722131cd0d25a434019f1acd5815acde5b2e))
- Fix Unexpected commit error in schedulerjob (apache#19213) ([commit](https://github.com/astronomer/airflow/commit/ec8dfba198a82644c54888dc9caf1c19a6930567))
- Don't install SQLAlchemy/Pendulum adapters for other DBs (apache#18745) ([commit](https://github.com/astronomer/airflow/commit/eb03da87599edfbd0b1fb615ab6df5811f9401f2))
- Add DagRun.logical_date as a property (apache#19198) ([commit](https://github.com/astronomer/airflow/commit/97314d3985f217be2501e7de8a8de9dc1a2a760b))
- Add test for interval timetable catchup=False (apache#19145) ([commit](https://github.com/astronomer/airflow/commit/a67c83866b6c0ce566ccb4ff61dae6e1b4b7ffe4))
- Clear ``ti.next_method`` and ``ti.next_kwargs`` on task finish (apache#19183) ([commit](https://github.com/astronomer/airflow/commit/a056d2957f98e3f7794dad50ecc7a96162c139c3))
- Create TI context with data interval compat layer (apache#19148) ([commit](https://github.com/astronomer/airflow/commit/c94f5faf358d6aa0f45121365ccbf2be767e6558))
- Faster PostgreSQL db migration to Airflow 2.2 (apache#19166) ([commit](https://github.com/astronomer/airflow/commit/68697ec7a5a9cd3983908ed2911d5cec773b7911))
- Fix queued dag runs changes catchup=False behaviour (apache#19130) ([commit](https://github.com/astronomer/airflow/commit/e6e6f3f49f18dd1f15e3f0ff88269f0de626b713))
- Prevent scheduler crash when serialized dag is missing (apache#19113) ([commit](https://github.com/astronomer/airflow/commit/78316ce18dec7d954c16e385c25113bde317640e))
- Ensure task state doesn't change when marked as failed/success/skipped (apache#19095) ([commit](https://github.com/astronomer/airflow/commit/2c569f4d45af5c7540004fa90ce17a48bb5cc18f))
- Change `ds`, `ts`, etc. back to use logical date (apache#19088) ([commit](https://github.com/astronomer/airflow/commit/d039c15147f427d1d1c6aff0e348147a9703e184))
- Relax packaging requirement (apache#19087) ([commit](https://github.com/astronomer/airflow/commit/f97b2ac38479c907a665bf674fa33845e6bbecd9))
- Row lock TI query in SchedulerJob._process_executor_events (apache#18975) ([commit](https://github.com/astronomer/airflow/commit/b7811c2165117dfde0bf9262de4e7ced827781db))
- Fix ``XCom.delete`` error in Airflow 2.2.0 (apache#18956) ([commit](https://github.com/astronomer/airflow/commit/0e8daeee355cf71b48eef0f68e15d4bef0fca79a))
- Fix catchup by limiting queued dagrun creation using max_active_runs (apache#18897) ([commit](https://github.com/astronomer/airflow/commit/e3fed9b272eef530b04a59261c75b8e03906a20c))
- Allow Param to support a default value of ``None`` (apache#19034) ([commit](https://github.com/astronomer/airflow/commit/bba4659faaf9ff667db97c9263bf4924406e7e50))
- Upgrade old DAG/task param format when deserializing from the DB (apache#18986) ([commit](https://github.com/astronomer/airflow/commit/5164f510456213026ce54cfb83a3c6b5911a8460))