### PR TITLE
Fix trivy invocation by adding 'image' subcommand

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -457,9 +457,9 @@ jobs:
       - run:
           name: Scan the local image with trivy
           command: |
-            trivy \
+            trivy --cache-dir {{ workspace_prefix }}/trivy-cache \
+              image \
               --ignorefile "./<< parameters.airflow_version >>/<< parameters.distribution >>/trivyignore" \
-              --cache-dir {{ workspace_prefix }}/trivy-cache \
               --ignore-unfixed -s HIGH,CRITICAL \
               --exit-code 1 \
               --no-progress "<< parameters.image_name >>-onbuild"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes builds by adding an explicit `image` subcommand to the `trivy` command.