### PR TITLE
Insert latest tags into a cloud DB and notify on slack

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -36,7 +36,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.4-3", ["buster"]),
     ("2.2.0-4", ["bullseye", "buster"]),
     ("2.2.1-2", ["bullseye", "buster"]),
-    ("2.2.2-1.dev", ["bullseye"]),
+    ("2.2.2-1", ["bullseye"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -389,7 +389,7 @@ jobs:
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
       - slack/notify:
-          branch_pattern: master
+          branch_pattern: master,push_tags_db
           channel: qa-team
           custom: |
             {

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -534,6 +534,46 @@ commands:
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
 
+                echo "Build TAG artifact using environment variables and into DB"
+
+                if [[ "${tag}" == *"onbuild-"* ]]; then
+                  release="$( cut -d '-' -f 1 \<<< "$tag" )"
+                  sudo apt-get install postgresql postgresql-contrib
+                  echo "Insert into the DB with the latest TAG"
+                  export PORT=5432
+
+                  sql="select latest_tag from tag_version where version_1='${release}'" 
+
+                  # Connect to the database, run the query, then disconnect
+                  PGPASSWORD="$QA_RELEASEINFO_PASSWORD" psql -t -A \
+                  -h "$QA_RELEASEINFO_HOST" \
+                  -p "$PORT" \
+                  -d "$QA_RELEASEINFO_DATABASE" \
+                  -U "$QA_RELEASEINFO_USERNAME" \
+                  -c "$sql" > current_tag
+                
+                  PREVIOUS_TAG=$(<current_tag)
+
+                  del_sql="DELETE FROM tag_version where version_1='${release}'"
+                  # Connect to the database, run the query, then disconnect DB
+                  PGPASSWORD="$QA_RELEASEINFO_PASSWORD" psql -t -A \
+                  -h "$QA_RELEASEINFO_HOST" \
+                  -p "$PORT" \
+                  -d "$QA_RELEASEINFO_DATABASE" \
+                  -U "$QA_RELEASEINFO_USERNAME" \
+                  -c "$del_sql"
+
+                  insert_sql="INSERT INTO tag_version values('${release}','${tag}','${PREVIOUS_TAG}')"
+                  # Connect to the database, run the query, then disconnect DB
+                  PGPASSWORD="$QA_RELEASEINFO_PASSWORD" psql -t -A \
+                  -h "$QA_RELEASEINFO_HOST" \
+                  -p "$PORT" \
+                  -d "$QA_RELEASEINFO_DATABASE" \
+                  -U "$QA_RELEASEINFO_USERNAME" \
+                  -c "$insert_sql"
+                fi
+
+
               else
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.prod_docker_repo_quay_io >>:${tag}"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -76,6 +76,7 @@ workflows:
             branches:
               only:
                 - master
+                - push_tags_db
       - pause_workflow:
           name: Need-Approval-{{ airflow_version }}
           requires:
@@ -85,6 +86,7 @@ workflows:
             branches:
               only:
                 - master
+                - push_tags_db
 {% for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -390,7 +390,7 @@ jobs:
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
       - slack/notify:
           branch_pattern: master,push_tags_db
-          channel: qa-team
+          channel: airflow-ac-build-release
           custom: |
             {
               "blocks": [

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -160,6 +160,8 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
+            - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -136,8 +136,6 @@ workflows:
           context:
             - quay.io
             - docker.io
-            - qa
-            - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
@@ -158,8 +156,6 @@ workflows:
           context:
             - quay.io
             - docker.io
-            - qa
-            - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
@@ -167,7 +163,7 @@ workflows:
             branches:
               only:
                 - master
-            
+
 {%- endfor %}
 {%- endfor %}
 {%- if image_map.keys() | dev_releases | length > 0 %}
@@ -226,6 +222,8 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
+            - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
@@ -233,7 +231,6 @@ workflows:
             branches:
               only:
                 - master
-                - push_tags_db
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: true
@@ -250,6 +247,25 @@ workflows:
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
+          filters:
+            branches:
+              only:
+                - master
+      - slack-notification:
+          name: slack-notification-{{ airflow_version }}-{{ distribution }}-onbuild
+          dev_build: true
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          airflow_version: "{{ airflow_version }}"
+          tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- else %}
+          tag: "{{ airflow_version }}-onbuild"
+          extra_tags: "{{ airflow_version }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-onbuild"
+          {%- endif %}
+          context:
+            - slack_ap-airflow
+          requires:
+            - push-{{ airflow_version }}-{{ distribution }}-onbuild
           filters:
             branches:
               only:
@@ -384,48 +400,63 @@ jobs:
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
-      - slack/notify:
-          branch_pattern: master,push_tags_db
-          channel: airflow-ac-build-release,airflow-release-engineering
-          custom: |
-            {
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "NEW BUILD ALERT",
-                      "emoji": true
-                    }
-                  },
-                  {
-                    "type": "divider"
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "A new docker image is pushed to https://quay.io/repository/astronomer/ap-airflow-dev\nIs this a dev build? << parameters.dev_build >> \nImage Tags:<< parameters.extra_tags >>"
-                    },
-                    "accessory": {
-                      "type": "image",
-                      "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
-                      "alt_text": "Docker Image"
-                    }
-                  },
-                  {
-                    "type": "context",
-                    "elements": [
-                      {
+  slack-notification:
+      executor: docker-executor
+      description: Push Airflow images
+      parameters:
+        dev_build:
+          description: "Indicate if this is a dev build"
+          type: boolean
+        airflow_version:
+          type: string
+        tag:
+          type: string
+        extra_tags:
+          type: string
+          default: ""
+      steps:
+        - slack/notify:
+            branch_pattern: master,push_tags_db
+            channel: airflow-ac-build-approvals,airflow-ac-build-tags
+            custom: |
+              {
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
                         "type": "plain_text",
-                        "text": "Release Owners: Airflow Team[Kaxil/Jed]",
+                        "text": "NEW BUILD ALERT- << parameters.airflow_version >>",
                         "emoji": true
                       }
-                    ]
-                  }
-                ]
-              }
-          event: pass
+                    },
+                    {
+                      "type": "divider"
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "A new docker image is pushed to https://quay.io/repository/astronomer/ap-airflow-dev\nIs this a dev build? << parameters.dev_build >> \nImage Tags:<< parameters.extra_tags >>"
+                      },
+                      "accessory": {
+                        "type": "image",
+                        "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
+                        "alt_text": "Docker Image"
+                      }
+                    },
+                    {
+                      "type": "context",
+                      "elements": [
+                        {
+                          "type": "plain_text",
+                          "text": "Release Owners: Airflow Team[Kaxil/Jed]",
+                          "emoji": true
+                        }
+                      ]
+                    }
+                  ]
+                }
+            event: pass
 
 orbs:
   slack: circleci/slack@4.4.4

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -386,18 +386,18 @@ jobs:
           branch_pattern: master
           channel: qa-team
           custom: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "plain_text",
-                  "text": "A new dev=<< parameters.dev_build >> image is generated.<< parameters.extra_tags >>",
-                  "emoji": true
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "A new dev=<< parameters.dev_build >> image is generated.<< parameters.extra_tags >>",
+                    "emoji": true
+                  }
                 }
-              }
-            ]
-          }
+              ]
+            }
           event: pass
 
 orbs:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -142,7 +142,7 @@ workflows:
             - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-            - test-{{ airflow_version }}-{{ distribution }}-images
+            #- test-{{ airflow_version }}-{{ distribution }}-images
           filters:
             branches:
               only:
@@ -164,7 +164,7 @@ workflows:
             - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-            - test-{{ airflow_version }}-{{ distribution }}-images
+            #- test-{{ airflow_version }}-{{ distribution }}-images
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -542,7 +542,7 @@ commands:
                   echo "Insert into the DB with the latest TAG"
                   export PORT=5432
 
-                  sql="select latest_tag from tag_version where version_1='${release}'" 
+                  sql="select latest_tag from tag_version where version_1='${release}'"
 
                   # Connect to the database, run the query, then disconnect
                   PGPASSWORD="$QA_RELEASEINFO_PASSWORD" psql -t -A \
@@ -551,7 +551,7 @@ commands:
                   -d "$QA_RELEASEINFO_DATABASE" \
                   -U "$QA_RELEASEINFO_USERNAME" \
                   -c "$sql" > current_tag
-                
+
                   PREVIOUS_TAG=$(<current_tag)
 
                   del_sql="DELETE FROM tag_version where version_1='${release}'"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -76,7 +76,6 @@ workflows:
             branches:
               only:
                 - master
-                - push_tags_db
       - pause_workflow:
           name: Need-Approval-{{ airflow_version }}
           requires:
@@ -86,7 +85,6 @@ workflows:
             branches:
               only:
                 - master
-                - push_tags_db
 {% for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
@@ -142,7 +140,7 @@ workflows:
             - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-            #- test-{{ airflow_version }}-{{ distribution }}-images
+            - test-{{ airflow_version }}-{{ distribution }}-images
           filters:
             branches:
               only:
@@ -164,13 +162,12 @@ workflows:
             - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-            #- test-{{ airflow_version }}-{{ distribution }}-images
+            - test-{{ airflow_version }}-{{ distribution }}-images
           filters:
             branches:
               only:
                 - master
-                - push_tags_db
-
+            
 {%- endfor %}
 {%- endfor %}
 {%- if image_map.keys() | dev_releases | length > 0 %}
@@ -257,7 +254,6 @@ workflows:
             branches:
               only:
                 - master
-                - push_tags_db
 {%- endfor %}
 {%- endif %}
 {%- endfor %}
@@ -390,20 +386,45 @@ jobs:
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
       - slack/notify:
           branch_pattern: master,push_tags_db
-          channel: airflow-ac-build-release
+          channel: airflow-ac-build-release,airflow-release-engineering
           custom: |
             {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "A new dev=<< parameters.dev_build >> image is generated.<< parameters.extra_tags >>",
-                    "emoji": true
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "NEW BUILD ALERT",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "A new docker image is pushed to https://quay.io/repository/astronomer/ap-airflow-dev\nIs this a dev build? << parameters.dev_build >> \nImage Tags:<< parameters.extra_tags >>"
+                    },
+                    "accessory": {
+                      "type": "image",
+                      "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
+                      "alt_text": "Docker Image"
+                    }
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      {
+                        "type": "plain_text",
+                        "text": "Release Owners: Airflow Team[Kaxil/Jed]",
+                        "emoji": true
+                      }
+                    ]
                   }
-                }
-              ]
-            }
+                ]
+              }
           event: pass
 
 orbs:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -138,6 +138,8 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
+            - slack_ap-airflow
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -163,7 +163,27 @@ workflows:
             branches:
               only:
                 - master
-
+      {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
+      - slack-notification:
+          name: slack-notification-{{ airflow_version }}-{{ distribution }}-onbuild
+          dev_build: {{ dev_build }}
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          airflow_version: "{{ airflow_version }}"
+          tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- else %}
+          tag: "{{ airflow_version }}-onbuild"
+          extra_tags: "{{ airflow_version }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-onbuild"
+          {%- endif %}
+          context:
+            - slack_ap-airflow
+          requires:
+            - push-{{ airflow_version }}-{{ distribution }}-onbuild
+          filters:
+            branches:
+              only:
+                - master
+      {%- endif %}
 {%- endfor %}
 {%- endfor %}
 {%- if image_map.keys() | dev_releases | length > 0 %}
@@ -276,7 +296,7 @@ workflows:
 {% endif %}
 jobs:
   static-checks:
-    executor: machine-executor
+    executor: docker-executor
     description: Static Checks
     steps:
       - checkout
@@ -417,7 +437,7 @@ jobs:
       steps:
         - slack/notify:
             branch_pattern: master,push_tags_db
-            channel: airflow-ac-build-approvals,airflow-ac-build-tags
+            channel: airflow-ac-build-tags
             custom: |
               {
                   "blocks": [

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -163,7 +163,8 @@ workflows:
             branches:
               only:
                 - master
-                - slack-build-approvals
+                - push_tags_db
+
 {%- endfor %}
 {%- endfor %}
 {%- if image_map.keys() | dev_releases | length > 0 %}
@@ -229,6 +230,7 @@ workflows:
             branches:
               only:
                 - master
+                - push_tags_db
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: true
@@ -249,6 +251,7 @@ workflows:
             branches:
               only:
                 - master
+                - push_tags_db
 {%- endfor %}
 {%- endif %}
 {%- endfor %}
@@ -346,6 +349,7 @@ jobs:
           key: trivy-cache
           paths:
             - /tmp/workspace/trivy-cache
+
   push:
     executor: docker-executor
     description: Push Airflow images
@@ -378,9 +382,26 @@ jobs:
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
+      - slack/notify:
+          branch_pattern: master
+          channel: qa-team
+          custom: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "plain_text",
+                  "text": "A new dev=<< parameters.dev_build >> image is generated.<< parameters.extra_tags >>",
+                  "emoji": true
+                }
+              }
+            ]
+          }
+          event: pass
 
 orbs:
-  slack: circleci/slack@4.2.0
+  slack: circleci/slack@4.4.4
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:

--- a/2.2.2/CHANGELOG.md
+++ b/2.2.2/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-Astronomer Certified 2.2.2-1, TBD
+Astronomer Certified 2.2.2-1, 2021-11-15
 ----------------------------------------
 
 User-facing CHANGELOG for AC 2.2.2+astro.1 from Airflow 2.2.2:
 
 ### Bugfixes
 
-- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/fab4e50018bda15dfec0d61bf368ebdbe382e099))
-- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods (#62) ([commit](https://github.com/astronomer/airflow/commit/11cce262e2f273eacaa6beb9ed27cdf8b3859354))
-- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/db6ad2c5daaba48126e60397bca9e68da69b6d3f))
+- [astro] Reconcile orphan holding table handling ([commit](https://github.com/astronomer/airflow/commit/c065531014fc596a251d915bfa228cfb113a51a8))
+- [astro] [AIRFLOW-5448] Handle istio-proxy for Kubernetes Pods ([commit](https://github.com/astronomer/airflow/commit/11a80aede0d1b51e6c424e45805ef3b36d1debaf))
+- [astro] Override UI with Astro theme, add AC version in footer ([commit](https://github.com/astronomer/airflow/commit/6a477103a4ed7358e82a1560c1c64477f85949d3))

--- a/2.2.2/bullseye/Dockerfile
+++ b/2.2.2/bullseye/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.2-1.*"
+ARG VERSION="2.2.2-1"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.2"
@@ -145,7 +145,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.2-1.*"
+ARG VERSION="2.2.2-1"
 ARG AIRFLOW_VERSION="2.2.2"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Insert latest airflow dev tags into a cloud DB so the automation framework can consume

Also everytime the team has to either go into quay or the actual pipeline to check for new tags. This will provide a slack notification whenever there is a new dev build. 

The latest commit moves the slack notification into a new job