### PR TITLE
Fix JSON syntax in Slack notification

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -27,6 +27,7 @@ workflows:
                   "text": {
                     "type": "mrkdwn",
                     "text": ":tada:    *New Astronomer Certified Build*    :tada:"
+                  }
                 },
                 {
                   "type": "section",


### PR DESCRIPTION
**What this PR does / why we need it**:

One character fix for the Slack notification for release approval.

Currently blocking the AC 2.2.3-1 release.