### PR TITLE
Add shellcheck pre-commit hook. Fix complaints.

### DIFF
--- a/.circleci/bin/install-ci-tools
+++ b/.circleci/bin/install-ci-tools
@@ -22,7 +22,7 @@ if [[ -f /tmp/bin/kind ]]; then
 else
   echo "Installing kind"
   cd /tmp
-  curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-amd64 > /dev/null 2>&1
+  curl -fsSLo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-${OS}-amd64" > /dev/null 2>&1
   chmod +x ./kind
   mv ./kind /tmp/bin/
 fi
@@ -31,9 +31,9 @@ if [[ -f /tmp/bin/helm ]]; then
   echo "helm is already installed."
 else
   echo "Installing helm"
-  wget https://get.helm.sh/helm-v${HELM_VERSION}-${OS}-amd64.tar.gz > /dev/null 2>&1
-  tar -zxvf ./helm-v${HELM_VERSION}-${OS}-amd64.tar.gz
-  mv ${OS}-amd64/helm /tmp/bin/
+  wget "https://get.helm.sh/helm-v${HELM_VERSION}-${OS}-amd64.tar.gz" > /dev/null 2>&1
+  tar -zxvf "./helm-v${HELM_VERSION}-${OS}-amd64.tar.gz"
+  mv "${OS}-amd64/helm" /tmp/bin/
 fi
 
 if [[ -f /tmp/bin/kubectl ]]; then
@@ -41,8 +41,8 @@ if [[ -f /tmp/bin/kubectl ]]; then
 else
   echo "Installing kubectl"
   cd /tmp/bin
-  curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/${OS}/amd64/kubectl
+  curl -fsSLO "https://storage.googleapis.com/kubernetes-release/release/$(curl -fsSL https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/${OS}/amd64/kubectl"
   chmod +x ./kubectl
 fi
 
-cd $STARTING_DIR
+cd "$STARTING_DIR"

--- a/.circleci/bin/start-kind-cluster
+++ b/.circleci/bin/start-kind-cluster
@@ -8,12 +8,12 @@ set +e
 # Start a cluster, if it does not already exist
 export CLUSTER_NAME=test-cluster
 if ! kind get clusters | grep $CLUSTER_NAME; then
-  kind create cluster --name $CLUSTER_NAME --image kindest/node:${KUBE_VERSION}
   # Kind will fail sometimes, it's worth retrying once.
-  if ! [[ $? -eq 0 ]]; then
+  if ! kind create cluster --name "$CLUSTER_NAME" --image "kindest/node:${KUBE_VERSION}"
+  then
     echo "Failed to create kind cluster, trying one more time"
-    kind delete cluster --name $CLUSTER_NAME || true
-    kind create cluster --name $CLUSTER_NAME --image kindest/node:${KUBE_VERSION}
+    kind delete cluster --name "$CLUSTER_NAME" || true
+    kind create cluster --name "$CLUSTER_NAME" --image "kindest/node:${KUBE_VERSION}"
   fi
   echo "kind cluster '$CLUSTER_NAME' created"
 else
@@ -23,7 +23,7 @@ fi
 kubectl config use-context kind-$CLUSTER_NAME
 kubectl cluster-info --context kind-$CLUSTER_NAME
 
-for i in {0..10}; do
+for _ in {0..10}; do
   if kubectl get nodes; then
     echo "kind kube API ready to go"
     break

--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
 
 export REPOSITORY=$1
 if [[ -z "$2" ]]; then
@@ -8,10 +9,10 @@ else
 fi
 
 function get_debugging_info {
-  for pod in $(kubectl get pods -n $NAMESPACE --no-headers=true | awk '{ print $1 }'); do
+  for pod in $(kubectl get pods -n "$NAMESPACE" --no-headers=true | awk '{ print $1 }'); do
     echo "======================="
     set -x
-    kubectl logs --all-containers -n  $NAMESPACE $pod | tail -n 30
+    kubectl logs --all-containers -n "$NAMESPACE" "$pod" | tail -n 30
     set +x
     echo "======================="
   done
@@ -20,8 +21,8 @@ function get_debugging_info {
 # set DIR to the directory of this script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-source $DIR/install-ci-tools
-source $DIR/start-kind-cluster
+source "$DIR/install-ci-tools"
+source "$DIR/start-kind-cluster"
 
 helm repo add stable https://charts.helm.sh/stable/
 helm repo add astronomer https://helm.astronomer.io/
@@ -42,15 +43,15 @@ cat "$TEST_DOCKERFILE_PATH"
 
 export TEST_TAG=$TAG-test
 
-docker build -t $REPOSITORY:$TEST_TAG $DIR/example_project
+docker build -t "${REPOSITORY}:${TEST_TAG}" "${DIR}/example_project"
 
-kind load docker-image --name $CLUSTER_NAME $REPOSITORY:$TEST_TAG
+kind load docker-image --name "$CLUSTER_NAME" "${REPOSITORY}:${TEST_TAG}"
 
 export NAMESPACE=airflow-$RANDOM
 export RELEASE_NAME=$NAMESPACE
 echo "Installing Airflow into kind as $RELEASE_NAME"
 
-AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.airflow.version" }}' "$REPOSITORY:$TEST_TAG")
+AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.airflow.version" }}' "${REPOSITORY}:${TEST_TAG}")
 # Make the version "SemVer" compliant.. Example: 2.2.0.dev becomes 2.2.0
 echo "Airflow Version (from labels): $AIRFLOW_VERSION"
 AIRFLOW_VERSION_SEMVER="${AIRFLOW_VERSION%.dev*}"
@@ -58,11 +59,11 @@ export AIRFLOW_VERSION
 export AIRFLOW_VERSION_SEMVER
 echo "Airflow Version (SemVer): $AIRFLOW_VERSION_SEMVER"
 
-EDGE_BUILD=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.build.edge" }}' "$REPOSITORY:$TEST_TAG")
+EDGE_BUILD=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.build.edge" }}' "${REPOSITORY}:${TEST_TAG}")
 export EDGE_BUILD
 
 # Find alpine or debian
-DISTRO=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.distro" }}' "$REPOSITORY:$TEST_TAG")
+DISTRO=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.distro" }}' "${REPOSITORY}:${TEST_TAG}")
 # This is handled by Houston for the platform: https://github.com/astronomer/houston-api/pull/581
 if [[ "$DISTRO" == "alpine" ]]; then
   export IMAGE_UID="100"
@@ -80,22 +81,21 @@ echo "Chart Version: $CHART_VERSION"
 kubectl get pods -n $NAMESPACE -w &
 WATCH_PID=$!
 
-kubectl create namespace $NAMESPACE
-helm install --namespace $NAMESPACE \
-  --set airflow.defaultAirflowRepository=$REPOSITORY \
-  --set airflow.defaultAirflowTag=$TEST_TAG \
-  --set airflow.images.airflow.repository=$REPOSITORY \
-  --set airflow.images.airflow.tag=$TEST_TAG \
+kubectl create namespace "$NAMESPACE"
+if ! helm install --namespace "$NAMESPACE" \
+  --set airflow.defaultAirflowRepository="$REPOSITORY" \
+  --set airflow.defaultAirflowTag="$TEST_TAG" \
+  --set airflow.images.airflow.repository="$REPOSITORY" \
+  --set airflow.images.airflow.tag="$TEST_TAG" \
   --set airflow.images.airflow.pullPolicy=Never \
   --set airflow.images.flower.pullPolicy=Never \
   --set airflow.executor=KubernetesExecutor \
-  --set airflow.airflowVersion=$AIRFLOW_VERSION_SEMVER \
-  --set airflow.uid=$IMAGE_UID \
-  --set airflow.gid=$IMAGE_GID \
-  --version=$CHART_VERSION \
-  $RELEASE_NAME astronomer/airflow
-
-if [ ! $? -eq 0 ]; then
+  --set airflow.airflowVersion="$AIRFLOW_VERSION_SEMVER" \
+  --set airflow.uid="$IMAGE_UID" \
+  --set airflow.gid="$IMAGE_GID" \
+  --version="$CHART_VERSION" \
+  "$RELEASE_NAME" astronomer/airflow
+then
   echo "Airflow image failed to work with latest Helm chart."
   get_debugging_info
   exit 1
@@ -105,10 +105,11 @@ kill $WATCH_PID
 
 echo "Deployed Airflow into latest Helm chart."
 
-export WEBSERVER_POD=$(kubectl get pods -n $NAMESPACE | grep webserver | awk '{ print $1 }')
-export SCHEDULER_POD=$(kubectl get pods -n $NAMESPACE | grep scheduler | awk '{ print $1 }')
+WEBSERVER_POD=$(kubectl get pods -n "$NAMESPACE" | grep webserver | awk '{ print $1 }')
+SCHEDULER_POD=$(kubectl get pods -n "$NAMESPACE" | grep scheduler | awk '{ print $1 }')
+export WEBSERVER_POD SCHEDULER_POD
 
 mkdir -p /tmp/test-reports
 export AIRFLOW_IMAGE="$REPOSITORY:$TAG"
 export AIRFLOW_ONBUILD_IMAGE="$REPOSITORY:$TAG-onbuild"
-pytest $DIR/test-airflow-image.py --junitxml=/tmp/test-reports/airflow-test-$REPOSITORY:$TAG.xml
+pytest "$DIR/test-airflow-image.py" --junitxml="/tmp/test-reports/airflow-test-${REPOSITORY}:${TAG}.xml"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -334,7 +334,7 @@ jobs:
       - run:
           name: Install yq
           command: |
-            curl -fsSLO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            curl -fsSLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
             chmod +x /usr/local/bin/yq
       - run:
           name: Install shellcheck

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -332,9 +332,11 @@ jobs:
       - image: quay.io/astronomer/ci-pre-commit:2022-01
     steps:
       - run:
-          name: Install yq
+          name: Install yq, jq
           command: |
             curl -fsSLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            chmod +x /usr/local/bin/yq
+            curl -fsSLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
             chmod +x /usr/local/bin/yq
       - run:
           name: Install shellcheck

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -328,8 +328,8 @@ jobs:
             git push --force origin astro-main
             git --no-pager remote --verbose
   static-checks:
-    executor: machine-executor
-    description: Static Checks
+    docker:
+      - image: quay.io/astronomer/ci-pre-commit:2022-01
     steps:
       - run:
           name: Install yq
@@ -343,10 +343,23 @@ jobs:
             sudo apt install --yes shellcheck
       - checkout
       - run:
-          name: Load archived Docker image
+          name: Create pre-commit-cache-key.txt
           command: |
-            pip install -r .circleci/test-requirements.txt
-            pre-commit run --all-files || { git --no-pager diff && false ; }
+            cp .pre-commit-config.yaml /tmp/pre-commit-cache-key.txt
+            python --version --version | sed 's/^/# /' >> /tmp/pre-commit-cache-key.txt
+      - restore_cache:
+          keys:
+            - pre-commit-cache-{{ '{{' }} checksum "/tmp/pre-commit-cache-key.txt" }}
+      - run:
+          name: Install pre-commit hooks
+          command: pre-commit install-hooks
+      - save_cache:
+          key: pre-commit-cache-{{ '{{' }} checksum "/tmp/pre-commit-cache-key.txt" }}
+          paths:
+            - ~/.cache/pre-commit
+      - run:
+          name: Run pre-commit
+          command: pre-commit run --all-files --show-diff-on-failure
   download-file:
     executor: machine-executor
     description: Download a file to disk

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -337,7 +337,7 @@ jobs:
             curl -fsSLo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
             chmod +x /usr/local/bin/yq
             curl -fsSLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/latest/download/jq-linux64
-            chmod +x /usr/local/bin/yq
+            chmod +x /usr/local/bin/jq
       - run:
           name: Install shellcheck
           command: |

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -334,7 +334,7 @@ jobs:
       - run:
           name: Install yq
           command: |
-            wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            curl -fsSLO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
             chmod +x /usr/local/bin/yq
       - run:
           name: Install shellcheck

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -345,7 +345,6 @@ jobs:
       - run:
           name: Load archived Docker image
           command: |
-            pyenv global 3.8.5
             pip install -r .circleci/test-requirements.txt
             pre-commit run --all-files || { git --no-pager diff && false ; }
   download-file:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -334,13 +334,13 @@ jobs:
       - run:
           name: Install yq
           command: |
-            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-            sudo chmod +x /usr/local/bin/yq
+            wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            chmod +x /usr/local/bin/yq
       - run:
           name: Install shellcheck
           command: |
-            sudo apt update
-            sudo apt install --yes shellcheck
+            apt update
+            apt install --yes shellcheck
       - checkout
       - run:
           name: Create pre-commit-cache-key.txt

--- a/.circleci/test-requirements.txt
+++ b/.circleci/test-requirements.txt
@@ -1,3 +1,3 @@
-pre-commit~=2.14.0
+pre-commit~=2.17.0
 pytest-testinfra==6.5.0
 docker==5.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^alpine-packages/.*$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,10 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
       - id: trailing-whitespace
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.8.0.3
+    hooks:
+      - id: shellcheck
   - repo: local
     hooks:
       - id: copyright-uptodate


### PR DESCRIPTION
### What this PR does / why we need it

Add shellcheck pre-commit hook. We have a lot of shell scripts. Gotta keep them working well.

### Special notes for your reviewer

While adding this I had to fix a lot of complaints. We should make sure that everything is working as desired. Sometimes scripts have mechanics that rely on invalid syntax, such as needing the value of a variable that has whitespace to whitespace-break, but shellcheck nagged that the var wasn't quoted. We just need to make sure everything here is working as desired, and fix anything that isn't.

In the pre-commit step I also replaced a machine image with the same pre-commit CI image we're using in astronomer/astronomer. This was mostly because I was unable to get the shellcheck hook working with the machine image and pyenv. the shellcheck hook was installing into the wrong pre-commit env, and I'm not sure why.

### CI Failures

The trivy failures in CI have nothing to do with this change.