### PR TITLE
Fix bug where packages.txt in Windows line-endings didn't work

### DIFF
--- a/common/Dockerfile.onbuild-buster
+++ b/common/Dockerfile.onbuild-buster
@@ -25,7 +25,7 @@ LABEL io.astronomer.docker.airflow.onbuild=true
 ONBUILD COPY packages.txt .
 ONBUILD USER root
 ONBUILD RUN if [[ -s packages.txt ]]; then \
-    apt-get update && cat packages.txt | xargs apt-get install -y --no-install-recommends \
+    apt-get update && cat packages.txt | tr '\r\n' '\n' | xargs apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*; \
   fi


### PR DESCRIPTION
Reported on a call by a customer