### PR TITLE
Silence a Docker warning (soon to be an error)

### DIFF
--- a/1.10.15/buster/Dockerfile
+++ b/1.10.15/buster/Dockerfile
@@ -163,10 +163,10 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 # Pin apache-airflow version to avoid accidental upgrade
 RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
+# Run pods spun up by Kubernetes Executor as astro user
+# Sync permissions in the entrypoint so we do not need to run in the Webserver again
 RUN sed -i \
-    # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 

--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -164,16 +164,16 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 # Pin apache-airflow version to avoid accidental upgrade
 RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
+# Run pods spun up by Kubernetes Executor as astro user
+# Lazily load all plugins, for astronomer-version-check-plugin
+# Sync permissions in the entrypoint so we do not need to run in the Webserver again
+# Use Astronomer FAB Security Manager authentication backend
+# Configure a 10.0s timeout for send_task_to_executor or fetch_celery_task_state operations.
 RUN sed -i \
-    # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # Needed by astronomer-version-check-plugin
     -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
-    # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
-    # The number of seconds to wait before timing out send_task_to_executor or fetch_celery_task_state operations.
     -e 's/^operation_timeout =.*/operation_timeout = 10.0/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 

--- a/2.2.5/bullseye/Dockerfile
+++ b/2.2.5/bullseye/Dockerfile
@@ -164,16 +164,16 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 # Pin apache-airflow version to avoid accidental upgrade
 RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
+# Run pods spun up by Kubernetes Executor as astro user
+# Lazily load all plugins, for astronomer-version-check-plugin
+# Sync permissions in the entrypoint so we do not need to run in the Webserver again
+# Use Astronomer FAB Security Manager authentication backend
+# Configure a 10.0s timeout for send_task_to_executor or fetch_celery_task_state operations.
 RUN sed -i \
-    # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # Needed by astronomer-version-check-plugin
     -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
-    # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g' \
-    # The number of seconds to wait before timing out send_task_to_executor or fetch_celery_task_state operations.
     -e 's/^operation_timeout =.*/operation_timeout = 10.0/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -160,16 +160,16 @@ COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 # Pin apache-airflow version to avoid accidental upgrade
 RUN pip freeze | grep "apache-airflow==" >>  /usr/local/share/astronomer-pip-constraints.txt
 
+# Run pods spun up by Kubernetes Executor as astro user
+# Lazily load all plugins, for astronomer-version-check-plugin
+# Sync permissions in the entrypoint so we do not need to run in the Webserver again
+# Use Astronomer FAB Security Manager authentication backend
+# Configure a 10.0s timeout for send_task_to_executor or fetch_celery_task_state operations.
 RUN sed -i \
-    # Run pods spun up by Kubernetes Executor as astro user
     -e 's/^run_as_user =.*/run_as_user = 50000/g' \
-    # Needed by astronomer-version-check-plugin
     -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g' \
-    # We sync permissions in the entrypoint so do not need to run in the Webserver again
     -e 's/^update_fab_perms =.*/update_fab_perms = False/g' \
-    # Use Auth Backend defined in Astronomer FAB Security Manager
     -e 's/^auth_backends =.*/auth_backends = astronomer.flask_appbuilder.current_user_backend/g' \
-    # The number of seconds to wait before timing out send_task_to_executor or fetch_celery_task_state operations.
     -e 's/^operation_timeout =.*/operation_timeout = 10.0/g' \
     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Docker was emitting a warning about blank continuation lines:

```
Removing intermediate container 23828e259861
[WARNING]: Empty continuation line found in:
    RUN sed -i     -e 's/^run_as_user =.*/run_as_user = 50000/g'     -e 's/^lazy_load_plugins =.*/lazy_load_plugins = False/g'     -e 's/^update_fab_perms =.*/update_fab_perms = False/g'     -e 's/^auth_backend =.*/auth_backend = astronomer.flask_appbuilder.current_user_backend/g'     -e 's/^operation_timeout =.*/operation_timeout = 10.0/g'     /usr/local/lib/python${PYTHON_MAJOR_MINOR_VERSION}/site-packages/airflow/config_templates/default_airflow.cfg
[WARNING]: Empty continuation lines will become errors in a future release.
[Warning] One or more build-args [BUILD_NUMBER REPO_BRANCH] were not consumed
Successfully built 819d851d5967
```

This PR fixes all of the currently supported/used Dockerfiles by moving the comments to above the Docker directive to fix/silence the warning.