### PR TITLE
Fix nightly non-main dev builds

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -228,10 +228,10 @@ workflows:
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
           {%- endif %}
+          {%- if edge_build %}
           requires:
-            {%- if edge_build %}
             - download-latest-{{ airflow_version_wout_dev }}-build-info
-            {%- endif %}
+          {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: {{ airflow_version }}


### PR DESCRIPTION
The nightly builds are failing with the following parsing error. Example: https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2171/workflows/46fce502-62ca-4975-a580-9b9c9498869a/jobs/51888

```
#!/bin/sh -eo pipefail
# Circular job dependency detected: \"download-latest-main-build-info\" -> \"build-2.2.2-bullseye\" -> \"build-2.2.1-buster\" -> \"build-2.2.2-bullseye\"
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false
```