### PR TITLE
Tweaks, fixups, and general cleanup

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -197,10 +197,10 @@ workflows:
           airflow_version: "{{ airflow_version }}"
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ ac_version }}-{{ distribution }}-onbuild"
           {%- else %}
           tag: "{{ airflow_version }}-onbuild"
-          extra_tags: "{{ airflow_version }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-onbuild"
+          extra_tags: "{{ ac_version }}-onbuild"
           {%- endif %}
           context:
             - slack_ap-airflow

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -140,6 +140,7 @@ workflows:
           name: push-{{ airflow_version }}-{{ distribution }}
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
+          nightly_build: false
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
@@ -166,6 +167,7 @@ workflows:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
+          nightly_build: false
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
@@ -306,12 +308,13 @@ workflows:
           name: push-{{ airflow_version }}-{{ distribution }}
           dev_build: true
           edge_build: {{ edge_build }}
+          nightly_build: true
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
+          extra_tags: "{{ airflow_version }}-{{ distribution }},{{ ac_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
-          extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM},{{ ac_version }}"
+          extra_tags: "{{ airflow_version }},{{ ac_version }}"
           {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
           {%- if edge_build %}
           extra_tags_file: {{ workspace_prefix }}/extra-tags-{{ airflow_version_wout_dev }}.txt
@@ -332,12 +335,13 @@ workflows:
           name: push-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: true
           edge_build: {{ edge_build }}
+          nightly_build: true
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild,{{ ac_version }}-{{ distribution }}-onbuild"
           {%- else %}
           tag: "{{ airflow_version }}-onbuild"
-          extra_tags: "{{ airflow_version }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-onbuild"
+          extra_tags: "{{ airflow_version }}-onbuild,{{ ac_version }}-onbuild"
           {%- endif %}
           context:
             - quay.io
@@ -543,6 +547,9 @@ jobs:
       edge_build:
         description: "Indicate if this is an edge build"
         type: boolean
+      nightly_build:
+        description: "Indicate if this is a nightly build"
+        type: boolean
       tag:
         type: string
       extra_tags:
@@ -570,6 +577,7 @@ jobs:
       - push:
           dev_release: << parameters.dev_build >>
           edge_build: << parameters.edge_build >>
+          nightly_build: << parameters.nightly_build >>
           extra_tags: "<< parameters.extra_tags >>"
           extra_tags_file: "<< parameters.extra_tags_file >>"
           tag: "<< parameters.tag >>"
@@ -745,6 +753,9 @@ commands:
         type: boolean
       edge_build:
         description: "Indicate if this is an edge build"
+        type: boolean
+      nightly_build:
+        description: "Indicate if this is a nightly build"
         type: boolean
       extra_tags:
         type: string

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -302,10 +302,10 @@ workflows:
           edge_build: {{ edge_build }}
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM}"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
-          extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM}"
+          extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM},{{ ac_version }}"
           {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
           {%- if edge_build %}
           extra_tags_file: {{ workspace_prefix }}/extra-tags-{{ airflow_version_wout_dev }}.txt

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -66,6 +66,9 @@ workflows:
             --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }})
             --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }})
             --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
+            --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}"
+            {#- This redirects to the canonical workflow URL #}
+            --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
             {%- endif %}{# edge_build #}
           {%- endif %}
           {%- if distribution in ["alpine3.10", "buster"] %}
@@ -256,6 +259,9 @@ workflows:
             --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }})
             --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }})
             --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
+            --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}"
+            {#- This redirects to the canonical workflow URL -#}
+            --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
             {%- endif %}{# edge_build #}
           {%- if distribution in ["alpine3.10", "buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"

--- a/.circleci/new_dev_build_slack_notification.json.j2
+++ b/.circleci/new_dev_build_slack_notification.json.j2
@@ -51,7 +51,7 @@
       "elements": [
         {
           "type": "plain_text",
-          "text": "Release Owners: Airflow Team [<@UHRPL613K>,<@U01PS0N06DN>]",
+          "text": "Release Owners: Airflow Team\n{{ approvers_slack_syntax }}",
           "emoji": true
         }
       ]

--- a/.circleci/push.bash.j2
+++ b/.circleci/push.bash.j2
@@ -7,6 +7,14 @@ IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.extra_tags >>"
 
 echo "DOCKER_TAGS: ${DOCKER_TAGS[@]}"
 
+if [[ "<< parameters.nightly_build >>" =~ (True|true) ]]; then
+  echo "Adding '-nightly+$(date +%Y%m%d)' to all docker tags"
+  for (( i=0; i<{% raw %}${#DOCKER_TAGS[@]}{% endraw %}; i++ )); do
+    DOCKER_TAGS[$i]=${DOCKER_TAGS[$i]}-nightly+$(date +%Y%m%d)
+  done
+  echo "DOCKER_TAGS->  ${DOCKER_TAGS[@]}"
+fi
+
 # Read in more tags from the extra_tags_file, if it exists
 if [[ -f "<< parameters.extra_tags_file >>" ]]; then
   echo "Contents of << parameters.extra_tags_file >>:"

--- a/README.md
+++ b/README.md
@@ -273,21 +273,11 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
     FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 
    ```
-4. Run the `verify-changelog-entries` pre-commit hook (this should fail but it should change the
-   relevant Dockerfile).
-
-   Example:
-   ```bash
-   pre-commit run verify-changelog-entries
-   ```
-
-   The pre-commit hook should add a link to the changelog in `README.md`.
-   ```diff
 4. Stage the changes to the Dockerfile and commit (the pre-commit hooks should all succeed).
 
    Example:
    ```bash
-   git add 2.3.0/bullseye && git commit
+   git add .circleci/common.py 2.3.0/bullseye && git commit
    ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@
 
 Astronomer makes it easy to run, monitor, and scale [Apache Airflow](https://github.com/apache/airflow) deployments in our cloud or yours. Source code is made available for the benefit of customers.
 
+#### Terminology
+
+| Terms         | Example                  | Description                                                                                         |
+| :------------ | :----------------------- | :-------------------------------------------------------------------------------------------------- |
+| `edge` build  | `main.dev`               | Built from the current `main` branch of [astronomer/airflow](https://github.com/astronomer/airflow) |
+| dev build     | `2.2.4-4.dev`            | Development build, released during ap-airflow changes, including pre-releases and version releases  |
+| nightly build | `2.2.4-nightly+20220314` | Nightly builds, regularly triggered by a CircleCI pipeline sometime during the midnight hour UTC    |
+| release build | `2.2.4-4`                | Release builds, triggered by a release PR                                                           |
+
+Note: Edge builds are always development builds
+
+#### Build matrix
+
+| Build         | Nightly                   | Pre-release PR     | Release PR         |
+| :------------ | :------------------------ | :----------------- | :----------------- |
+| `edge` build  | :white_check_mark:        | :white_check_mark: | :white_check_mark: |
+| nightly build | :white_check_mark:        | :white_check_mark: |                    |
+| dev build     | (only during pre-release) | :white_check_mark: | :white_check_mark: |
+| release build |                           |                    | :white_check_mark: |
+
 ## Docker images
 
 Docker images for deploying and running Astronomer Core are currently available on


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes instructions for adding a new distro
* Documents all of the different types of builds and how they are triggered
* Always tags `main.dev` images
* Adds labels to images containing the CircleCI workflow ID that build the image and a link to the workflow
* Adjusts the suffix of the nightly build tags to `-nightly+YYYYMMDD`
* Uses the list of approvers that's already defined
* Removes (incorrect) tag from the Slack notification