### PR TITLE
Fix `CVE-2021-21240` and `CVE-2021-33503` in 2.1.0

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -30,7 +30,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.15-4", ["buster"]),
     ("2.0.0-10", ["buster"]),
     ("2.0.2-6", ["buster"]),
-    ("2.1.0-5", ["buster"]),
+    ("2.1.0-6.dev", ["buster"]),
     ("2.1.1-5.dev", ["buster"]),
     ("2.1.3-2", ["buster"]),
     ("2.1.4-2", ["buster"]),

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-5"
+ARG VERSION="2.1.0-6.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.0"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.0-5"
+ARG VERSION="2.1.0-6.*"
 ARG AIRFLOW_VERSION="2.1.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.1.0/buster/build-time-pip-constraints.txt
+++ b/2.1.0/buster/build-time-pip-constraints.txt
@@ -135,7 +135,7 @@ grpcio-gcp==0.2.2
 gunicorn==20.1.0
 h11==0.12.0
 httpcore==0.13.3
-httplib2==0.17.4
+httplib2==0.19.1
 httpx==0.18.1
 humanize==3.5.0
 idna==2.10
@@ -233,7 +233,7 @@ typing-extensions==3.7.4.3
 typing-inspect==0.6.0
 unicodecsv==0.14.1
 uritemplate==3.0.1
-urllib3==1.25.11
+urllib3==1.26.7
 vine==1.3.0
 virtualenv==20.4.6
 watchtower==0.7.3


### PR DESCRIPTION
Fixes `CVE-2021-21240` and `CVE-2021-33503`

