### PR TITLE
Ensure that numbered dev version strings are SemVer

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -51,9 +51,9 @@ export RELEASE_NAME=$NAMESPACE
 echo "Installing Airflow into kind as $RELEASE_NAME"
 
 AIRFLOW_VERSION=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.airflow.version" }}' "$REPOSITORY:$TEST_TAG")
-# Make the version "SemVer" compliant.. Example: 2.2.0.dev becomes 2.2.0
+# Make the version "SemVer" compliant.. Example: 2.2.0-dev becomes 2.2.0
 echo "Airflow Version (from labels): $AIRFLOW_VERSION"
-AIRFLOW_VERSION_SEMVER="${AIRFLOW_VERSION%.dev*}"
+AIRFLOW_VERSION_SEMVER="${AIRFLOW_VERSION%-dev*}"
 export AIRFLOW_VERSION
 export AIRFLOW_VERSION_SEMVER
 echo "Airflow Version (SemVer): $AIRFLOW_VERSION_SEMVER"

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -78,9 +78,9 @@ def test_version(webserver, docker_client):
     assert "+astro." in ac_version_output
     ac_version_postfix_output = ac_version_output.rsplit('+astro.')[-1]
 
-    # Example: 2.0.2.post2.dev2
+    # Example: 2.0.2.post2-dev2
     if "dev" in ac_version:
-        ac_version = ac_version.rsplit('.dev')[0]
+        ac_version = ac_version.rsplit('-dev')[0]
         post_fix_version_astro = ac_version.rsplit('.post')[-1]
     else:
         # Example: 1.10.10-8 will give '8'

--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -37,7 +37,7 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.15-6", ["buster"]),
     ("2.1.4-6", ["buster"]),
     ("2.2.4-3", ["bullseye"]),
-    ("main.dev", ["bullseye"]),
+    ("main-dev", ["bullseye"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -24,7 +24,7 @@ workflows:
 
       {%- for ac_version, distributions in image_map.items() %}
       {%- set airflow_version = ac_version | get_airflow_version -%}
-      {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') -%}
+      {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') | replace('-dev', '') -%}
       {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- set ext_build_filename_workspace = workspace_prefix + '/latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- set dev_build = "true" if "dev" in ac_version else "false" %}
@@ -222,7 +222,7 @@ workflows:
     jobs:
       {%- for ac_version, distributions in image_map.items() %}
       {%- set airflow_version = ac_version | get_airflow_version %}
-      {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') -%}
+      {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') | replace('-dev', '') -%}
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- set ext_build_filename_workspace = workspace_prefix + '/latest-' + airflow_version_wout_dev + '.build.json' %}

--- a/.circleci/update_dockerfiles.py
+++ b/.circleci/update_dockerfiles.py
@@ -51,7 +51,7 @@ def update_dockerfiles():
             # We only do this for all buster images
             # If it is the first post-fix version in AC / Airflow series use constraints-branch, if not
             # use the constraints from Airflow Version tag.
-            if dev_version and "-1.dev" in ac_version:
+            if dev_version and "-1-dev" in ac_version:
                 branch = "-".join(airflow_version.split(".", 3)[0:2])
                 constraints_url = (
                     f'https://raw.githubusercontent.com/apache/airflow/constraints-{branch}/'

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Astronomer makes it easy to run, monitor, and scale [Apache Airflow](https://git
 
 | Terms         | Example                  | Description                                                                                         |
 | :------------ | :----------------------- | :-------------------------------------------------------------------------------------------------- |
-| `edge` build  | `main.dev`               | Built from the current `main` branch of [astronomer/airflow](https://github.com/astronomer/airflow) |
-| dev build     | `2.2.4-4.dev`            | Development build, released during ap-airflow changes, including pre-releases and version releases  |
+| `edge` build  | `main-dev`               | Built from the current `main` branch of [astronomer/airflow](https://github.com/astronomer/airflow) |
+| dev build     | `2.2.4-4-dev`            | Development build, released during ap-airflow changes, including pre-releases and version releases  |
 | nightly build | `2.2.4-nightly-20220314` | Nightly builds, regularly triggered by a CircleCI pipeline sometime during the midnight hour UTC    |
 | release build | `2.2.4-4`                | Release builds, triggered by a release PR                                                           |
 
@@ -82,10 +82,10 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
 <details>
 <summary>Click to expand Step-By-Step instructions</summary>
 
-1. Remove the `.dev` part of the relevant version in `IMAGE_MAP` in `.circleci/common.py`.
+1. Remove the `-dev` part of the relevant version in `IMAGE_MAP` in `.circleci/common.py`.
 
    Example:
-   The latest dev version is `2.2.1-1.dev`, and we want to release `2.2.1-1`.
+   The latest dev version is `2.2.1-1-dev`, and we want to release `2.2.1-1`.
    ```diff
    diff --git a/.circleci/common.py b/.circleci/common.py
    index xxxxxxx..yyyyyyy 100644
@@ -94,8 +94,8 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
    @@ -35,7 +35,7 @@ IMAGE_MAP = collections.OrderedDict([
         ("2.1.3-2", ["buster"]),
         ("2.1.4-2", ["buster"]),
-        ("2.2.0-3.dev", ["bullseye", "buster"]),
-   -    ("2.2.1-1.dev", ["bullseye", "buster"]),
+        ("2.2.0-3-dev", ["bullseye", "buster"]),
+   -    ("2.2.1-1-dev", ["bullseye", "buster"]),
    +    ("2.2.1-1", ["bullseye", "buster"]),
    ])
 
@@ -134,7 +134,7 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
    @@ -35,7 +35,7 @@ IMAGE_MAP = collections.OrderedDict([
         ("2.1.3-2", ["buster"]),
         ("2.1.4-2", ["buster"]),
-        ("2.2.0-3.dev", ["bullseye", "buster"]),
+        ("2.2.0-3-dev", ["bullseye", "buster"]),
    -    ("2.2.1-1", ["bullseye", "buster"]),
    +    ("2.2.1-2", ["bullseye", "buster"]),
     ])
@@ -166,7 +166,7 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
 1. Add the Astronomer Certified version to `IMAGE_MAP` in `.circleci/common.py`.
 
    Example:
-   The latest previous release was `2.2.1-1` and we're adding `2.3.0-1.dev`.
+   The latest previous release was `2.2.1-1` and we're adding `2.3.0-1-dev`.
    ```diff
    diff --git a/.circleci/common.py b/.circleci/common.py
    index xxxxxxx..yyyyyyy 100644
@@ -174,9 +174,9 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
    +++ b/.circleci/common.py
    @@ -36,6 +36,7 @@ IMAGE_MAP = collections.OrderedDict([
         ("2.1.4-2", ["buster"]),
-        ("2.2.0-3.dev", ["bullseye", "buster"]),
+        ("2.2.0-3-dev", ["bullseye", "buster"]),
         ("2.2.1-1", ["bullseye", "buster"]),
-   +    ("2.3.0-1.dev", ["bullseye"]),
+   +    ("2.3.0-1-dev", ["bullseye"]),
     ])
 
     # Airflow Versions for which we don't publish Python Wheels
@@ -258,10 +258,10 @@ the [Version Life Cycle](https://docs.astronomer.io/software/ac-support-policy/)
    +++ b/.circleci/common.py
    @@ -36,7 +36,7 @@ IMAGE_MAP = collections.OrderedDict([
         ("2.1.4-2", ["buster"]),
-        ("2.2.0-3.dev", ["bullseye", "buster"]),
+        ("2.2.0-3-dev", ["bullseye", "buster"]),
         ("2.2.1-1", ["bullseye", "buster"]),
-   -    ("2.3.0-1.dev", ["buster"]),
-   +    ("2.3.0-1.dev", ["bullseye", "buster"]),
+   -    ("2.3.0-1-dev", ["buster"]),
+   +    ("2.3.0-1-dev", ["bullseye", "buster"]),
     ])
 
     # Airflow Versions for which we don't publish Python Wheels


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR switches the `.dev` version string suffix to `-dev` so that dev version strings are valid SemVer.