### PR TITLE
Update before install with apt-get

### DIFF
--- a/.circleci/push.bash.j2
+++ b/.circleci/push.bash.j2
@@ -45,7 +45,7 @@ do
 
     if [[ "${tag}" == *"onbuild-"* && <<parameters.dev_release >> ]]; then
       release="$( cut -d '-' -f 1 \<<< "$tag" )"
-      sudo apt-get install postgresql postgresql-contrib
+      sudo apt-get update && sudo apt-get install postgresql postgresql-contrib
       echo "UPSERT the latest tag '${tag}' for '${release}' into the QA DB"
 
       # Connect to the database, run the query, then disconnect


### PR DESCRIPTION
If you don't, you could try fetching packages that are no longer on the
mirror.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
