### PR TITLE
Bump FAB security manager to 1.9.0 for main build

### DIFF
--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -143,7 +143,7 @@ RUN apt-get update \
 
 ARG VERSION
 ARG AIRFLOW_VERSION=${VERSION}
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.8.4"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.0"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump FAB security manager to 1.9.0 for main build

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
