### PR TITLE
Add buster tag for 2.2.2

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -46,7 +46,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.4-3", ["buster"]),
     ("2.2.0-4", ["bullseye", "buster"]),
     ("2.2.1-2", ["bullseye", "buster"]),
-    ("2.2.2-1", ["bullseye"]),
+    ("2.2.2-1", ["bullseye", "buster"]),
     ("main.dev", ["bullseye"]),
 ])
 

--- a/2.2.2/buster
+++ b/2.2.2/buster
@@ -1,0 +1,1 @@
+bullseye


### PR DESCRIPTION
Parts of our stack still expect a tag with `buster` in it, unfortunately.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
