### PR TITLE
Release AC 2.2.2-1

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -36,7 +36,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.4-3", ["buster"]),
     ("2.2.0-4", ["bullseye", "buster"]),
     ("2.2.1-2", ["bullseye", "buster"]),
-    ("2.2.2-1.dev", ["bullseye"]),
+    ("2.2.2-1", ["bullseye"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/2.2.2/CHANGELOG.md
+++ b/2.2.2/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-Astronomer Certified 2.2.2-1, TBD
+Astronomer Certified 2.2.2-1, 2021-11-15
 ----------------------------------------
 
 User-facing CHANGELOG for AC 2.2.2+astro.1 from Airflow 2.2.2:
 
 ### Bugfixes
 
-- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/fab4e50018bda15dfec0d61bf368ebdbe382e099))
-- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/11cce262e2f273eacaa6beb9ed27cdf8b3859354))
-- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/db6ad2c5daaba48126e60397bca9e68da69b6d3f))
+- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/c065531014fc596a251d915bfa228cfb113a51a8))
+- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods ([commit](https://github.com/astronomer/airflow/commit/11a80aede0d1b51e6c424e45805ef3b36d1debaf))
+- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/6a477103a4ed7358e82a1560c1c64477f85949d3))

--- a/2.2.2/bullseye/Dockerfile
+++ b/2.2.2/bullseye/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.2-1.*"
+ARG VERSION="2.2.2-1"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.2"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.2-1.*"
+ARG VERSION="2.2.2-1"
 ARG AIRFLOW_VERSION="2.2.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
# Changelog

Astronomer Certified 2.2.2-1, 2021-11-15
----------------------------------------

User-facing CHANGELOG for AC 2.2.2+astro.1 from Airflow 2.2.2:

### Bugfixes

- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/c065531014fc596a251d915bfa228cfb113a51a8))
- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods ([commit](https://github.com/astronomer/airflow/commit/11a80aede0d1b51e6c424e45805ef3b36d1debaf))
- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/6a477103a4ed7358e82a1560c1c64477f85949d3))
