### PR TITLE
Linkify things and swap out pull request for Git SHA info

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -42,11 +42,11 @@ workflows:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Project*:\n    $CIRCLE_PROJECT_REPONAME :circleci:"
+                      "text": "*Project*:\n    <https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH&filter=all|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME :circleci:>"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Branch*:\n    $CIRCLE_BRANCH"
+                      "text": "*Branch*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH|`$CIRCLE_BRANCH`>"
                     },
                     {
                       "type": "mrkdwn",
@@ -54,7 +54,7 @@ workflows:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Pull Request*:\n    <$CIRCLE_PULL_REQUEST|$CIRCLE_PR_REPONAME#$CIRCLE_PR_NUMBER>"
+                      "text": "*Git SHA*:\n    https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|`${CIRCLE_SHA1:0:7}`>"
                     }
                   ]
                 },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR linkifies the CircleCI project and branch fields, and changes the pull request field to a direct link to the Git SHA on GitHub.

We don't make releases from pull requests, so the pull request environment variables weren't set it CircleCI anyway.

I also expect us to separate out some of the older releases into separate branch(es) at some point, so while the branch field isn't currently really useful at the moment, I expect it to be in the future.

Partial screenshots:

![Screen Shot 2021-12-13 at 12 41 51 PM](https://user-images.githubusercontent.com/597113/145885863-2e9c0fcd-1966-4601-9f90-716dd93091c9.png) ![Screen Shot 2021-12-13 at 12 42 05 PM](https://user-images.githubusercontent.com/597113/145885867-19cb5aad-31f2-4106-8ab1-425b4fa353fd.png)