### PR TITLE
Bump FAB Security Manager to 1.8.4

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -34,10 +34,10 @@ def get_airflow_version(ac_version):
 
 
 IMAGE_MAP = collections.OrderedDict([
-    ("1.10.15-5", ["buster"]),
-    ("2.1.4-5", ["buster"]),
+    ("1.10.15-6.dev", ["buster"]),
+    ("2.1.4-6.dev", ["buster"]),
     ("2.2.3-2", ["bullseye"]),
-    ("2.2.4-1", ["bullseye"]),
+    ("2.2.4-2.dev", ["bullseye"]),
     ("main.dev", ["bullseye"]),
 ])
 

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="1.10.15-6.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.

--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-5"
+ARG VERSION="1.10.15-6.*"
 ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
@@ -145,9 +145,9 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="1.10.15-5"
+ARG VERSION="1.10.15-6.*"
 ARG AIRFLOW_VERSION="1.10.15"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.1.4-6.*"
 ARG AIRFLOW_VERSION="2.1.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -110,11 +110,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.4-5"
+ARG VERSION="2.1.4-6.*"
 ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -146,7 +146,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.1.4-5"
+ARG VERSION="2.1.4-6.*"
 ARG AIRFLOW_VERSION="2.1.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"

--- a/2.2.4/bullseye/Dockerfile
+++ b/2.2.4/bullseye/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.2.4-2.*"
 ARG AIRFLOW_VERSION="2.2.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/2.2.4/bullseye/Dockerfile
+++ b/2.2.4/bullseye/Dockerfile
@@ -110,11 +110,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.4-1"
+ARG VERSION="2.2.4-2.*"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -146,7 +146,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.2.4-1"
+ARG VERSION="2.2.4-2.*"
 ARG AIRFLOW_VERSION="2.2.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
