### PR TITLE
Fix build string in Docker image tag

### DIFF
--- a/.circleci/push.bash.j2
+++ b/.circleci/push.bash.j2
@@ -8,9 +8,12 @@ IFS="," read -ra DOCKER_TAGS \<<< "<< parameters.extra_tags >>"
 echo "DOCKER_TAGS: ${DOCKER_TAGS[@]}"
 
 if [[ "<< parameters.nightly_build >>" =~ (True|true) ]]; then
-  echo "Adding '-nightly+$(date +%Y%m%d)' to all docker tags"
+  # Docker tags must match [\w][\w.-]{0,127}
+  # https://github.com/distribution/distribution/blob/514cbd71bedb3331f53e2fe5293075726c67e68a/reference/regexp.go#L41
+  TAG_PRERELEASE_SUFFIX="-nightly-$(date +%Y%m%d)"
+  echo "Adding '${TAG_PRERELEASE_SUFFIX}' to all docker tags"
   for (( i=0; i<{% raw %}${#DOCKER_TAGS[@]}{% endraw %}; i++ )); do
-    DOCKER_TAGS[$i]=${DOCKER_TAGS[$i]}-nightly+$(date +%Y%m%d)
+    DOCKER_TAGS[$i]=${DOCKER_TAGS[$i]}${TAG_PRERELEASE_SUFFIX}
   done
   echo "DOCKER_TAGS->  ${DOCKER_TAGS[@]}"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Docker image tags cannot contain `+` characters and have to match this regex: `[\w][\w.-]{0,127}`. This PR tweaks the logic a bit, but it also swaps out the `+` for a `-`.

Unfortunately this means that the `-YYYYMMDD` suffix is now considered part of the "prerelease" section of the version string instead of the "build [identifier]" section of the version string, but until Docker relaxes their tag format a bit, we're stuck with this.

This should also fix the nightly build failures ([1](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2687/workflows/edde0849-a201-478f-8a7b-da623a44b3c7/jobs/63426) and [2](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2687/workflows/edde0849-a201-478f-8a7b-da623a44b3c7/jobs/63427)).

The failing check is unrelated.