### PR TITLE
Pull the VERSION build arg from the correct build info file

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -233,8 +233,10 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: true
           extra_args:
+            {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)
-            {%- if edge_build %}
+            {%- else %}
+            --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
             --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename_workspace }})
             --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename_workspace }})
             --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename_workspace }})


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the build by pulling the version info from the `latest-main.build.json` file instead of the (out of date) `latest-main.build` file.

We should probably remove the `latest-main.build` file from the server so it causes louder errors in the future.