### PR TITLE
Better edge builds

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -336,22 +336,24 @@ def test_labels_for_edge_builds(docker_client):
 
     image_labels = get_labels(docker_client)
     for label in labels_to_check:
-        assert label in image_labels,
-            (f"'{label}' should be in image labels for edge build (image labels: "
-             f"{','.join(image_labels.keys())})")
+        assert (
+            label in image_labels
+        ), f"'{label}' should be in image labels for edge build (image labels: {','.join(image_labels.keys())})"
         label_value = image_labels[label]
-        assert label_value != ''
+        assert label_value != ""
 
     # Assert that either
     # org.apache.airflow.git.branch
     # or
     # org.apache.airflow.git.tag
     # are in the image labels, and make sure their value is not empty
-    assert (('org.apache.airflow.git.branch' in image_labels and
-             image_labels['org.apache.airflow.git.branch'] != '')
-            or
-            ('org.apache.airflow.git.tag' in image_labels and
-             image_labels['org.apache.airflow.git.tag'] != ''))
+    assert (
+        "org.apache.airflow.git.branch" in image_labels
+        and image_labels["org.apache.airflow.git.branch"] != ""
+    ) or (
+        "org.apache.airflow.git.tag" in image_labels
+        and image_labels["org.apache.airflow.git.tag"] != ""
+    )
 
 
 def test_apache_airflow_in_requirements(tmp_path):

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -316,6 +316,47 @@ def test_labels_for_onbuild_image(docker_client):
         "'maintainer' label should be 'Astronomer <humans@astronomer.io>'"
 
 
+@pytest.mark.skipif(not is_edge_build, reason="Not needed for non-Edge/main builds")
+def test_labels_for_edge_builds(docker_client):
+    # Note that this list does not include
+    # org.apache.airflow.git.branch or org.apache.airflow.git.tag
+    # because those aren't guarateed to tbe in the labels.
+    # They are checked seprately down below.
+    labels_to_check = [
+        'org.apache.airflow.ci.build.date',
+        'org.apache.airflow.ci.build.url',
+        'org.apache.airflow.ci.build.version',
+        'org.apache.airflow.ci.js.node.version_string',
+        'org.apache.airflow.ci.js.npm.version_string',
+        'org.apache.airflow.ci.js.yarn.version_string',
+        'org.apache.airflow.ci.python.version_string',
+        'org.apache.airflow.git.commit_sha',
+        'io.astronomer.astronomer_certified.build.version',
+    ]
+
+    image_labels = get_labels(docker_client)
+    for label in labels_to_check:
+        assert label in image_labels,
+            (f"'{label}' should be in image labels for edge build (image labels: "
+             f"{','.join(image_labels.keys())})")
+        label_value = image_labels[label]
+        assert label_value != '',
+            f"Value for label '{label}' should not be empty (was: '{label_value}')"
+
+    # Assert that either
+    # org.apache.airflow.git.branch
+    # or
+    # org.apache.airflow.git.tag
+    # are in the image labels, and make sure their value is not empty
+    assert (('org.apache.airflow.git.branch' in image_labels and
+             image_labels['org.apache.airflow.git.branch'] != '')
+            or
+            ('org.apache.airflow.git.tag' in image_labels and
+             image_labels['org.apache.airflow.git.tag'] != '')),
+        (f"Either 'org.apache.airflow.git.branch' or 'org.apache.airflow.git.tag'"
+         "should be in the image labels and its value should not be empty")
+
+
 def test_apache_airflow_in_requirements(tmp_path):
     """
     Add test to check that docker build errors when apache-airflow is specified

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -340,8 +340,7 @@ def test_labels_for_edge_builds(docker_client):
             (f"'{label}' should be in image labels for edge build (image labels: "
              f"{','.join(image_labels.keys())})")
         label_value = image_labels[label]
-        assert label_value != '',
-            f"Value for label '{label}' should not be empty (was: '{label_value}')"
+        assert label_value != ''
 
     # Assert that either
     # org.apache.airflow.git.branch
@@ -352,9 +351,7 @@ def test_labels_for_edge_builds(docker_client):
              image_labels['org.apache.airflow.git.branch'] != '')
             or
             ('org.apache.airflow.git.tag' in image_labels and
-             image_labels['org.apache.airflow.git.tag'] != '')),
-        (f"Either 'org.apache.airflow.git.branch' or 'org.apache.airflow.git.tag'"
-         "should be in the image labels and its value should not be empty")
+             image_labels['org.apache.airflow.git.tag'] != ''))
 
 
 def test_apache_airflow_in_requirements(tmp_path):

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -101,7 +101,8 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: {{ dev_build }}
           {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)"
+          extra_args:
+            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)
           {%- endif %}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -103,7 +103,7 @@ workflows:
           dev_build: {{ dev_build }}
           {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
           extra_args:
-            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)
+            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build.json | jq -r '.output.astronomer_certified.package.version')
           {%- endif %}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
@@ -192,31 +192,46 @@ workflows:
 
       {%- if edge_build %}
       - download-file:
-          name: download-latest-{{ airflow_version | replace('.dev', '') }}-build
-          url: https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build
-          file: latest-{{ airflow_version | replace('.dev', '') }}.build
-      {%- endif %}
+          name: download-latest-{{ airflow_version | replace('.dev', '') }}-build-info
+          url: https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build.json
+          file: latest-{{ airflow_version | replace('.dev', '') }}.build.json
+      - write-version-to-tag-file:
+          name: write-version-to-tag-file-{{ airflow_version | replace('.dev', '') }}
+          input_json_file: latest-{{ airflow_version | replace('.dev', '') }}.build.json
+          output_file: extra-tags-{{ airflow_version | replace('.dev', '') }}.txt
+          requires:
+            - download-latest-{{ airflow_version | replace('.dev', '') }}-build-info
+      {%- endif %}{# edge_build #}
 
       {%- for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
-          {%- if edge_build %}
-          requires:
-            - download-latest-{{ airflow_version | replace('.dev', '') }}-build
-          {%- endif %}
           airflow_version: {{ airflow_version }}
           distribution_name: {{ distribution }}
           dev_build: true
           extra_args:
+            --build-arg VERSION=$(jq -r '.output.airflow.package.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
             {%- if edge_build %}
-            --tag $(cat latest-{{ airflow_version | replace('.dev', '') }}.build)
-            {%- endif %}
-            --build-arg VERSION=$(cat latest-{{ airflow_version | replace('.dev', '') }}.build)
+            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.python.version_string=$(jq -r '.python.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.git.commit_sha=$(jq -r '.git.commit' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.git.$(jq -r '.git.ref.type' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)=$(jq -r '.git.ref.name' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            {%- endif %}{# edge_build #}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
           {%- endif %}
+          requires:
+            {%- if edge_build %}
+            - build-{{ airflow_version }}-{{ distribution }}
+            {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}
@@ -247,13 +262,19 @@ workflows:
           {%- else %}
           tag: "{{ airflow_version }}"
           extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM}"
-          {%- endif %}
+          {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
+          {%- if edge_build %}
+          extra_tags_file: extra-tags-{{ airflow_version | replace('.dev', '') }}.txt
+          {%- endif %}{# edge_build #}
           context:
             - quay.io
             - docker.io
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
+            {%- if edge_build %}
+            - write-version-to-tag-file-{{ airflow_version | replace('.dev', '') }}
+            {%- endif %}
           filters:
             branches:
               only:
@@ -331,6 +352,21 @@ jobs:
           name: Downloading file with curl
           command: |
             curl << parameters.url >> > << parameters.file >>
+  write-version-to-tag-file:
+    executor: machine-executor
+    description: Write a version tag to the output file
+    parameters:
+      input_json_file:
+        description: The input JSON file
+        type: string
+      output_file:
+        description: The file to write
+        type: string
+    steps:
+      - run:
+          name: Writing extra steps file
+          command: |
+            jq '.output.astronomer_certified.package.version' < << parameters.input_json_file >> > << parameters.output_file >>
   build:
     executor: docker-executor
     description: Build Airflow images
@@ -424,6 +460,10 @@ jobs:
       extra_tags:
         type: string
         default: ""
+      extra_tags_file:
+        description: ""
+        type: string
+        default: ""
       prod_docker_repo_docker_hub:
         description: "The docker repo to tag and push to, for example 'quay.io/astronomer/ap-airflow'"
         default: "astronomerinc/ap-airflow"
@@ -440,6 +480,7 @@ jobs:
       - push:
           dev_release: "<< parameters.dev_build >>"
           extra_tags: "<< parameters.extra_tags >>"
+          extra_tags_file: "<< parameters.extra_tags_file >>"
           tag: "<< parameters.tag >>"
           prod_docker_repo_docker_hub: "<< parameters.prod_docker_repo_docker_hub >>"
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
@@ -556,6 +597,10 @@ commands:
       extra_tags:
         type: string
         default: ""
+      extra_tags_file:
+        description: "File containing additional tags, one per line"
+        type: string
+        default: ""
       tag:
         type: string
       image_name:
@@ -590,7 +635,18 @@ commands:
             image="ap-airflow:<< parameters.tag >>"
             set -x
             export NEW_POINT_RELEASE=true
-            for tag in $(echo "<< parameters.extra_tags >>" | sed "s/,/ /g");
+
+            IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.extra_tags >>"
+
+            # Read in more tags from the extra_tags_file, if it exists
+            if [[ -f "<< parameters.extra_tags_file >>" ]]; then
+              while read tag;
+              do
+                DOCKER_TAGS+=($tag)
+              done < "<< parameters.extra_tags_file >>"
+            fi
+
+            for tag in "${DOCKER_TAGS[@]}";
             do
               if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "<< parameters.prod_docker_repo_docker_hub >>:$tag" >/dev/null 2>&1; then
                 echo "Image with Tag ("<< parameters.prod_docker_repo_docker_hub >>:$tag") already exists"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -14,11 +14,11 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - static-checks
-{%- for ac_version, distributions in image_map.items() %}
-{%- set airflow_version = ac_version | get_airflow_version -%}
-{%- set dev_build = "true" if "dev" in ac_version else "false" %}
-{%- set edge_build = ac_version | is_edge_build -%}
-{%- if not edge_build %}
+      {%- for ac_version, distributions in image_map.items() %}
+      {%- set airflow_version = ac_version | get_airflow_version -%}
+      {%- set dev_build = "true" if "dev" in ac_version else "false" %}
+      {%- set edge_build = ac_version | is_edge_build -%}
+      {%- if not edge_build %}
       - slack/on-hold:
           name: Slack_Notification-{{ airflow_version }}
           context: slack_ap-airflow
@@ -94,7 +94,7 @@ workflows:
             branches:
               only:
                 - master
-{% for distribution in distributions %}
+      {% for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
           airflow_version: {{ airflow_version }}
@@ -174,21 +174,21 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
-{%- endfor %}
-{%- endif %}
-{%- endfor %}
-{%- if image_map.keys() | dev_releases | length > 0 %}
+      {%- endfor %}
+      {%- endif %}
+      {%- endfor %}
+  {%- if image_map.keys() | dev_releases | length > 0 %}
   nightly:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ "every-midnight-utc", << pipeline.schedule.name >> ]
     jobs:
-{%- for ac_version, distributions in image_map.items() %}
-{%- set airflow_version = ac_version | get_airflow_version %}
-{%- set edge_build = ac_version | is_edge_build -%}
-{%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
-{%- for distribution in distributions %}
+      {%- for ac_version, distributions in image_map.items() %}
+      {%- set airflow_version = ac_version | get_airflow_version %}
+      {%- set edge_build = ac_version | is_edge_build -%}
+      {%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
+      {%- for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
           airflow_version: {{ airflow_version }}
@@ -265,10 +265,10 @@ workflows:
             branches:
               only:
                 - master
-{%- endfor %}
-{%- endif %}
-{%- endfor %}
-{% endif %}
+      {%- endfor %}
+      {%- endif %}
+      {%- endfor %}
+  {% endif %}
 jobs:
   rebase-astro-main:
     machine:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -19,6 +19,7 @@ workflows:
       {%- set dev_build = "true" if "dev" in ac_version else "false" %}
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- if not edge_build %}
+
       - slack/on-hold:
           name: Slack_Notification-{{ airflow_version }}
           context: slack_ap-airflow
@@ -94,7 +95,7 @@ workflows:
             branches:
               only:
                 - master
-      {% for distribution in distributions %}
+      {%- for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
           airflow_version: {{ airflow_version }}
@@ -268,7 +269,8 @@ workflows:
       {%- endfor %}
       {%- endif %}
       {%- endfor %}
-  {% endif %}
+  {%- endif %}
+
 jobs:
   rebase-astro-main:
     machine:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -175,9 +175,9 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
-      {%- endfor %}
-      {%- endif %}
-      {%- endfor %}
+      {%- endfor %}{# distribution in distributions #}
+      {%- endif %}{# not edge_build #}
+      {%- endfor %}{# ac_version, distributions in image_map.items() #}
   {%- if image_map.keys() | dev_releases | length > 0 %}
   nightly:
     when:
@@ -266,10 +266,10 @@ workflows:
             branches:
               only:
                 - master
-      {%- endfor %}
-      {%- endif %}
-      {%- endfor %}
-  {%- endif %}
+      {%- endfor %}{# distribution in distributions #}
+      {%- endif %}{# if "dev" in ac_version and airflow_version not in dev_allowlist #}
+      {%- endfor %}{# ac_version, distributions in image_map.items() #}
+  {%- endif %}{# image_map.keys() | dev_releases | length > 0 #}
 
 jobs:
   rebase-astro-main:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -189,17 +189,29 @@ workflows:
       {%- set airflow_version = ac_version | get_airflow_version %}
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
+
+      {%- if edge_build %}
+      - download-file:
+          name: download-latest-{{ airflow_version | replace('.dev', '') }}-build
+          url: https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build
+          file: latest-{{ airflow_version | replace('.dev', '') }}.build
+      {%- endif %}
+
       {%- for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
+          {%- if edge_build %}
+          requires:
+            - download-latest-{{ airflow_version | replace('.dev', '') }}-build
+          {%- endif %}
           airflow_version: {{ airflow_version }}
           distribution_name: {{ distribution }}
           dev_build: true
           extra_args:
             {%- if edge_build %}
-            --tag $(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)
+            --tag $(cat latest-{{ airflow_version | replace('.dev', '') }}.build)
             {%- endif %}
-            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)
+            --build-arg VERSION=$(cat latest-{{ airflow_version | replace('.dev', '') }}.build)
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
@@ -304,6 +316,21 @@ jobs:
             pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
             pre-commit run --all-files || { git --no-pager diff && false ; }
+  download-file:
+    executor: machine-executor
+    description: Download a file to disk
+    parameters:
+      url:
+        description: The full URL to download from
+        type: string
+      file:
+        description: The output file to write to (existing files will be overwritten)
+        type: string
+    steps:
+      - run:
+          name: Downloading file with curl
+          command: |
+            curl << parameters.url >> > << parameters.file >>
   build:
     executor: docker-executor
     description: Build Airflow images

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -16,6 +16,7 @@ workflows:
       - static-checks
       {%- for ac_version, distributions in image_map.items() %}
       {%- set airflow_version = ac_version | get_airflow_version -%}
+      {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') -%}
       {%- set dev_build = "true" if "dev" in ac_version else "false" %}
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- if not edge_build %}
@@ -103,7 +104,7 @@ workflows:
           dev_build: {{ dev_build }}
           {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
           extra_args:
-            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build.json | jq -r '.output.astronomer_certified.package.version')
+            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build.json | jq -r '.output.astronomer_certified.package.version')
           {%- endif %}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
@@ -187,20 +188,22 @@ workflows:
     jobs:
       {%- for ac_version, distributions in image_map.items() %}
       {%- set airflow_version = ac_version | get_airflow_version %}
+      {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') -%}
       {%- set edge_build = ac_version | is_edge_build -%}
+      {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
 
       {%- if edge_build %}
       - download-file:
-          name: download-latest-{{ airflow_version | replace('.dev', '') }}-build-info
-          url: https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build.json
-          file: latest-{{ airflow_version | replace('.dev', '') }}.build.json
+          name: download-latest-{{ airflow_version_wout_dev }}-build-info
+          url: https://pip.astronomer.io/simple/astronomer-certified/{{ ext_build_filename }}
+          file: {{ ext_build_filename }}
       - write-version-to-tag-file:
-          name: write-version-to-tag-file-{{ airflow_version | replace('.dev', '') }}
-          input_json_file: latest-{{ airflow_version | replace('.dev', '') }}.build.json
-          output_file: extra-tags-{{ airflow_version | replace('.dev', '') }}.txt
+          name: write-version-to-tag-file-{{ airflow_version_wout_dev }}
+          input_json_file: {{ ext_build_filename }}
+          output_file: extra-tags-{{ airflow_version_wout_dev }}.txt
           requires:
-            - download-latest-{{ airflow_version | replace('.dev', '') }}-build-info
+            - download-latest-{{ airflow_version_wout_dev }}-build-info
       {%- endif %}{# edge_build #}
 
       {%- for distribution in distributions %}
@@ -210,18 +213,18 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: true
           extra_args:
-            --build-arg VERSION=$(jq -r '.output.airflow.package.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --build-arg VERSION=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename }})
             {%- if edge_build %}
-            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.ci.python.version_string=$(jq -r '.python.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.git.commit_sha=$(jq -r '.git.commit' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label org.apache.airflow.git.$(jq -r '.git.ref.type' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)=$(jq -r '.git.ref.name' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
-            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <latest-{{ airflow_version | replace('.dev', '') }}.build.json)
+            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename }})
+            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename }})
+            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename }})
+            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <{{ ext_build_filename }})
+            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <{{ ext_build_filename }})
+            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <{{ ext_build_filename }})
+            --label org.apache.airflow.ci.python.version_string=$(jq -r '.python.version' <{{ ext_build_filename }})
+            --label org.apache.airflow.git.commit_sha=$(jq -r '.git.commit' <{{ ext_build_filename }})
+            --label org.apache.airflow.git.$(jq -r '.git.ref.type' <{{ ext_build_filename }})=$(jq -r '.git.ref.name' <{{ ext_build_filename }})
+            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename }})
             {%- endif %}{# edge_build #}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
@@ -264,7 +267,7 @@ workflows:
           extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM}"
           {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
           {%- if edge_build %}
-          extra_tags_file: extra-tags-{{ airflow_version | replace('.dev', '') }}.txt
+          extra_tags_file: extra-tags-{{ airflow_version_wout_dev }}.txt
           {%- endif %}{# edge_build #}
           context:
             - quay.io
@@ -273,7 +276,7 @@ workflows:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
             {%- if edge_build %}
-            - write-version-to-tag-file-{{ airflow_version | replace('.dev', '') }}
+            - write-version-to-tag-file-{{ airflow_version_wout_dev }}
             {%- endif %}
           filters:
             branches:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -185,6 +185,7 @@ workflows:
     jobs:
 {%- for ac_version, distributions in image_map.items() %}
 {%- set airflow_version = ac_version | get_airflow_version %}
+{%- set edge_build = ac_version | is_edge_build -%}
 {%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
 {%- for distribution in distributions %}
       - build:
@@ -192,7 +193,11 @@ workflows:
           airflow_version: {{ airflow_version }}
           distribution_name: {{ distribution }}
           dev_build: true
-          extra_args: "--build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)"
+          extra_args:
+            {%- if edge_build %}
+            --tag $(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)
+            {%- endif %}
+            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version | replace('.dev', '') }}.build)
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -17,6 +17,8 @@ workflows:
 {%- for ac_version, distributions in image_map.items() %}
 {%- set airflow_version = ac_version | get_airflow_version -%}
 {%- set dev_build = "true" if "dev" in ac_version else "false" %}
+{%- set edge_build = ac_version | is_edge_build -%}
+{%- if not edge_build %}
       - slack/on-hold:
           name: Slack_Notification-{{ airflow_version }}
           context: slack_ap-airflow
@@ -172,6 +174,7 @@ workflows:
                 - master
                 - slack-build-approvals
 {%- endfor %}
+{%- endif %}
 {%- endfor %}
 {%- if image_map.keys() | dev_releases | length > 0 %}
   nightly:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -104,7 +104,7 @@ workflows:
           dev_build: {{ dev_build }}
           {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
           extra_args:
-            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build.json | jq -r '.output.astronomer_certified.package.version')
+            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)
           {%- endif %}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -6,7 +6,14 @@ so that we can stay DRY.
 
 from jinja2 import Environment, FileSystemLoader
 
-from common import circle_directory, DEV_ALLOWLIST, dev_releases, get_airflow_version, IMAGE_MAP
+from common import (
+    circle_directory,
+    DEV_ALLOWLIST,
+    dev_releases,
+    get_airflow_version,
+    IMAGE_MAP,
+    is_edge_build,
+)
 
 
 def generate_circleci_config():
@@ -17,6 +24,7 @@ def generate_circleci_config():
     template_env = Environment(loader=FileSystemLoader(searchpath=circle_directory), autoescape=True)
     template_env.filters['dev_releases'] = dev_releases
     template_env.filters['get_airflow_version'] = get_airflow_version
+    template_env.filters['is_edge_build'] = is_edge_build
     template = template_env.get_template("config.yml.j2")
 
     config = template.render(

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ All changes applied to available point releases will be documented in the `CHANG
 
 This testing will run automatically in CI, but it will save some time to try it out locally first.
 
-Airflow is launched into a local Kubernetes cluster using the project "kind" and the most recent version of the Astronomer airflow chart. Python's 'testinfra' module is used to perform system testing on the components while they are running in "kind".
+Airflow is launched into a local Kubernetes cluster using the project "kind" and the most recent
+version of the Astronomer airflow chart. Python's 'testinfra' module is used to perform system
+testing on the components while they are running in "kind".
 
 ### Ensure prerequisites are met:
 
@@ -356,7 +358,12 @@ Run system testing
 .circleci/bin/test-airflow airflow
 ```
 
-The first time you do the build, and the first time you do the system test it will take longer than subsequent runs. The system testing will install the tested versions of CI tools in /tmp/bin (helm, kubectl, kind). It will leave an airflow cluster running on your kind cluster in 'test-cluster'. When you run it again, it will delete the namespace of your most recent deployment and redeploy into a new namespace. If you make changes in the image, don't forget to re-build the image before testing it.
+The first time you do the build, and the first time you do the system test it will take longer
+than subsequent runs. The system testing will install the tested versions of CI tools in /tmp/bin
+(helm, kubectl, kind). It will leave an airflow cluster running on your kind cluster in
+'test-cluster'. When you run it again, it will delete the namespace of your most recent deployment
+and redeploy into a new namespace. If you make changes in the image, don't forget to re-build the
+image before testing it.
 
 Use the newly installed tools
 ```
@@ -377,6 +384,70 @@ Clean up
 ```
 kind delete cluster --name test-cluster
 ```
+
+## Scheduled Tasks
+
+The regularly scheduled tasks are:
+
+#### Edge Builds
+
+* Rebase the `astro-main` branch of [`astronomer/airflow`](https://github.com/astronomer/airflow)
+  onto `main` and push it to `astronomer/airflow:astro-main` (this then kicks off a GitHub Actions
+  workflow that builds Airflow and Astronomer Certified Python packages/wheels) and pushes them to
+  our PyPI package repository
+* Build nightly Docker images for QA (using those nightly Airflow and Astronomer Certified wheels)
+  and push them to the dev image repository
+
+### CircleCI Schedules
+
+The [CircleCI documentation](https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/scheduled-pipelines.md)
+on scheduled pipelines is very new and in slight disarray.
+
+See also:
+* The [announcement](https://discuss.circleci.com/t/scheduled-pipelines-are-here/41684/2) for
+  scheduled pipelines
+* This [relevant (for now) PR](https://github.com/CircleCI-Public/api-preview-docs/pull/104),
+  which includes an example of branch filtering
+* Documentation on [parameter syntax](https://circleci.com/docs/2.0/reusing-config/#parameter-syntax)
+* Documentation on [logic statements](https://circleci.com/docs/2.0/configuration-reference/#logic-statements)
+
+The API for manipulating schedules is documented [here](https://circleci.com/docs/api/v2/#tag/Schedule),
+including examples.
+
+Here is an example listing all schedules with HTTPie (and colorizing the response with `jq`):
+
+```bash
+$ http https://circleci.com/api/v2/project/gh/astronomer/ap-airflow/schedule \
+       circle-token:<CIRCLECI_PERSONAL_ACCESS_TOKEN> \
+       | jq
+```
+
+To create a new schedule (refer to the [HTTPie docs about raw JSON](https://httpie.io/docs#json)):
+
+```bash
+$ http --verbose \
+       https://circleci.com/api/v2/project/gh/astronomer/ap-airflow/schedule \
+       circle-token:<CIRCLECI_PERSONAL_ACCESS_TOKEN> \
+       name="every-morning-0200-UTC" \
+       description="Every morning at 02:00 UTC" \
+       attribution-actor="system" \
+       parameters:='{ "branch": "master" }' \
+       timetable:='{ "per-hour": 1, "hours-of-day": [2], "days-of-week": ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"]}'
+```
+
+Note that updating and deleting schedules uses a different URL path:
+
+```bash
+$ http PATCH \
+       https://circleci.com/api/v2/schedule/<schedule_uuid> \
+       circle-token:<CRCLECI_PERSONAL_ACCESS_TOKEN> \
+       name=every-sunday-0100-utc \
+       description="Every Sunday at 01:00 UTC"
+````
+
+You can create a CircleCI personal API token [in your CircleCI user settings](https://app.circleci.com/settings/user/tokens).
+Do note that a PAT will authenticate as you, and have full, read and write access on CircleCI, so
+keep your PAT secret and do not publish it anywhere!
 
 ## License
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR:

* Limits building "edge" images (from `astronomer/airflow:astro-main`) to only nightly builds
* Adds a YYYYMMDD image tag to the built Docker image
* Reformats the Jinja file that generates the CircleCI YAML configuration to make it easier to view both the Jinja and the generated YAML file

TODO:

* [x] Document all the things
* [x] Add a label to the image containing the commit hash of the Airflow version.
* [x] Might also be smart to include the commit hash of the ap-airflow version that built the image as well, just in case we have a non-reproducible image due to an updated build process.

**Special notes for your reviewer**:

It might be easier to review the commits individually (they're all small).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
