### PR TITLE
Fix release builds

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -808,10 +808,10 @@ commands:
               do
                 DOCKER_TAGS+=($tag)
               done < "<< parameters.extra_tags_file >>"
-
-              echo "DOCKER_TAGS:"
-              echo "${DOCKER_TAGS[@]}"
             fi
+
+            echo "DOCKER_TAGS:"
+            echo "${DOCKER_TAGS[@]}"
 
             for tag in "${DOCKER_TAGS[@]}";
             do

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -180,6 +180,7 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
@@ -201,6 +202,7 @@ workflows:
           context:
             - quay.io
             - docker.io
+            - qa
           requires:
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes release builds by include the `qa` context to the `push` jobs in the non-nightly workflow.