### PR TITLE
Split out built_from and built_by Docker image labels

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -206,8 +206,10 @@ workflows:
             --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <{{ ext_build_filename_workspace }})
             --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <{{ ext_build_filename_workspace }})
             --label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' <{{ ext_build_filename_workspace }})"
-            --label org.apache.airflow.git.commit_sha=$(jq -r '.git.commit' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.git.$(jq -r '.git.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.ref.name' <{{ ext_build_filename_workspace }})
+            --label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' <{{ ext_build_filename_workspace }})
+            --label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' <{{ ext_build_filename_workspace }})
+            --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }})
+            --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }})
             --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
             {%- endif %}{# edge_build #}
           {%- if distribution in ["alpine3.10", "buster"] %}


### PR DESCRIPTION
**What this PR does / why we need it**:

QA needs to identify the exact commit that the Airflow packages and Docker images are built from.

Previously we included Git information from the GitHub Actions workflow that identified the `astro-main` branch and its HEAD commit SHA. Not only was this slightly misleading because the corresponding label name, `org.apache.airflow.git.commit_sha`, indicated that the commit was from the `apache/airflow:main` branch, it was also incorrect because it didn't identify the exact commit from `astronomer/airflow:main` or even `astronomer/airflow:astro-main` that the Python package and Docker images were built from.

The branch and commit SHA from `astro-main` identified the information for what the package and images were built _by_, but not what they were built from.

This PR tweaks the label names to be more accurate as to what they represent, and explicitly identifies the `built_by` and `built_from` information. The `built_from` information should usually be the `main` branch from the `astronomer/airflow` repo and the latest commit SHA from that branch at build time. And the `built_by` information should usually be the `astro-main` from the `astronomer/airflow` repo and the commit SHA of that branch's HEAD at build time.

This change should make it drastically easier for QA to identify which commits from `astronomer:main` are included in the version they are testing.