### PR TITLE
Update release date for `2.2.3-1`

### DIFF
--- a/2.2.3/CHANGELOG.md
+++ b/2.2.3/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Astronomer Certified 2.2.3-1, TBD
+Astronomer Certified 2.2.3-1, 2021-12-21
 ----------------------------------------
 
 User-facing CHANGELOG for AC 2.2.3+astro.1 from Airflow 2.2.3:


### PR DESCRIPTION
The release date was missing in https://github.com/astronomer/ap-airflow/pull/381

(depends on #389)

Only review last commit - https://github.com/astronomer/ap-airflow/pull/389/commits/4428ac5df70460687240d649904822fbadbc3242