### PR TITLE
Fix nightly build tagging

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -1,3 +1,4 @@
+{%- set workspace_prefix = '/tmp/workspace' -%}
 version: 2.1
 
 workflows:
@@ -191,7 +192,7 @@ workflows:
       {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') -%}
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
-      {%- set ext_build_filename_workspace = '/tmp/workspace/latest-' + airflow_version_wout_dev + '.build.json' %}
+      {%- set ext_build_filename_workspace = workspace_prefix + '/latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
 
       {%- if edge_build %}
@@ -429,10 +430,10 @@ jobs:
       - checkout
       - setup_remote_docker
       - attach_workspace:
-          at: /tmp/workspace
+          at: {{ workspace_prefix }}
       - run:
           name: Load archived Docker image
-          command: docker load -i /tmp/workspace/saved-images/<< parameters.image_name >>-onbuild.tar
+          command: docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar
       - run:
           name: Install trivy
           command: |
@@ -446,14 +447,14 @@ jobs:
           command: |
             trivy \
               --ignorefile "./<< parameters.airflow_version >>/<< parameters.distribution >>/trivyignore" \
-              --cache-dir /tmp/workspace/trivy-cache \
+              --cache-dir {{ workspace_prefix }}/trivy-cache \
               --ignore-unfixed -s HIGH,CRITICAL \
               --exit-code 1 \
               --no-progress "<< parameters.image_name >>-onbuild"
       - save_cache:
           key: trivy-cache
           paths:
-            - /tmp/workspace/trivy-cache
+            - {{ workspace_prefix }}/trivy-cache
   push:
     executor: docker-executor
     description: Push Airflow images
@@ -554,7 +555,7 @@ commands:
         default: ""
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: {{ workspace_prefix }}
       - run:
           name: Build the Docker image
           command: |
@@ -580,12 +581,12 @@ commands:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/workspace
+          at: {{ workspace_prefix }}
       - run:
           name: Load archived Airflow Docker image
           command: |
-            docker load -i /tmp/workspace/saved-images/ap-airflow:<< parameters.tag >>.tar
-            docker load -i /tmp/workspace/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
+            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>.tar
+            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
       - run:
           name: Test Airflow Docker images (Base + Onbuild)
           command: |
@@ -625,11 +626,11 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: {{ workspace_prefix }}
       - setup_remote_docker
       - run:
           name: Load archived Docker image
-          command: docker load -i '/tmp/workspace/saved-images/ap-airflow:<< parameters.tag >>.tar'
+          command: docker load -i '{{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>.tar'
       - run:
           name: Login to DockerHub
           command: echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.io

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -366,7 +366,7 @@ jobs:
           command: |
             echo "Input JSON file:"
             cat << parameters.file >>
-            jq '.output.astronomer_certified.package.version' < << parameters.file >> > << parameters.output_file >>
+            jq --raw-output '.output.astronomer_certified.package.version' < << parameters.file >> > << parameters.output_file >>
             echo "Output newline-separated file:"
             cat << parameters.output_file >>
       - persist_to_workspace:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -264,7 +264,7 @@ workflows:
           extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM}"
           {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
           {%- if edge_build %}
-          extra_tags_file: extra-tags-{{ airflow_version_wout_dev }}.txt
+          extra_tags_file: {{ workspace_prefix }}/extra-tags-{{ airflow_version_wout_dev }}.txt
           {%- endif %}{# edge_build #}
           context:
             - quay.io
@@ -484,6 +484,8 @@ jobs:
         default: "quay.io/astronomer/ap-airflow-dev"
         type: string
     steps:
+      - attach_workspace:
+          at: {{ workspace_prefix }}
       - push:
           dev_release: "<< parameters.dev_build >>"
           extra_tags: "<< parameters.extra_tags >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Judging from [this line](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2155/workflows/b6afb3d8-dae7-4e06-9d24-8ada996478fd/jobs/51585?invite=true#step-106-70) of the build output, the `extra-tags-main.txt` file didn't exist when the "Push Docker image(s)" job step ran. My best guess is that, while the build file was [persisted to the workspace](https://github.com/astronomer/ap-airflow/pull/361/files#diff-dc966af4263c0633167a31cdea357f336b51ee74e7d62d341f251d1db94a21edR545) (hat tip to @kaxil), the workspace was not loaded for the `push` step.

This PR fixes that by putting the workspace path into a Jinja variable for better reuse and attaching the workspace for the `push` job.

Additionally, this PR fixes an instance where `jq` writes a non-raw, quoted string to a file where it should just contain a non-quoted string, which would have also tripped us up.