### PR TITLE
Bump Fab Security Manager to 1.8.3

### DIFF
--- a/1.10.12/alpine3.10/Dockerfile
+++ b/1.10.12/alpine3.10/Dockerfile
@@ -101,7 +101,7 @@ RUN echo https://github.com/astronomer/ap-airflow/raw/${REPO_BRANCH}/alpine-pack
 	&& pip3 install --no-cache-dir --upgrade snowflake-connector-python==1.9.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints.txt \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip3 install --no-cache-dir "astronomer-fab-security-manager~=1.8, >=1.8.2" \
+	&& pip3 install --no-cache-dir "astronomer-fab-security-manager~=1.8, >=1.8.3" \
 	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip \

--- a/1.10.12/buster/Dockerfile
+++ b/1.10.12/buster/Dockerfile
@@ -129,7 +129,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 # Pip install airflow and astro security manager
 RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.8, >=1.8.2"
+	&& pip install "astronomer-fab-security-manager~=1.8, >=1.8.3"
 
 
 ## move this to same layer as airflow because its from tag.

--- a/1.10.14/buster/Dockerfile
+++ b/1.10.14/buster/Dockerfile
@@ -129,7 +129,7 @@ COPY build-time-pip-constraints.txt /tmp/build-time-pip-constraints.txt
 # Pip install airflow and astro security manager
 RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints.txt \
   && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
-	&& pip install "astronomer-fab-security-manager~=1.8, >=1.8.2"
+	&& pip install "astronomer-fab-security-manager~=1.8, >=1.8.3"
 
 
 ## move this to same layer as airflow because its from tag.

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="1.10.15-4"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -147,7 +147,7 @@ RUN apt-get update \
 
 ARG VERSION="1.10.15-4"
 ARG AIRFLOW_VERSION="1.10.15"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.1.0/buster/Dockerfile
+++ b/2.1.0/buster/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.1.0-7"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.0"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.1.0-7"
 ARG AIRFLOW_VERSION="2.1.0"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.1.1/buster/Dockerfile
+++ b/2.1.1/buster/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.1.1-6"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.1"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.1.1-6"
 ARG AIRFLOW_VERSION="2.1.1"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.1.3/buster/Dockerfile
+++ b/2.1.3/buster/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.1.3-4"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.3"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.1.3-4"
 ARG AIRFLOW_VERSION="2.1.3"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.1.4-4"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.1.4-4"
 ARG AIRFLOW_VERSION="2.1.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.2.0/bullseye/Dockerfile
+++ b/2.2.0/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.2.0-5"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.0"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.2.0-5"
 ARG AIRFLOW_VERSION="2.2.0"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.2.1/bullseye/Dockerfile
+++ b/2.2.1/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.2.1-3"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.1"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.2.1-3"
 ARG AIRFLOW_VERSION="2.2.1"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.2.2/bullseye/Dockerfile
+++ b/2.2.2/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.2.2-2"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.2"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.2.2-2"
 ARG AIRFLOW_VERSION="2.2.2"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.2.3/bullseye/Dockerfile
+++ b/2.2.3/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.2.3-2"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.3"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.2.3-2"
 ARG AIRFLOW_VERSION="2.2.3"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.2.4/bullseye/Dockerfile
+++ b/2.2.4/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.2.4-1.*"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.2.4-1.*"
 ARG AIRFLOW_VERSION="2.2.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.2"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"


### PR DESCRIPTION
This is to support implicit namespace change in https://github.com/astronomer/astronomer-fab-securitymanager/releases/tag/v1.8.3
