### PR TITLE
Silence 2.3.0 deprecation warnings

### DIFF
--- a/2.3.0/bullseye/include/entrypoint
+++ b/2.3.0/bullseye/include/entrypoint
@@ -16,15 +16,27 @@ if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
   export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
 fi
 
+# Handle 2.3.0 DeprecationWarnings - can be removed once platform is setting these themselves
+# Add SQL_ALCHEMY_CONN to new section if it only exists in the old section
+if [[ -n "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" && -z "$AIRFLOW__DATABASE__SQL_ALCHEMY_CONN" ]]; then
+  export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=$AIRFLOW__CORE__SQL_ALCHEMY_CONN
+fi
+# add new `session` backend to AUTH_BACKENDS if no env vars are set and old key/value is present in cfg
+if [[ -z "$AIRFLOW__API__AUTH_BACKEND" && -z "$AIRFLOW__API__AUTH_BACKENDS" && -r "$AIRFLOW_HOME/airflow.cfg" ]] \
+  && grep -q "auth_backend = astronomer.flask_appbuilder.current_user_backend$" "$AIRFLOW_HOME/airflow.cfg" \
+  && ! grep -q "auth_backends = " "$AIRFLOW_HOME/airflow.cfg"; then
+  export AIRFLOW__API__AUTH_BACKENDS="astronomer.flask_appbuilder.current_user_backend,airflow.api.auth.backend.session"
+fi
+
 # Airflow subcommand
 CMD=$2
 
 url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
+if [[ -n $AIRFLOW__DATABASE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  [[ ${AIRFLOW__DATABASE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
   HOST=${BASH_REMATCH[2]}
   PORT=${BASH_REMATCH[3]}
   echo "Waiting for database: ${HOST}:${PORT}"

--- a/main/bullseye/include/entrypoint
+++ b/main/bullseye/include/entrypoint
@@ -16,29 +16,41 @@ if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
   export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
 fi
 
+# Handle 2.3.0 DeprecationWarnings - can be removed once platform is setting these themselves
+# Add SQL_ALCHEMY_CONN to new section if it only exists in the old section
+if [[ -n "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" && -z "$AIRFLOW__DATABASE__SQL_ALCHEMY_CONN" ]]; then
+  export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=$AIRFLOW__CORE__SQL_ALCHEMY_CONN
+fi
+# add new `session` backend to AUTH_BACKENDS if no env vars are set and old key/value is present in cfg
+if [[ -z "$AIRFLOW__API__AUTH_BACKEND" && -z "$AIRFLOW__API__AUTH_BACKENDS" && -r "$AIRFLOW_HOME/airflow.cfg" ]] \
+  && grep -q "auth_backend = astronomer.flask_appbuilder.current_user_backend$" "$AIRFLOW_HOME/airflow.cfg" \
+  && ! grep -q "auth_backends = " "$AIRFLOW_HOME/airflow.cfg"; then
+  export AIRFLOW__API__AUTH_BACKENDS="astronomer.flask_appbuilder.current_user_backend,airflow.api.auth.backend.session"
+fi
+
 # Airflow subcommand
 CMD=$2
 
 url_parse_regex="[^:]+://([^@/]*@)?([^/:]*):?([0-9]*)/?"
 
 # Wait for postgres then init the db
-if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]]; then
+if [[ -n $AIRFLOW__DATABASE__SQL_ALCHEMY_CONN  ]]; then
   # Wait for database port to open up
-  [[ ${AIRFLOW__CORE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
+  [[ ${AIRFLOW__DATABASE__SQL_ALCHEMY_CONN} =~ $url_parse_regex ]]
   HOST=${BASH_REMATCH[2]}
   PORT=${BASH_REMATCH[3]}
-  echo "Waiting for host: ${HOST} ${PORT}"
+  echo "Waiting for database: ${HOST}:${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
   done
 fi
 
 if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|celery worker|celery flower)$ ]]; then
-  # Wait for database port to open up
+  # Wait for broker port to open up
   [[ ${AIRFLOW__CELERY__BROKER_URL} =~ $url_parse_regex ]]
   HOST=${BASH_REMATCH[2]}
   PORT=${BASH_REMATCH[3]}
-  echo "Waiting for host: ${HOST} ${PORT}"
+  echo "Waiting for broker: ${HOST}:${PORT}"
   while ! nc -w 1 -z "${HOST}" "${PORT}"; do
     sleep 0.001
   done


### PR DESCRIPTION
In 2.3.0, there are some configuration changes that lead to deprecation
warnings. Instead of having tons of these in platform, let's move/update
the config in the entrypoint to avoid extra noise. These can be removed
once platform is setting the new config properly.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
