### PR TITLE
Add nightly builds for QA Docker images

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -51,6 +51,9 @@ export RELEASE_NAME=$NAMESPACE
 echo "Installing Airflow into kind as $RELEASE_NAME"
 
 AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.airflow.version" }}' "$REPOSITORY:$TEST_TAG")
+# Make the version "SemVer" compliant.. Example: 2.2.0.dev becomes 2.2.0
+echo "Airflow Version (from labels): $AIRFLOW_VERSION"
+AIRFLOW_VERSION="${AIRFLOW_VERSION%.dev*}"
 export AIRFLOW_VERSION
 echo "Airflow Version: $AIRFLOW_VERSION"
 

--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -53,9 +53,10 @@ echo "Installing Airflow into kind as $RELEASE_NAME"
 AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.airflow.version" }}' "$REPOSITORY:$TEST_TAG")
 # Make the version "SemVer" compliant.. Example: 2.2.0.dev becomes 2.2.0
 echo "Airflow Version (from labels): $AIRFLOW_VERSION"
-AIRFLOW_VERSION="${AIRFLOW_VERSION%.dev*}"
+AIRFLOW_VERSION_SEMVER="${AIRFLOW_VERSION%.dev*}"
 export AIRFLOW_VERSION
-echo "Airflow Version: $AIRFLOW_VERSION"
+export AIRFLOW_VERSION_SEMVER
+echo "Airflow Version (SemVer): $AIRFLOW_VERSION_SEMVER"
 
 # Find alpine or debian
 DISTRO=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.distro" }}' "$REPOSITORY:$TEST_TAG")
@@ -85,7 +86,7 @@ helm install --namespace $NAMESPACE \
   --set airflow.images.airflow.pullPolicy=Never \
   --set airflow.images.flower.pullPolicy=Never \
   --set airflow.executor=KubernetesExecutor \
-  --set airflow.airflowVersion=$AIRFLOW_VERSION \
+  --set airflow.airflowVersion=$AIRFLOW_VERSION_SEMVER \
   --set airflow.uid=$IMAGE_UID \
   --set airflow.gid=$IMAGE_GID \
   --version=$CHART_VERSION \

--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -58,6 +58,9 @@ export AIRFLOW_VERSION
 export AIRFLOW_VERSION_SEMVER
 echo "Airflow Version (SemVer): $AIRFLOW_VERSION_SEMVER"
 
+EDGE_BUILD=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.build.edge" }}' "$REPOSITORY:$TEST_TAG")
+export EDGE_BUILD
+
 # Find alpine or debian
 DISTRO=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.distro" }}' "$REPOSITORY:$TEST_TAG")
 # This is handled by Houston for the platform: https://github.com/astronomer/houston-api/pull/581

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -27,6 +27,7 @@ class ImageType(Enum):
 
 airflow_version = os.environ.get("AIRFLOW_VERSION")
 airflow_2 = True if airflow_version.startswith("2") else False
+is_edge_build = os.environ.get("EDGE_BUILD") == "true"
 
 
 def test_airflow_in_path(webserver):
@@ -58,6 +59,7 @@ def test_maintainer(webserver, docker_client):
         "'maintainer' label should be 'Astronomer <humans@astronomer.io>'"
 
 
+@pytest.mark.skipif(is_edge_build, reason="Not needed for Edge/main builds")
 def test_version(webserver, docker_client):
     """ Ensure the version of Airflow matches the Docker image label
     """

--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -14,12 +14,22 @@ def dev_releases(all_releases):
     """Find dev releases from a list of releases"""
     return [
         release for release in all_releases
-        if "dev" in release and get_airflow_version(release) not in DEV_ALLOWLIST
+        if is_dev_release(release) and get_airflow_version(release) not in DEV_ALLOWLIST
     ]
+
+
+def is_dev_release(version):
+    return "dev" in version or is_edge_build(version)
+
+
+def is_edge_build(version):
+    return "main" in version
 
 
 def get_airflow_version(ac_version):
     """Get Airflow Version from the string containing AC Version"""
+    if is_edge_build(ac_version):
+        return "main"
     return ac_version.split('-')[0]
 
 
@@ -37,6 +47,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.2.0-4", ["bullseye", "buster"]),
     ("2.2.1-2", ["bullseye", "buster"]),
     ("2.2.2-1", ["bullseye"]),
+    ("main.dev", ["bullseye"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ orbs:
 workflows:
   setup:
     jobs:
-      - generate-config
+      # - generate-config
+      - rebase-astro-main
 
 executors:
   docker-executor:
@@ -33,3 +34,23 @@ jobs:
             cat generated_config.yml
       - continuation/continue:
           configuration_path: generated_config.yml
+  rebase-astro-main:
+    machine:
+      image: ubuntu-2004:202107-02
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "11:0b:15:6b:f2:77:3e:93:c5:83:0e:8a:0a:93:2e:7e"
+      - run:
+          name: Rebase astronomer/airflow:astro-main onto main
+          command: |
+            git clone git@github.com:astronomer/airflow.git
+            cd airflow
+            git branch --verbose
+            git fetch --all
+            git checkout astro-main
+            git --no-pager log --max-count 4
+            git rebase main
+            git --no-pager log --max-count 4
+            git push origin astro-main
+            git --no-pager remote --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - run:
           name: Rebase astronomer/airflow:astro-main onto main
           command: |
+            export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -i $HOME/.ssh/id_rsa_110b156bf2773e93c5830e8a0a932e7e"
             git clone git@github.com:astronomer/airflow.git
             cd airflow
             git branch --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ orbs:
 workflows:
   setup:
     jobs:
-      # - generate-config
-      - rebase-astro-main
+      - generate-config
 
 executors:
   docker-executor:
@@ -34,24 +33,3 @@ jobs:
             cat generated_config.yml
       - continuation/continue:
           configuration_path: generated_config.yml
-  rebase-astro-main:
-    machine:
-      image: ubuntu-2004:202107-02
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "11:0b:15:6b:f2:77:3e:93:c5:83:0e:8a:0a:93:2e:7e"
-      - run:
-          name: Rebase astronomer/airflow:astro-main onto main
-          command: |
-            export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -i $HOME/.ssh/id_rsa_110b156bf2773e93c5830e8a0a932e7e"
-            git clone git@github.com:astronomer/airflow.git
-            cd airflow
-            git branch --verbose
-            git fetch --all
-            git checkout astro-main
-            git --no-pager log --max-count 4
-            git rebase main
-            git --no-pager log --max-count 4
-            git push origin astro-main
-            git --no-pager remote --verbose

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -1,6 +1,13 @@
 version: 2.1
 
 workflows:
+  rebase-astro-main:
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ "every-midnight-utc", << pipeline.schedule.name >> ]
+    jobs:
+      - rebase-astro-main
   certified-airflow:
     when:
       not:
@@ -254,6 +261,27 @@ workflows:
 {%- endfor %}
 {% endif %}
 jobs:
+  rebase-astro-main:
+    machine:
+      image: ubuntu-2004:202107-02
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "11:0b:15:6b:f2:77:3e:93:c5:83:0e:8a:0a:93:2e:7e"
+      - run:
+          name: Rebase astronomer/airflow:astro-main onto main
+          command: |
+            export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -i $HOME/.ssh/id_rsa_110b156bf2773e93c5830e8a0a932e7e"
+            git clone git@github.com:astronomer/airflow.git
+            cd airflow
+            git branch --verbose
+            git fetch --all
+            git checkout astro-main
+            git --no-pager log --max-count 4
+            git rebase main
+            git --no-pager log --max-count 4
+            git push origin astro-main
+            git --no-pager remote --verbose
   static-checks:
     executor: machine-executor
     description: Static Checks

--- a/.circleci/update_dockerfiles.py
+++ b/.circleci/update_dockerfiles.py
@@ -6,7 +6,7 @@ This script is used to update the VERSION in all Dockerfiles with the correspond
 import os
 import re
 
-from common import DEV_ALLOWLIST, get_airflow_version, IMAGE_MAP, project_directory
+from common import DEV_ALLOWLIST, get_airflow_version, IMAGE_MAP, project_directory, is_edge_build
 
 
 def update_dockerfiles():
@@ -14,6 +14,9 @@ def update_dockerfiles():
     Replace the VERSION in all the Dockerfiles with the corresponding VERSION in IMAGE_MAP
     """
     for ac_version, distros in IMAGE_MAP.items():
+        if is_edge_build(ac_version):
+            # We don't have a Changelog for edge builds
+            continue
         dev_version = False
         airflow_version = get_airflow_version(ac_version)
         arg_ac_version = ac_version

--- a/.circleci/verify_changelog_entries.py
+++ b/.circleci/verify_changelog_entries.py
@@ -7,7 +7,7 @@ links for all these CHANGELOG.md files in README.md
 import os
 import re
 
-from common import DEV_ALLOWLIST, get_airflow_version, IMAGE_MAP, project_directory
+from common import get_airflow_version, IMAGE_MAP, project_directory, is_edge_build
 
 
 def verify_changelog_entries():
@@ -22,6 +22,9 @@ def verify_changelog_entries():
     )
 
     for ac_version, distros in IMAGE_MAP.items():
+        if is_edge_build(ac_version):
+            # We don't have a Changelog for edge builds
+            continue
         airflow_version = get_airflow_version(ac_version)
 
         if "dev" not in ac_version:

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -145,6 +145,7 @@ ARG VERSION
 ARG AIRFLOW_VERSION=${VERSION}
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
+LABEL io.astronomer.docker.build.edge="true"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -1,0 +1,204 @@
+#
+# Copyright 2019 Astronomer Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG APT_DEPS_IMAGE="airflow-apt-deps"
+ARG PYTHON_MAJOR_MINOR_VERSION="3.9"
+ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-bullseye"
+
+FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
+
+LABEL maintainer="Astronomer <humans@astronomer.io>"
+
+ARG ASTRONOMER_USER="astro"
+ARG ASTRONOMER_UID="50000"
+
+LABEL io.astronomer.docker=true
+LABEL io.astronomer.docker.distro="debian"
+LABEL io.astronomer.docker.module="airflow"
+LABEL io.astronomer.docker.component="airflow"
+LABEL io.astronomer.docker.uid="${ASTRONOMER_UID}"
+
+
+ARG ORG="astronomer"
+
+
+ENV AIRFLOW_HOME="/usr/local/airflow"
+ENV PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}${AIRFLOW_HOME}
+
+ENV ASTRONOMER_USER=${ASTRONOMER_USER}
+ENV ASTRONOMER_UID=${ASTRONOMER_UID}
+
+# Need to repeat the empty argument here otherwise it will not be set for this stage
+# But the default value carries from the one set before FROM
+ARG PYTHON_BASE_IMAGE
+ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE}
+ARG PYTHON_MAJOR_MINOR_VERSION
+ENV PYTHON_MAJOR_MINOR_VERSION=${PYTHON_MAJOR_MINOR_VERSION}
+ARG PIP_VERSION="21.2.4"
+ENV PYTHON_PIP_VERSION=${PIP_VERSION}
+
+# Make sure noninteractie debian install is used and language variables set
+ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
+
+# By increasing this number we can do force build of all dependencies
+ARG DEPENDENCIES_EPOCH_NUMBER="1"
+# Increase the value below to force renstalling of all dependencies
+ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+           apt-utils \
+           curl \
+           libmariadb3 \
+           freetds-bin \
+           gosu \
+           libffi7 \
+           libkrb5-3 \
+           libpq5 \
+           libsasl2-2 \
+           libsasl2-modules \
+           libssl1.1 \
+           locales  \
+           netcat \
+           rsync \
+           sasl2-bin \
+           sudo \
+           tini \
+    && apt-get autoremove -yqq --purge \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip=="${PYTHON_PIP_VERSION}"
+
+RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER} \
+    && groupadd astrogroup --gid 101 \
+    && usermod --append --groups astrogroup ${ASTRONOMER_USER}
+
+# From the airflow image on master
+
+#################################################################
+######## Installed dependencies - now installing Airflow ########
+#################################################################
+
+FROM ${APT_DEPS_IMAGE} as devel
+SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
+
+ENV PIP_NO_CACHE_DIR="true"
+
+RUN apt-get update \
+    && curl -sL https://deb.nodesource.com/setup_14.x | sudo bash - \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        default-libmysqlclient-dev \
+        libffi-dev \
+        libkrb5-dev \
+        libpq-dev \
+        libsasl2-dev \
+        libssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION
+ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
+ARG AIRFLOW_VERSION=${VERSION}
+
+# Make pip look at our pip repo too, and force it to install these specific
+# versions when ever it installs a module.
+COPY include/pip.conf /etc/pip.conf
+COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
+
+# Pip install airflow and astro security manager. Install Airflow module with extra separately to account
+# for difference of OSS and Astro Providers
+RUN pip install "astronomer_certified==${VERSION}" celery flower "elasticsearch==7.13.4" \
+    --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt" \
+  && pip install "${AIRFLOW_MODULE}" \
+  && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
+	&& pip install "astronomer-fab-security-manager~=1.7"
+
+
+## move this to same layer as airflow because its from tag.
+
+FROM ${APT_DEPS_IMAGE} as main
+
+# By increasing this number we force CI to upgrade all system packages
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION
+ARG AIRFLOW_VERSION=${VERSION}
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+
+# Copy all installed python modules. This gets us the compiled without needing dev installed
+COPY --from=devel /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages
+COPY --from=devel /usr/local/bin /usr/local/bin
+
+# Force pip to install these specific versions when ever it installs a module
+COPY include/pip.conf /etc/pip.conf
+COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
+
+# Pin apache-airflow version to avoid accidental upgrade
+RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
+
+RUN sed -i \
+    # Run pods spun up by Kubernetes Executor as astro user
+    -e 's/^run_as_user =.*/run_as_user = 50000/g' \
+    # Needed by astronomer-version-check-plugin
+    -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
+    # We sync permissions in the entrypoint so do not need to run in the Webserver again
+    -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
+    # Use Auth Backend defined in Astronomer FAB Security Manager
+    -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
+    # The number of seconds to wait before timing out send_task_to_executor or fetch_celery_task_state operations.
+    -e 's/^operation_timeout =.*/operation_timeout = 10.0/g' \
+    /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
+
+# Create logs directory, so we can own it when we mount volumes
+RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \
+    && install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}/logs"
+
+# Copy entrypoint to root
+COPY include/entrypoint /
+
+# Copy "cron" scripts
+COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
+
+# Set it up so that _apt/UID 100 can `gosu`, but no other users can
+RUN groupadd gosuers \
+    && usermod --append --groups gosuers _apt \
+    && chgrp gosuers /usr/sbin/gosu \
+    && chmod u+s,g+sx,o-rx /usr/sbin/gosu
+
+# Create man directory to solve issues installing JRE
+RUN mkdir -pv /usr/share/man/man1 && mkdir -pv /usr/share/man/man7
+
+# Environment Variables for Partner Programs
+ENV AIRFLOW_SNOWFLAKE_PARTNER=ASTRONOMER
+
+# Though this is set here we currently override this in the helm template, so
+# this _might_ not have any effect once deployed. The /entrypoint script copes
+# with this
+USER ${ASTRONOMER_USER}
+
+# Switch to AIRFLOW_HOME
+WORKDIR ${AIRFLOW_HOME}
+
+ENTRYPOINT ["/entrypoint"]
+CMD ["airflow", "--help"]

--- a/main/bullseye/include/clean-airflow-logs
+++ b/main/bullseye/include/clean-airflow-logs
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIRECTORY=${AIRFLOW_HOME:-/usr/local/airflow}
+RETENTION=${ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION_DAYS:-15}
+
+trap "exit" INT TERM
+
+EVERY=$((15*60))
+
+echo "Cleaning logs every $EVERY seconds"
+
+while true; do
+  seconds=$(( $(date -u +%s) % EVERY))
+  [[ $seconds -lt 1 ]] || sleep $((EVERY - seconds))
+
+  echo "Trimming airflow logs to ${RETENTION} days."
+  find "${DIRECTORY}"/logs -mtime +"${RETENTION}" -name '*.log' -delete
+done

--- a/main/bullseye/include/entrypoint
+++ b/main/bullseye/include/entrypoint
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ $UID == "${ASTRONOMER_UID:-1000}" ]]; then
+  # Since we need to support running tini as another user, we can't put tini in
+  # the ENTRYPOINT command, we have to run it here, if we haven't already
+  if [[ -z "$__TINIFIED" ]]; then
+    __TINIFIED=1 exec tini -- "$0" "$@"
+  fi
+else
+  __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
+fi
+
+if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
+  # Support for puckle style of defining configs
+  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
+fi
+
+# Airflow subcommand
+CMD=$2
+
+url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
+
+# Wait for postgres then init the db
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
+  # Wait for database port to open up
+  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
+  echo "Waiting for host: ${HOST} ${PORT}"
+  while ! nc -w 1 -z "${HOST}" "${PORT}"; do
+    sleep 0.001
+  done
+fi
+
+if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|celery worker|celery flower)$ ]]; then
+  # Wait for database port to open up
+  [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
+  HOST=${BASH_REMATCH[2]}
+  PORT=${BASH_REMATCH[3]}
+  echo "Waiting for host: ${HOST} ${PORT}"
+  while ! nc -w 1 -z "${HOST}" "${PORT}"; do
+    sleep 0.001
+  done
+fi
+
+if [[ $CMD == "webserver" ]]; then
+  airflow sync-perm
+fi
+
+# Run the original command
+exec "$@"

--- a/main/bullseye/include/pip-constraints.txt
+++ b/main/bullseye/include/pip-constraints.txt
@@ -1,0 +1,4 @@
+# Constraint the version pip will install, if it ever needs to install a module
+
+# https://github.com/astronomer/issues/issues/3347#issuecomment-901370036
+elasticsearch<7.14

--- a/main/bullseye/include/pip.conf
+++ b/main/bullseye/include/pip.conf
@@ -1,0 +1,3 @@
+[global]
+extra-index-url = https://pip.astronomer.io/simple/
+constraint = /usr/local/share/astronomer-pip-constraints.txt

--- a/main/bullseye/trivyignore
+++ b/main/bullseye/trivyignore
@@ -1,0 +1,4 @@
+# False Positive - We are using PyYaml version that is not vulnerable
+# and Kubernetes Python client is already using safe_load
+# Details: https://github.com/astronomer/issues-airflow/issues/39
+CVE-2020-1747


### PR DESCRIPTION
## Full Picture ##

Three things need to happen:

1. The `astronomer/airflow:astro-main` branch needs to be rebased against `astronomer/airflow:main` daily/nightly.
2. New Airflow and Astronomer Certified Python artifacts (wheels) need to be built and uploaded somewhere.
3. New Docker images need to be built using those packages, tagged and labeled for QA, and uploaded to our dev image repository.

* Step 1 is implemented within a dynamically generated, scheduled pipeline here with CircleCI using an SSH deploy key due to limitations on GitHub Actions (re: scheduled workflows).
* Step 2 is implemented within the `astro-main` branch in GHA on every push event.
* Step 3 is implemented here again, to make it easy to keep the QA images built as close to production images as possible.

There will be an upcoming companion PR for astronomer/airflow with the GHA workflow.

## This PR ##

**What this PR does / why we need it**:

* [x] Pulls `astronomer/airflow:astro-main` and rebases it onto `astronomer/airflow:main` and pushes it via SSH.
* [ ] Builds an AC Docker image for QA using the two Python wheels from step 2 above.

**Special notes for your reviewer**:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
