### PR TITLE
Fix tests now that we build release version nightlies

### DIFF
--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -82,6 +82,9 @@ def test_version(webserver, docker_client):
     if "dev" in ac_version:
         ac_version = ac_version.rsplit('-dev')[0]
         post_fix_version_astro = ac_version.rsplit('.post')[-1]
+    elif ".post" in ac_version:
+        # Example: 2.2.4.post3
+        post_fix_version_astro = ac_version.rsplit('.post')[-1]
     else:
         # Example: 1.10.10-8 will give '8'
         post_fix_version_astro = ac_version.rsplit('-')[-1]


### PR DESCRIPTION
**What this PR does / why we need it**:

In #442 I [changed the nightly builds to always build, tag, and push nightly images for versioned releases](https://github.com/astronomer/ap-airflow/pull/442/files#diff-dc966af4263c0633167a31cdea357f336b51ee74e7d62d341f251d1db94a21edR229).

However, I didn't update the tests.

Since that change creates additional nightly builds, we need to expand the way that we extract the AC version from the full AC version string.

There's a tiny bit of repetition between lines 84 and 87, but I couldn't figure out a cleaner way to get the logic to work for all cases, and I included an example case.

This should fix the [nightly build test failures](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/2727/workflows/60cf49b2-20f8-408a-b28a-1431ba3c6019).