### PR TITLE
Fixes nightly builds

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -233,7 +233,8 @@ workflows:
           {%- endif %}
           requires:
             {%- if edge_build %}
-            - build-{{ airflow_version }}-{{ distribution }}
+            - download-latest-{{ airflow_version_wout_dev }}-build-info
+            - write-version-to-tag-file-{{ airflow_version_wout_dev }}
             {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -233,7 +233,6 @@ workflows:
           {%- endif %}
           requires:
             {%- if edge_build %}
-            - download-latest-{{ airflow_version_wout_dev }}-build-info
             - write-version-to-tag-file-{{ airflow_version_wout_dev }}
             {%- endif %}
       - scan-trivy:


### PR DESCRIPTION
Current error (https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2130/workflows/665b29ef-1ae1-4ae4-8e8d-39a9a12951a7/jobs/51312/steps):

```
#!/bin/sh -eo pipefail
# Job 'build-main-bullseye' requires 'build-main-bullseye', which is the name of 0 other jobs in workflow 'nightly'
#
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false
```
