### PR TITLE
Always build version nightlies

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -226,7 +226,7 @@ workflows:
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- set ext_build_filename_workspace = workspace_prefix + '/latest-' + airflow_version_wout_dev + '.build.json' %}
-      {%- if "dev" in ac_version and airflow_version not in dev_allowlist  %}
+      {%- if airflow_version not in dev_allowlist  %}
 
       {%- if edge_build %}
       - download-file:
@@ -356,7 +356,7 @@ workflows:
               only:
                 - master
       {%- endfor %}{# distribution in distributions #}
-      {%- endif %}{# if "dev" in ac_version and airflow_version not in dev_allowlist #}
+      {%- endif %}{# if airflow_version not in dev_allowlist #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
   {%- endif %}{# image_map.keys() | dev_releases | length > 0 #}
 

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -311,10 +311,10 @@ workflows:
           nightly_build: true
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
-          extra_tags: "{{ airflow_version }}-{{ distribution }},{{ ac_version }}-{{ distribution }}"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
-          extra_tags: "{{ airflow_version }},{{ ac_version }}"
+          extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM},{{ ac_version }}"
           {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
           {%- if edge_build %}
           extra_tags_file: {{ workspace_prefix }}/extra-tags-{{ airflow_version_wout_dev }}.txt
@@ -338,10 +338,10 @@ workflows:
           nightly_build: true
           {%- if distribution in ["alpine3.10", "buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
-          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild,{{ ac_version }}-{{ distribution }}-onbuild"
+          extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
           {%- else %}
           tag: "{{ airflow_version }}-onbuild"
-          extra_tags: "{{ airflow_version }}-onbuild,{{ ac_version }}-onbuild"
+          extra_tags: "{{ airflow_version }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-onbuild"
           {%- endif %}
           context:
             - quay.io

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Astronomer makes it easy to run, monitor, and scale [Apache Airflow](https://git
 | :------------ | :----------------------- | :-------------------------------------------------------------------------------------------------- |
 | `edge` build  | `main.dev`               | Built from the current `main` branch of [astronomer/airflow](https://github.com/astronomer/airflow) |
 | dev build     | `2.2.4-4.dev`            | Development build, released during ap-airflow changes, including pre-releases and version releases  |
-| nightly build | `2.2.4-nightly+20220314` | Nightly builds, regularly triggered by a CircleCI pipeline sometime during the midnight hour UTC    |
+| nightly build | `2.2.4-nightly-20220314` | Nightly builds, regularly triggered by a CircleCI pipeline sometime during the midnight hour UTC    |
 | release build | `2.2.4-4`                | Release builds, triggered by a release PR                                                           |
 
 Note: Edge builds are always development builds


### PR DESCRIPTION
**What this PR does / why we need it**:

* [x] Sneaks in a documentation fixup that I forgot to do previously.
* [x] Builds nightly images for all versions listed in `common.py`
  - [x] Tags images with `X.Y.Z-nightly-YYYYMMDD`
  - [x] Tags images with `Z.Y.Z-123456` (CircleCI build number)