### PR TITLE
Run pre-commit hooks accessing file serially

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,10 @@ repos:
         language: python
         files: "(common|update_dockerfiles).py$|Dockerfile$"
         entry: python3 .circleci/update_dockerfiles.py
+        require_serial: true
       - id: verify-changelog-entries
         name: Verifies individual CHANGELOG files for each release and adds links to README.md
         language: python
         files: "(common|verify_changelog_entries).py$|README.md$|CHANGELOG.md$"
         entry: python3 .circleci/verify_changelog_entries.py
+        require_serial: true


### PR DESCRIPTION
We had a race condition where the pre-commit hooks were accessing the files parallel-ly mainly for `verify-changelog-entries` and `update-dockerfiles` which caused empty files as `.read()` would entry file if the file is not closed.

This PR fixes it.

Example failure: https://app.circleci.com/pipelines/github/astronomer/ap-airflow/1969/workflows/7d9e8477-6a1c-4960-bf01-c03cf9394af5/jobs/47416