### PR TITLE
Move CVE fixes for `2.1.0-2.2.3`

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -667,6 +667,7 @@ commands:
           project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}-app
           severity-threshold: high
           organization: ${SNYK_CICD_ORGANIZATION}
+          additional-arguments: "--fail-on=all"
   push:
     description: "Push a Docker image to DockerHub"
     parameters:

--- a/2.1.0/buster/build-time-pip-constraints.txt
+++ b/2.1.0/buster/build-time-pip-constraints.txt
@@ -169,7 +169,7 @@ msrestazure==0.6.4
 mypy-extensions==0.4.3
 mysql-connector-python==8.0.22
 mysqlclient==2.0.3
-numpy==1.20.3
+numpy==1.21.5
 oauthlib==2.1.0
 openapi-schema-validator==0.1.5
 openapi-spec-validator==0.3.0

--- a/2.1.0/buster/build-time-pip-constraints.txt
+++ b/2.1.0/buster/build-time-pip-constraints.txt
@@ -79,7 +79,7 @@ email-validator==1.1.2
 eventlet==0.31.0
 filelock==3.0.12
 Flask==1.1.2
-Flask-AppBuilder==3.3.0
+Flask-AppBuilder==3.4.3
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.10.1

--- a/2.1.0/buster/build-time-pip-constraints.txt
+++ b/2.1.0/buster/build-time-pip-constraints.txt
@@ -180,7 +180,7 @@ paramiko==2.7.2
 pendulum==2.1.2
 plyvel==1.3.0
 portalocker==1.7.1
-prison==0.1.3
+prison==0.2.1
 prometheus-client==0.8.0
 proto-plus==1.18.1
 protobuf==3.16.0

--- a/2.1.0/buster/trivyignore
+++ b/2.1.0/buster/trivyignore
@@ -20,3 +20,11 @@ CVE-2020-7774
 # and Kubernetes Python client is already using safe_load
 # Details: https://github.com/astronomer/issues-airflow/issues/39
 CVE-2020-1747
+
+# Airflow 2.1.0 only supports Celery 4,
+# so we cannot upgrade to Celery 5.2.2+ to fix this.
+# In addition, this does require manipulation in the celery
+# backend.
+# Snyk also lists this as medium (contrary to the CVE):
+# https://security.snyk.io/vuln/SNYK-PYTHON-CELERY-2314953
+CVE-2021-23727

--- a/2.1.1/buster/build-time-pip-constraints.txt
+++ b/2.1.1/buster/build-time-pip-constraints.txt
@@ -332,7 +332,7 @@ neo4j==4.3.1
 nest-asyncio==1.5.1
 nodeenv==1.6.0
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==2.1.0
 openapi-schema-validator==0.1.5

--- a/2.1.1/buster/build-time-pip-constraints.txt
+++ b/2.1.1/buster/build-time-pip-constraints.txt
@@ -4,7 +4,7 @@ APScheduler==3.6.3
 Authlib==0.15.4
 Babel==2.9.1
 Deprecated==1.2.12
-Flask-AppBuilder==3.3.1
+Flask-AppBuilder==3.4.3
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.10.1

--- a/2.1.1/buster/build-time-pip-constraints.txt
+++ b/2.1.1/buster/build-time-pip-constraints.txt
@@ -359,7 +359,7 @@ plyvel==1.3.0
 portalocker==1.7.1
 pre-commit==2.13.0
 presto-python-client==0.7.0
-prison==0.1.3
+prison==0.2.1
 prometheus-client==0.8.0
 prompt-toolkit==3.0.19
 proto-plus==1.18.1

--- a/2.1.1/buster/trivyignore
+++ b/2.1.1/buster/trivyignore
@@ -20,3 +20,11 @@ CVE-2020-7774
 # and Kubernetes Python client is already using safe_load
 # Details: https://github.com/astronomer/issues-airflow/issues/39
 CVE-2020-1747
+
+# Airflow 2.1.1 only supports Celery 4,
+# so we cannot upgrade to Celery 5.2.2+ to fix this.
+# In addition, this does require manipulation in the celery
+# backend.
+# Snyk also lists this as medium (contrary to the CVE):
+# https://security.snyk.io/vuln/SNYK-PYTHON-CELERY-2314953
+CVE-2021-23727

--- a/2.1.3/buster/build-time-pip-constraints.txt
+++ b/2.1.3/buster/build-time-pip-constraints.txt
@@ -335,7 +335,7 @@ nest-asyncio==1.5.1
 nodeenv==1.6.0
 nox==2020.12.31
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==3.1.1
 openapi-schema-validator==0.1.5

--- a/2.1.3/buster/build-time-pip-constraints.txt
+++ b/2.1.3/buster/build-time-pip-constraints.txt
@@ -3,7 +3,7 @@ APScheduler==3.6.3
 Authlib==0.15.4
 Babel==2.9.1
 Deprecated==1.2.12
-Flask-AppBuilder==3.3.2
+Flask-AppBuilder==3.4.3
 Flask-Babel==1.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.10.1

--- a/2.1.3/buster/build-time-pip-constraints.txt
+++ b/2.1.3/buster/build-time-pip-constraints.txt
@@ -363,7 +363,7 @@ plyvel==1.3.0
 portalocker==1.7.1
 pre-commit==2.13.0
 presto-python-client==0.7.0
-prison==0.1.3
+prison==0.2.1
 prometheus-client==0.8.0
 prompt-toolkit==3.0.19
 proto-plus==1.19.0

--- a/2.1.3/buster/trivyignore
+++ b/2.1.3/buster/trivyignore
@@ -20,3 +20,11 @@ CVE-2020-7774
 # and Kubernetes Python client is already using safe_load
 # Details: https://github.com/astronomer/issues-airflow/issues/39
 CVE-2020-1747
+
+# Airflow 2.1.3 only supports Celery 4,
+# so we cannot upgrade to Celery 5.2.2+ to fix this.
+# In addition, this does require manipulation in the celery
+# backend.
+# Snyk also lists this as medium (contrary to the CVE):
+# https://security.snyk.io/vuln/SNYK-PYTHON-CELERY-2314953
+CVE-2021-23727

--- a/2.1.4/buster/build-time-pip-constraints.txt
+++ b/2.1.4/buster/build-time-pip-constraints.txt
@@ -334,7 +334,7 @@ nest-asyncio==1.5.1
 nodeenv==1.6.0
 nox==2020.12.31
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==3.1.1
 openapi-schema-validator==0.1.5

--- a/2.1.4/buster/trivyignore
+++ b/2.1.4/buster/trivyignore
@@ -20,3 +20,11 @@ CVE-2020-7774
 # and Kubernetes Python client is already using safe_load
 # Details: https://github.com/astronomer/issues-airflow/issues/39
 CVE-2020-1747
+
+# Airflow 2.1.4 only supports Celery 4,
+# so we cannot upgrade to Celery 5.2.2+ to fix this.
+# In addition, this does require manipulation in the celery
+# backend.
+# Snyk also lists this as medium (contrary to the CVE):
+# https://security.snyk.io/vuln/SNYK-PYTHON-CELERY-2314953
+CVE-2021-23727

--- a/2.2.0/bullseye/build-time-pip-constraints.txt
+++ b/2.2.0/bullseye/build-time-pip-constraints.txt
@@ -339,7 +339,7 @@ nest-asyncio==1.5.1
 nodeenv==1.6.0
 nox==2020.12.31
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==3.1.1
 openapi-schema-validator==0.1.5

--- a/2.2.1/bullseye/build-time-pip-constraints.txt
+++ b/2.2.1/bullseye/build-time-pip-constraints.txt
@@ -339,7 +339,7 @@ nest-asyncio==1.5.1
 nodeenv==1.6.0
 nox==2020.12.31
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==3.1.1
 openapi-schema-validator==0.1.5

--- a/2.2.2/bullseye/build-time-pip-constraints.txt
+++ b/2.2.2/bullseye/build-time-pip-constraints.txt
@@ -342,7 +342,7 @@ nest-asyncio==1.5.1
 nodeenv==1.6.0
 nox==2020.12.31
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==3.1.1
 openapi-schema-validator==0.1.5

--- a/2.2.3/bullseye/build-time-pip-constraints.txt
+++ b/2.2.3/bullseye/build-time-pip-constraints.txt
@@ -2,7 +2,7 @@ APScheduler==3.6.3
 Authlib==0.15.5
 Babel==2.9.1
 Deprecated==1.2.13
-Flask-AppBuilder==3.3.4
+Flask-AppBuilder==3.4.3
 Flask-Babel==2.0.0
 Flask-Bcrypt==0.7.1
 Flask-Caching==1.10.1
@@ -41,7 +41,7 @@ alabaster==0.7.12
 alembic==1.7.4
 aliyun-python-sdk-core==2.13.35
 aliyun-python-sdk-kms==2.15.0
-amqp==5.0.6
+amqp==5.0.9
 analytics-python==1.4.0
 ansiwrap==0.8.4
 anyio==3.3.4
@@ -165,7 +165,7 @@ bowler==0.9.0
 cachetools==4.2.2
 cassandra-driver==3.25.0
 cattrs==1.5.0
-celery==5.2.0
+celery==5.2.3
 certifi==2020.12.5
 cffi==1.15.0
 cfgv==3.3.1
@@ -304,7 +304,7 @@ jupyter-client==7.0.6
 jupyter-core==4.9.1
 jwcrypto==1.0
 keyring==23.2.1
-kombu==5.2.1
+kombu==5.2.3
 krb5==0.2.0
 kubernetes==11.0.0
 kylinpy==2.8.4

--- a/2.2.3/bullseye/build-time-pip-constraints.txt
+++ b/2.2.3/bullseye/build-time-pip-constraints.txt
@@ -342,7 +342,7 @@ nest-asyncio==1.5.1
 nodeenv==1.6.0
 nox==2020.12.31
 ntlm-auth==1.5.0
-numpy==1.20.3
+numpy==1.21.5
 oauth2client==4.1.3
 oauthlib==3.1.1
 openapi-schema-validator==0.1.5


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes, or ignores, all the CVE issues in `2.1.0` through `2.2.3`.

Note, this changes the behavior of snyk to only exit non-zero if there are _fixable_ issues. As of now, none of the issues found in debian 10/11 have fixes upstream, so there is no easy resolution to them.

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
