### PR TITLE
Update 2.2.4 dependencies to get latest expat

### DIFF
--- a/2.2.4/bullseye/Dockerfile
+++ b/2.2.4/bullseye/Dockerfile
@@ -139,7 +139,7 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="2"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="3"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
This fixes DSA-5085-1

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
