### PR TITLE
Fixup slack notifications

### DIFF
--- a/.circleci/build_approval_slack_notification.json.j2
+++ b/.circleci/build_approval_slack_notification.json.j2
@@ -15,8 +15,8 @@
       },
       "accessory": {
         "type": "image",
-        "image_url": "https://pbs.twimg.com/profile_images/1138094475211878400/f3rTb0hP_400x400.png",
-        "alt_text": "Astronomer.io logo"
+        "image_url": "https://i.imgur.com/NMUmkxH.png",
+        "alt_text": "Astronomer.io logo, white background, dark blue letter A, multicolored stars, and a rocket with red to yellow exhaust orbiting the letter A"
       }
     },
     {

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -116,6 +116,9 @@ workflows:
       - slack/on-hold:
           name: Slack-Approval-Notification-{{ airflow_version }}-{{ distribution }}
           context: slack_ap-airflow
+          # If anybody complains about us using the old Astronomer logo, here's
+          # an Imgur album containing a few different options:
+          # https://imgur.com/a/CYRKjQ3
           custom: |
             {% filter indent(width=12) -%}
             {% include "build_approval_slack_notification.json.j2" %}

--- a/.circleci/new_dev_build_slack_notification.json.j2
+++ b/.circleci/new_dev_build_slack_notification.json.j2
@@ -16,7 +16,7 @@
       "accessory": {
         "type": "image",
         "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
-        "alt_text": "Docker Image"
+        "alt_text": "Cute cartoon Docker whale with containers on its back and a notification bell in the upper left showing one notification"
       }
     },
     {
@@ -47,12 +47,11 @@
       "type": "divider"
     },
     {
-      "type": "context",
-      "elements": [
+      "type": "section",
+      "fields": [
         {
-          "type": "plain_text",
-          "text": "Release Owners: Airflow Team\n{{ approvers_slack_syntax }}",
-          "emoji": true
+          "type": "mrkdwn",
+          "text": "Release Owners: Airflow Team\n{{ approvers_slack_syntax }}"
         }
       ]
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR has a few fixups for our Slack notifications.

1. Fixes the hotlink for the embedded Astronomer logo. We now use the same image, but [hosted from an Imgur album](https://imgur.com/a/CYRKjQ3), which supports hotlinking:
   ![New logo](https://i.imgur.com/NMUmkxH.png "Astronomer logo, white background, dark blue letter A, multicolored stars, and a rocket with red to yellow exhaust orbiting the letter A")
2. Fixed (I think) the at-mentions for new dev build Slack notifications.
3. Adds a much better descriptions in image alt texts (helpful for any blind or vision handicapped Astronomers).