### PR TITLE
Only set versions once, while keeping labels

### DIFF
--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -111,10 +111,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION="1.10.15-6"
-ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
-ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="1.10.15"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
+ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -132,6 +132,9 @@ RUN pip install "${AIRFLOW_MODULE}" --constraint /tmp/build-time-pip-constraints
     && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
     && pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
 ## move this to same layer as airflow because its from tag.
 
@@ -144,13 +147,6 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ARG VERSION="1.10.15-6"
-ARG AIRFLOW_VERSION="1.10.15"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages

--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -111,10 +111,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION="2.1.4-6"
-ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
-ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
+ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -133,6 +133,9 @@ RUN pip install "${AIRFLOW_MODULE}" \
     && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
     && pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
 ## move this to same layer as airflow because its from tag.
 
@@ -145,13 +148,6 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ARG VERSION="2.1.4-6"
-ARG AIRFLOW_VERSION="2.1.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages

--- a/2.2.4/bullseye/Dockerfile
+++ b/2.2.4/bullseye/Dockerfile
@@ -111,10 +111,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION="2.2.4-2"
-ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
-ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.2.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
+ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -133,6 +133,9 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower \
     && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
     && pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
 ## move this to same layer as airflow because its from tag.
 
@@ -145,13 +148,6 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ARG VERSION="2.2.4-2"
-ARG AIRFLOW_VERSION="2.2.4"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -111,10 +111,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG VERSION
-ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
-ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION=${VERSION}
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
+ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -128,6 +128,10 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower "elasticsearch==7.13.4" \
 	&& pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
+LABEL io.astronomer.docker.ac.version="${VERSION}"
+LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
+LABEL io.astronomer.docker.build.edge="true"
 
 ## move this to same layer as airflow because its from tag.
 
@@ -140,14 +144,6 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-ARG VERSION
-ARG AIRFLOW_VERSION=${VERSION}
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
-LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
-LABEL io.astronomer.docker.ac.version="${VERSION}"
-LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
-LABEL io.astronomer.docker.build.edge="true"
 
 # Copy all installed python modules. This gets us the compiled without needing dev installed
 COPY --from=devel /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages


### PR DESCRIPTION
**What this PR does / why we need it**:

We set versions with ARGS multiple times in our Dockerfiles, but we really only need to do it once.

This is just nicer as only one version string needs to get changed during updates.

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
