### PR TITLE
Update astronomer-fab-securitymanager to 1.9.1 for 2.3.0 and main images

### DIFF
--- a/2.3.0/bullseye/Dockerfile
+++ b/2.3.0/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION="2.3.0-1-*"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.3.0"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.0"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.1"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -148,7 +148,7 @@ RUN apt-get update \
 
 ARG VERSION="2.3.0-1-*"
 ARG AIRFLOW_VERSION="2.3.0"
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.0"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -114,7 +114,7 @@ ARG VERSION
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION=${VERSION}
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.0"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.1"
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -143,7 +143,7 @@ RUN apt-get update \
 
 ARG VERSION
 ARG AIRFLOW_VERSION=${VERSION}
-ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.0"
+ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.1"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"
 LABEL io.astronomer.docker.ac.version="${VERSION}"
 LABEL io.astronomer.docker.fab_security_manager.version="${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps astronomer-fab-securitymanager to 1.9.1 so we have [this fix](https://github.com/astronomer/astronomer-fab-securitymanager/pull/39) for both 2.3.0 and main images.