### PR TITLE
Only build LTS and last two versions

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -34,18 +34,8 @@ def get_airflow_version(ac_version):
 
 
 IMAGE_MAP = collections.OrderedDict([
-    ("1.10.12-6", ["alpine3.10", "buster"]),
-    ("1.10.14-5", ["buster"]),
     ("1.10.15-4", ["buster"]),
-    ("2.0.0-10", ["buster"]),
-    ("2.0.2-6", ["buster"]),
-    ("2.1.0-7", ["buster"]),
-    ("2.1.1-6", ["buster"]),
-    ("2.1.3-4", ["buster"]),
     ("2.1.4-4", ["buster"]),
-    ("2.2.0-5", ["bullseye", "buster"]),
-    ("2.2.1-3", ["bullseye", "buster"]),
-    ("2.2.2-2", ["bullseye", "buster"]),
     ("2.2.3-2", ["bullseye"]),
     ("2.2.4-1", ["bullseye"]),
     ("main.dev", ["bullseye"]),

--- a/README.md
+++ b/README.md
@@ -296,18 +296,8 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
 ## Changelog
 
 All changes applied to available point releases will be documented in the `CHANGELOG.md` files within each version folder:
-- [1.10.12 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md)
-- [1.10.14 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.14/CHANGELOG.md)
 - [1.10.15 Changelog](https://github.com/astronomer/ap-airflow/blob/master/1.10.15/CHANGELOG.md)
-- [2.0.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.0/CHANGELOG.md)
-- [2.0.2 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.0.2/CHANGELOG.md)
-- [2.1.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.0/CHANGELOG.md)
-- [2.1.1 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.1/CHANGELOG.md)
-- [2.1.3 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.3/CHANGELOG.md)
 - [2.1.4 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.1.4/CHANGELOG.md)
-- [2.2.0 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.2.0/CHANGELOG.md)
-- [2.2.1 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.2.1/CHANGELOG.md)
-- [2.2.2 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.2.2/CHANGELOG.md)
 - [2.2.3 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.2.3/CHANGELOG.md)
 - [2.2.4 Changelog](https://github.com/astronomer/ap-airflow/blob/master/2.2.4/CHANGELOG.md)
 <!-- CHANGELOG END -->


### PR DESCRIPTION
closes https://github.com/astronomer/issues-airflow/issues/169

Based on our [new versioning policy](https://docs.astronomer.io/software/ac-support-policy/#end-of-maintenance-date), there is no point in building older images.

I have kept the docker image and changelogs for now but we should remove them after 28 Feb, probably just keep changelogs (🤷 ).

