### PR TITLE
Fix dev builds

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -210,7 +210,7 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: true
           extra_args:
-            --build-arg VERSION=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename_workspace }})
+            --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)"
             {%- if edge_build %}
             --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename_workspace }})
             --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename_workspace }})


### PR DESCRIPTION
For Dev but non-edge builds we still use `latest-***.build` file instead of the `*.json` file for main builds.

This PR fixes the error in https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2178/workflows/b71ba65c-be64-492d-af77-40c230e6214c/jobs/51974
