### PR TITLE
Release AC `2.2.1-2`, `2.2.0-4` and `2.1.4-3`

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -34,8 +34,8 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.1-4", ["buster"]),
     ("2.1.3-2", ["buster"]),
     ("2.1.4-2", ["buster"]),
-    ("2.2.0-4.dev", ["bullseye", "buster"]),
-    ("2.2.1-2.dev", ["bullseye", "buster"]),
+    ("2.2.0-4", ["bullseye", "buster"]),
+    ("2.2.1-2", ["bullseye", "buster"]),
     ("2.2.2-1.dev", ["bullseye"]),
 ])
 

--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -33,7 +33,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.0-5", ["buster"]),
     ("2.1.1-4", ["buster"]),
     ("2.1.3-2", ["buster"]),
-    ("2.1.4-2", ["buster"]),
+    ("2.1.4-3", ["buster"]),
     ("2.2.0-4", ["bullseye", "buster"]),
     ("2.2.1-2", ["bullseye", "buster"]),
     ("2.2.2-1.dev", ["bullseye"]),

--- a/2.1.4/CHANGELOG.md
+++ b/2.1.4/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+Astronomer Certified 2.1.4-3, 2021-11-05
+----------------------------------------
+
+### Bugfixes
+
+- Only mark SchedulerJobs as failed, not any jobs (#19375) ([commit](https://github.com/astronomer/airflow/commit/207154417))
+
 Astronomer Certified 2.1.4-2, 2021-09-24
 --------------------------------------------
 

--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.4-2"
+ARG VERSION="2.1.4-3"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.4"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.4-2"
+ARG VERSION="2.1.4-3"
 ARG AIRFLOW_VERSION="2.1.4"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.2.0/CHANGELOG.md
+++ b/2.2.0/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.2.0-4, TBD
+Astronomer Certified 2.2.0-4, 2021-11-04
 ----------------------------------------
 
 ### Bugfixes

--- a/2.2.0/CHANGELOG.md
+++ b/2.2.0/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.2.0-4, 2021-11-04
+Astronomer Certified 2.2.0-4, 2021-11-05
 ----------------------------------------
 
 ### Bugfixes

--- a/2.2.0/bullseye/Dockerfile
+++ b/2.2.0/bullseye/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.0-4.*"
+ARG VERSION="2.2.0-4"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.0"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.0-4.*"
+ARG VERSION="2.2.0-4"
 ARG AIRFLOW_VERSION="2.2.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.2.1/CHANGELOG.md
+++ b/2.2.1/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.2.1-2, TBD
+Astronomer Certified 2.2.1-2, 2021-11-04
 ----------------------------------------
 
 ### Bugfixes

--- a/2.2.1/CHANGELOG.md
+++ b/2.2.1/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.2.1-2, 2021-11-04
+Astronomer Certified 2.2.1-2, 2021-11-05
 ----------------------------------------
 
 ### Bugfixes

--- a/2.2.1/bullseye/Dockerfile
+++ b/2.2.1/bullseye/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.1-2.*"
+ARG VERSION="2.2.1-2"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.1"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.1-2.*"
+ARG VERSION="2.2.1-2"
 ARG AIRFLOW_VERSION="2.2.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
- https://github.com/astronomer/airflow/releases/tag/v2.2.1%2Bastro.2
- https://github.com/astronomer/airflow/releases/tag/v2.2.0%2Bastro.4
- https://github.com/astronomer/airflow/releases/tag/v2.1.4%2Bastro.3

Astronomer Certified 2.2.0-4, 2021-11-04
----------------------------------------

### Bugfixes

- Only mark SchedulerJobs as failed, not any jobs (#19375) ([commit](https://github.com/astronomer/airflow/commit/39ef7280940a39aa9a98ecf48422d0f876f12747))

Astronomer Certified 2.2.1-2, 2021-11-04
----------------------------------------

### Bugfixes

- Only mark SchedulerJobs as failed, not any jobs (#19375) ([commit](https://github.com/astronomer/airflow/commit/fa0b99891f56b71466299aa4729c7193e609b263))

Astronomer Certified 2.1.4-3, 2021-11-05
----------------------------------------

### Bugfixes

- Only mark SchedulerJobs as failed, not any jobs (#19375) ([commit](https://github.com/astronomer/airflow/commit/207154417))
