### PR TITLE
Fix or ignore CVEs for 1.10.15

### DIFF
--- a/1.10.15/buster/build-time-pip-constraints.txt
+++ b/1.10.15/buster/build-time-pip-constraints.txt
@@ -128,7 +128,7 @@ pendulum==1.4.4
 prison==0.1.3
 prometheus-client==0.8.0
 proto-plus==1.11.0
-protobuf==3.14.0
+protobuf==3.15.0
 psutil==5.7.3
 psycopg2-binary==2.8.6
 pyarrow==0.17.1

--- a/1.10.15/buster/trivyignore
+++ b/1.10.15/buster/trivyignore
@@ -32,3 +32,23 @@ CVE-2020-7774
 # and Kubernetes Python client is already using safe_load
 # Details: https://github.com/astronomer/issues-airflow/issues/39
 CVE-2020-1747
+
+# Airflow 1.10.15 only supports Celery 4,
+# so we cannot upgrade to Celery 5.2.2+ to fix this.
+# In addition, this does require manipulation in the celery
+# backend.
+# Snyk also lists this as medium (contrary to the CVE):
+# https://security.snyk.io/vuln/SNYK-PYTHON-CELERY-2314953
+CVE-2021-23727
+
+# Airflow 1.10.15 is on FAB 2.x, not FAB 3.x
+# We also don't have any FAB REST endpoints that
+# are of any interest, and our auth process provides
+# additional protection on top of it. Low risk for us.
+CVE-2021-41265
+
+# Updating urllib3 isn't easy because of its dependency chain:
+#   requests -> snowflake, and botocore
+# In addition, this DOS vulnerability can really only cause
+# service disruption, so the risk is greater to do the upgrade
+CVE-2021-33503


### PR DESCRIPTION
Fixes:
  - CVE-2021-22570

Ignores:
  - CVE-2021-23727
  - CVE-2021-33503
  - CVE-2021-41265

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
