### PR TITLE
Revert "Fix the nightly Job"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,7 @@ workflows:
   setup:
     jobs:
       - generate-config
-  nightly:
-    triggers:
-      - schedule:
-          cron: "* * * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - generate-config
+
 executors:
   docker-executor:
     docker:


### PR DESCRIPTION
Reverts last change to fix "Max number of workflows exceeded." error described in https://support.circleci.com/hc/en-us/articles/360060934851--Max-number-of-workflows-exceeded-error
![image](https://user-images.githubusercontent.com/8811558/141211688-7878c158-d8a1-4f4a-979a-7418032d88d1.png)

So if we want to get it working we need to use Scheduled Pipelines — https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/scheduled-pipelines.md

@blag has already created those via API
