### PR TITLE
Fix `CVE-2021-33503` in AC 2.1.1

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -31,7 +31,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.0.0-10", ["buster"]),
     ("2.0.2-6", ["buster"]),
     ("2.1.0-5", ["buster"]),
-    ("2.1.1-4", ["buster"]),
+    ("2.1.1-5.dev", ["buster"]),
     ("2.1.3-2", ["buster"]),
     ("2.1.4-2", ["buster"]),
     ("2.2.0-4.dev", ["bullseye", "buster"]),

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.1-4"
+ARG VERSION="2.1.1-5.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.1"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.1-4"
+ARG VERSION="2.1.1-5.*"
 ARG AIRFLOW_VERSION="2.1.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"

--- a/2.1.1/buster/build-time-pip-constraints.txt
+++ b/2.1.1/buster/build-time-pip-constraints.txt
@@ -491,7 +491,7 @@ typing-inspect==0.7.1
 tzlocal==2.1
 unicodecsv==0.14.1
 uritemplate==3.0.1
-urllib3==1.25.11
+urllib3==1.26.7
 vertica-python==1.0.1
 vine==1.3.0
 virtualenv==20.4.7


### PR DESCRIPTION
Fix `CVE-2021-33503` in AC 2.1.1