### PR TITLE
Update dependecies to get latest libexpat1

### DIFF
--- a/2.2.4/bullseye/Dockerfile
+++ b/2.2.4/bullseye/Dockerfile
@@ -53,7 +53,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="1"
+ARG DEPENDENCIES_EPOCH_NUMBER="2"
 # Increase the value below to force renstalling of all dependencies
 ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
 

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -53,7 +53,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="1"
+ARG DEPENDENCIES_EPOCH_NUMBER="2"
 # Increase the value below to force renstalling of all dependencies
 ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
 


### PR DESCRIPTION
This fixes a number of CVE's:
CVE-2022-22822
CVE-2022-22823
CVE-2022-22824
CVE-2022-23852
CVE-2022-23990
CVE-2021-45960
CVE-2021-46143
CVE-2022-22825
CVE-2022-22826
CVE-2022-22827

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
