### PR TITLE
Check for different Dockerfile version ARG values

### DIFF
--- a/.circleci/bin/check-different-arg-values.sh
+++ b/.circleci/bin/check-different-arg-values.sh
@@ -8,8 +8,6 @@ for dockerfile in $@; do
             grep -n "^ARG $argname=" $dockerfile
             echo >&2
             echo "Please update all ARG $argname directives to the same value in $dockerfile." >&2
-            echo >&2
-            echo "You can also temporarily disable this check by setting SKIP=check-different-arg-values." >&2
             EXIT=$(( $EXIT + 1 ))
         fi
     done

--- a/.circleci/bin/check-different-arg-values.sh
+++ b/.circleci/bin/check-different-arg-values.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+EXIT=0
+for dockerfile in $@; do
+    for argname in $(grep -E '^ARG [_[:alnum:]]{1,}=' $dockerfile | sort | sed 's/^ARG \([_[:alnum:]]\{1,\}\).*/\1/' | uniq); do
+        if [[ $(grep -E "^ARG $argname=" $dockerfile | uniq | wc -l) -gt 1 ]]; then
+            echo "Found multiple ARG $argname in $dockerfile with different values:" >&2
+            grep -n "^ARG $argname=" $dockerfile
+            echo >&2
+            echo "Please update both/all ARG $argname directives to the same value in $dockerfile." >&2
+            echo >&2
+            echo "You can also temporarily disable this check by setting SKIP=check-different-arg-values." >&2
+            EXIT=$(( $EXIT + 1 ))
+        fi
+    done
+done
+exit $EXIT

--- a/.circleci/bin/check-different-arg-values.sh
+++ b/.circleci/bin/check-different-arg-values.sh
@@ -7,7 +7,7 @@ for dockerfile in $@; do
             echo "Found multiple ARG $argname in $dockerfile with different values:" >&2
             grep -n "^ARG $argname=" $dockerfile
             echo >&2
-            echo "Please update both/all ARG $argname directives to the same value in $dockerfile." >&2
+            echo "Please update all ARG $argname directives to the same value in $dockerfile." >&2
             echo >&2
             echo "You can also temporarily disable this check by setting SKIP=check-different-arg-values." >&2
             EXIT=$(( $EXIT + 1 ))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
         additional_dependencies: ['jinja2']
         files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
         entry: python3 .circleci/generate_circleci_config.py
+      - id: check-different-arg-values
+        name: Checking that all ARG variable values agree with each other in Dockerfiles
+        files: "^(\\d+\\.\\d+\\.\\d+.*|main)/\\w+/Dockerfile$"
+        types: [file, dockerfile]
+        language: script
+        entry: .circleci/bin/check-different-arg-values.sh
       - id: update-dockerfiles
         name: Updates all Dockerfiles with their respective version numbers and constraint files
         language: python


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a pre-commit check for differing values in version ARGs in Dockerfiles.

This would catch issues like #458, corrected in #459, where we only updated one of the two `ASTRONOMER_FAB_SECURITY_MANAGER_VERSION` ARGs.

It's dirty messy Bash, but it works.

Example output:

```
Checking that all ARG variable values agree with each other in Dockerfiles.......................Failed
- hook id: check-different-arg-values
- exit code: 1

Found multiple ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION in main/bullseye/Dockerfile with different values:
117:ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.1"
146:ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.2"

Please update both/all ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION directives to the same value in main/bullseye/Dockerfile.
```