### PR TITLE
Configure user.name and user.email for git rebase/commit

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -274,6 +274,8 @@ jobs:
             export GIT_SSH_COMMAND="ssh -o IdentitiesOnly=yes -i $HOME/.ssh/id_rsa_110b156bf2773e93c5830e8a0a932e7e"
             git clone git@github.com:astronomer/airflow.git
             cd airflow
+            git config user.name "astronomer/ap-airflow GitHub:CircleCI integration"
+            git config user.email "astronomer@users.noreply.github.com"
             git branch --verbose
             git fetch --all
             git checkout astro-main


### PR DESCRIPTION
**What this PR does / why we need it**:

The nightly rebase [failed](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2117/workflows/55dbab3a-9ada-49ae-9b88-c105e4048e9d/jobs/50869) because `user.name` and `user.email` were not set. This PR simply sets them.