### PR TITLE
Send Slack notifications and update QA database on new releases

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -206,6 +206,27 @@ workflows:
               only:
                 - master
                 - slack-build-approvals
+      {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
+      - slack-notification:
+          name: slack-notification-{{ airflow_version }}-{{ distribution }}-onbuild
+          dev_build: {{ dev_build }}
+          airflow_version: "{{ airflow_version }}"
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          {%- else %}
+          tag: "{{ airflow_version }}-onbuild"
+          extra_tags: "{{ airflow_version }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-onbuild"
+          {%- endif %}
+          context:
+            - slack_ap-airflow
+          requires:
+            - push-{{ airflow_version }}-{{ distribution }}-onbuild
+          filters:
+            branches:
+              only:
+                - master
+      {%- endif %}
       {%- endfor %}{# distribution in distributions #}
       {%- endif %}{# not edge_build #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
@@ -524,8 +545,88 @@ jobs:
           prod_docker_repo_quay_io: "<< parameters.prod_docker_repo_quay_io >>"
           dev_docker_repo_quay_io: "<< parameters.dev_docker_repo_quay_io >>"
 
+  slack-notification:
+    executor: docker-executor
+    description: Push Airflow images
+    parameters:
+      dev_build:
+        description: "Indicate if this is a dev build"
+        type: boolean
+      airflow_version:
+        type: string
+      tag:
+        type: string
+      extra_tags:
+        type: string
+        default: ""
+    steps:
+      - slack/notify:
+          branch_pattern: master,push_tags_db
+          channel: airflow-ac-build-tags
+          event: pass
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":tada:    *New Astronomer Certified DEV Build*    :tada:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "<< parameters.airflow_version >> Development Image(s) Released"
+                  },
+                  "accessory": {
+                    "type": "image",
+                    "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
+                    "alt_text": "Docker Image"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Image Registry*:\n    <https://quay.io/repository/astronomer/ap-airflow-dev?tag=latest&tab=tags|ap-airflow-dev>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Tags*:\n    << parameters.extra_tags >>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Author*:\n    $CIRCLE_USERNAME"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Git SHA*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|`${CIRCLE_SHA1:0:7}`>"
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "plain_text",
+                      "text": "Release Owners: Airflow Team [<@UHRPL613K>,<@U01PS0N06DN>]",
+                      "emoji": true
+                    }
+                  ]
+                }
+              ]
+            }
 orbs:
-  slack: circleci/slack@4.2.0
+  slack: circleci/slack@4.4.4
   clair-scanner: ovotech/clair-scanner@1.6.0
 executors:
   docker-executor:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -168,6 +168,7 @@ workflows:
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}
           dev_build: {{ dev_build }}
+          edge_build: {{ edge_build }}
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
@@ -188,6 +189,7 @@ workflows:
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: {{ dev_build }}
+          edge_build: {{ edge_build }}
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
@@ -306,6 +308,7 @@ workflows:
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}
           dev_build: true
+          edge_build: {{ edge_build }}
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
@@ -330,6 +333,7 @@ workflows:
       - push:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: true
+          edge_build: {{ edge_build }}
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
@@ -514,6 +518,9 @@ jobs:
       dev_build:
         description: "Indicate if this is a dev build"
         type: boolean
+      edge_build:
+        description: "Indicate if this is an edge build"
+        type: boolean
       tag:
         type: string
       extra_tags:
@@ -540,6 +547,7 @@ jobs:
           at: {{ workspace_prefix }}
       - push:
           dev_release: << parameters.dev_build >>
+          edge_build: << parameters.edge_build >>
           extra_tags: "<< parameters.extra_tags >>"
           extra_tags_file: "<< parameters.extra_tags_file >>"
           tag: "<< parameters.tag >>"
@@ -737,6 +745,9 @@ commands:
         description: "Indicate if this is a dev release"
         default: true
         type: boolean
+      edge_build:
+        description: "Indicate if this is an edge build"
+        type: boolean
       extra_tags:
         type: string
         default: ""
@@ -797,12 +808,6 @@ commands:
               echo "${DOCKER_TAGS[@]}"
             fi
 
-            if [[ "<< parameters.tag >>" == *"main"* ]]; then
-              edge_build=true
-            else
-              edge_build=false
-            fi
-
             for tag in "${DOCKER_TAGS[@]}";
             do
               if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "<< parameters.prod_docker_repo_docker_hub >>:$tag" >/dev/null 2>&1; then
@@ -830,7 +835,7 @@ commands:
                        --dbname="$QA_RELEASEINFO_DATABASE" \
                        --username="$QA_RELEASEINFO_USERNAME" \
                        --command="INSERT INTO tag_version (version_1,    latest_tag, previous_tag, is_latest)
-                                       VALUES             ('${release}', '${tag}',   NULL,         ${edge_build})
+                                       VALUES             ('${release}', '${tag}',   NULL,         << parameters.edge_build >>)
                                   ON CONFLICT (version_1)
                                   DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
                                                 previous_tag = tag_version.latest_tag;"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -319,6 +319,7 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
@@ -339,6 +340,7 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
@@ -537,7 +539,7 @@ jobs:
       - attach_workspace:
           at: {{ workspace_prefix }}
       - push:
-          dev_release: "<< parameters.dev_build >>"
+          dev_release: << parameters.dev_build >>
           extra_tags: "<< parameters.extra_tags >>"
           extra_tags_file: "<< parameters.extra_tags_file >>"
           tag: "<< parameters.tag >>"
@@ -795,15 +797,44 @@ commands:
               echo "${DOCKER_TAGS[@]}"
             fi
 
+            if [[ "<< parameters.tag >>" == *"main"* ]]; then
+              edge_build=true
+            else
+              edge_build=false
+            fi
+
             for tag in "${DOCKER_TAGS[@]}";
             do
               if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "<< parameters.prod_docker_repo_docker_hub >>:$tag" >/dev/null 2>&1; then
                 echo "Image with Tag ("<< parameters.prod_docker_repo_docker_hub >>:$tag") already exists"
                 export NEW_POINT_RELEASE=false
+
               elif [[ "$tag" == "<< parameters.tag >>-$CIRCLE_BUILD_NUM" ]] || <<parameters.dev_release >> ; then
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.dev_docker_repo_quay_io >>"
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
+
+                echo "Build TAG artifact using environment variables and into DB"
+
+                if [[ "${tag}" == *"onbuild-"* ]]; then
+                  release="$( cut -d '-' -f 1 \<<< "$tag" )"
+                  sudo apt-get install postgresql postgresql-contrib
+                  echo "UPSERT into the DB with the latest dev TAG"
+
+                  # Connect to the database, run the query, then disconnect
+                  PGPASSWORD="$QA_RELEASEINFO_PASSWORD" \
+                  psql --tuples-only \
+                       --no-align \
+                       --host="$QA_RELEASEINFO_HOST" \
+                       --port=5432 \
+                       --dbname="$QA_RELEASEINFO_DATABASE" \
+                       --username="$QA_RELEASEINFO_USERNAME" \
+                       --command="INSERT INTO tag_version (version_1,    latest_tag, previous_tag, is_latest)
+                                       VALUES             ('${release}', '${tag}',   NULL,         ${edge_build})
+                                  ON CONFLICT (version_1)
+                                  DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
+                                                previous_tag = tag_version.latest_tag;"
+                fi
 
               else
                 echo "Tagging and pushing image <<parameters.image_name>>:$tag to << parameters.prod_docker_repo_quay_io >>"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -819,12 +819,10 @@ commands:
                 docker tag "$image" "<< parameters.dev_docker_repo_quay_io >>:${tag}"
                 docker push "<< parameters.dev_docker_repo_quay_io >>:${tag}"
 
-                echo "Build TAG artifact using environment variables and into DB"
-
                 if [[ "${tag}" == *"onbuild-"* ]]; then
                   release="$( cut -d '-' -f 1 \<<< "$tag" )"
                   sudo apt-get install postgresql postgresql-contrib
-                  echo "UPSERT into the DB with the latest dev TAG"
+                  echo "UPSERT the latest tag '${tag}' for '${release}' into the QA DB"
 
                   # Connect to the database, run the query, then disconnect
                   PGPASSWORD="$QA_RELEASEINFO_PASSWORD" \

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -26,7 +26,13 @@ workflows:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":tada:    *New Astronomer Certified Build*    :tada:\n\nRelease(s) Awaiting Approval"
+                    "text": ":tada:    *New Astronomer Certified Build*    :tada:"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Release(s) Awaiting Approval"
                   },
                   "accessory": {
                     "type": "image",


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves #334, resolves #354.

This PR does three things:

* [x] Tweaks a Slack notification template to improve the look on small-width screens
* [x] Adds Slack notifications for non-edge builds
* [x] Updates the QA database when new tags are built

The UPSERT attempts to INSERT data into the table, and when the unique constraint on the `version_1` column is violated, it then attempts to UPDATE the same row using the latest tag from the rejected ("excluded") data and moving the previous latest tag to the previous tag:

```sql
INSERT INTO tag_version (version_1,    latest_tag, previous_tag, is_latest)
     VALUES             ('${release}', '${tag}',   NULL,         << parameters.edge_build >>)
ON CONFLICT (version_1)
DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
              previous_tag = tag_version.latest_tag;
```

The `is_latest` column is used to identify versions built from edge builds. It is always `true` for edge builds and `false` for versioned dev builds.

This UPSERT is executed atomically and in a single query, ensuring that there are no race conditions.

<summary>

I have included some SQL tests of the UPSERT query. Click to expand:

<details>

```sql
postgres=# CREATE TABLE "tag_version" (
postgres(#   id SERIAL PRIMARY KEY,
postgres(#   version_1 VARCHAR(50),
postgres(#   latest_tag VARCHAR(50),
postgres(#   previous_tag VARCHAR(50),
postgres(#   is_latest BOOLEAN,
postgres(#   UNIQUE(version_1)
postgres(# );
CREATE TABLE
postgres=#
postgres=#
postgres=#
postgres=# INSERT INTO tag_version (version_1, latest_tag,          previous_tag, is_latest)
postgres-#      VALUES      ('2.0.0',   '2.0.0-edge-oldtag', NULL,         true);
INSERT 0 1
postgres=# INSERT INTO tag_version (version_1, latest_tag,          previous_tag, is_latest)
postgres-#      VALUES      ('2.1.0',   '2.1.0-edge-oldtag', NULL,         true);
INSERT 0 1
postgres=#
postgres=# SELECT * FROM tag_version;
 id | version_1 |    latest_tag     | previous_tag | is_latest
----+-----------+-------------------+--------------+-----------
  1 | 2.0.0     | 2.0.0-edge-oldtag |              | t
  2 | 2.1.0     | 2.1.0-edge-oldtag |              | t
(2 rows)

postgres=#
postgres=#
postgres=#
postgres=# INSERT INTO tag_version (version_1, latest_tag,          previous_tag, is_latest)
postgres-#      VALUES      ('2.1.0',   '2.1.0-edge-newtag', NULL,         false)
postgres-# ON CONFLICT (version_1)
postgres-# DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
postgres-#               previous_tag = tag_version.latest_tag;
INSERT 0 1
postgres=#
postgres=# SELECT * FROM tag_version;
 id | version_1 |    latest_tag     |   previous_tag    | is_latest
----+-----------+-------------------+-------------------+-----------
  1 | 2.0.0     | 2.0.0-edge-oldtag |                   | t
  2 | 2.1.0     | 2.1.0-edge-newtag | 2.1.0-edge-oldtag | t
(2 rows)

postgres=#
postgres=#
postgres=#
postgres=# INSERT INTO tag_version (version_1, latest_tag,          previous_tag, is_latest)
postgres-#      VALUES      ('2.2.0',   '2.2.0-release-tag', NULL,         false)
postgres-# ON CONFLICT (version_1)
postgres-# DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
postgres-#               previous_tag = tag_version.latest_tag;
INSERT 0 1
postgres=#
postgres=# SELECT * FROM tag_version;
 id | version_1 |    latest_tag     |   previous_tag    | is_latest
----+-----------+-------------------+-------------------+-----------
  1 | 2.0.0     | 2.0.0-edge-oldtag |                   | t
  2 | 2.1.0     | 2.1.0-edge-newtag | 2.1.0-edge-oldtag | t
  4 | 2.2.0     | 2.2.0-release-tag |                   | f
(3 rows)

postgres=#
postgres=#
postgres=#
postgres=# INSERT INTO tag_version (version_1, latest_tag,            previous_tag, is_latest)
postgres-#      VALUES      ('2.2.0',   '2.2.0-release-tag-2', NULL,         false)
postgres-# ON CONFLICT (version_1)
postgres-# DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
postgres-#               previous_tag = tag_version.latest_tag;
INSERT 0 1
postgres=#
postgres=# SELECT * FROM tag_version;
 id | version_1 |     latest_tag      |   previous_tag    | is_latest
----+-----------+---------------------+-------------------+-----------
  1 | 2.0.0     | 2.0.0-edge-oldtag   |                   | t
  2 | 2.1.0     | 2.1.0-edge-newtag   | 2.1.0-edge-oldtag | t
  4 | 2.2.0     | 2.2.0-release-tag-2 | 2.2.0-release-tag | f
(3 rows)

postgres=#
postgres=#
postgres=#
postgres=# INSERT INTO tag_version (version_1, latest_tag, previous_tag, is_latest)
postgres-#      VALUES      ('2.3.0',   '2.3.0',    NULL,         false)
postgres-# ON CONFLICT (version_1)
postgres-# DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
postgres-#               previous_tag = tag_version.latest_tag;
INSERT 0 1
postgres=#
postgres=# SELECT * FROM tag_version;
 id | version_1 |     latest_tag      |   previous_tag    | is_latest
----+-----------+---------------------+-------------------+-----------
  1 | 2.0.0     | 2.0.0-edge-oldtag   |                   | t
  2 | 2.1.0     | 2.1.0-edge-newtag   | 2.1.0-edge-oldtag | t
  4 | 2.2.0     | 2.2.0-release-tag-2 | 2.2.0-release-tag | f
  6 | 2.3.0     | 2.3.0               |                   | f
(4 rows)

postgres=#
postgres=#
postgres=#
postgres=# INSERT INTO tag_version (version_1, latest_tag,   previous_tag, is_latest)
postgres-#      VALUES      ('2.3.0',   '2.3.0-asdf', NULL,         false)
postgres-# ON CONFLICT (version_1)
postgres-# DO UPDATE SET   latest_tag = EXCLUDED.latest_tag,
postgres-#               previous_tag = tag_version.latest_tag;
INSERT 0 1
postgres=#
postgres=# SELECT * FROM tag_version;
 id | version_1 |     latest_tag      |   previous_tag    | is_latest
----+-----------+---------------------+-------------------+-----------
  1 | 2.0.0     | 2.0.0-edge-oldtag   |                   | t
  2 | 2.1.0     | 2.1.0-edge-newtag   | 2.1.0-edge-oldtag | t
  4 | 2.2.0     | 2.2.0-release-tag-2 | 2.2.0-release-tag | f
  6 | 2.3.0     | 2.3.0-asdf          | 2.3.0             | f
(4 rows)
```
</details>
</summary>

Full releases are recorded in the QA database but are not announced to the new tag announcement channel on Slack.

This may require some post-merge fixups as I fix the `push` command.