### PR TITLE
Expand saved logs for easier debugging

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -11,7 +11,7 @@ function get_debugging_info {
   for pod in $(kubectl get pods -n $NAMESPACE --no-headers=true | awk '{ print $1 }'); do
     echo "======================="
     set -x
-    kubectl logs --all-containers -n  $NAMESPACE $pod | tail -n 30
+    kubectl logs --all-containers -n  $NAMESPACE $pod | tail -n 100
     set +x
     echo "======================="
   done

--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -11,7 +11,7 @@ function get_debugging_info {
   for pod in $(kubectl get pods -n $NAMESPACE --no-headers=true | awk '{ print $1 }'); do
     echo "======================="
     set -x
-    kubectl logs --all-containers -n  $NAMESPACE $pod | tail -n 100
+    kubectl logs --all-containers -n  $NAMESPACE --tail=100 $pod
     set +x
     echo "======================="
   done


### PR DESCRIPTION
**What this PR does / why we need it**:

Expands the lines logged to stdout to 100, up from 30. It's 3x more verbose, but it really helps include information that would otherwise be trampled by tracebacks, like the [recent build failures](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/3215/workflows/df3b3077-666a-4181-a18a-c5c5be28304a/jobs/72413).

30 lines:

```
=======================
+ kubectl logs --all-containers -n airflow-31526 airflow-31526-run-airflow-migrations-lb785
+ tail -n 30
  File "/usr/local/lib/python3.9/site-packages/alembic/script/base.py", line 569, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/usr/local/lib/python3.9/site-packages/alembic/util/pyfiles.py", line 94, in load_python_file
    module = load_module_py(module_id, path)
  File "/usr/local/lib/python3.9/site-packages/alembic/util/pyfiles.py", line 110, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/env.py", line 108, in <module>
    run_migrations_online()
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/env.py", line 102, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/usr/local/lib/python3.9/site-packages/alembic/runtime/environment.py", line 853, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/usr/local/lib/python3.9/site-packages/alembic/runtime/migration.py", line 623, in run_migrations
    step.migration_fn(**kw)
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/versions/0074_2_0_0_resource_based_permissions.py", line 342, in upgrade
    remap_permissions()
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/versions/0074_2_0_0_resource_based_permissions.py", line 290, in remap_permissions
    appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
  File "/usr/local/lib/python3.9/site-packages/airflow/www/app.py", line 140, in create_app
    init_plugins(flask_app)
  File "/usr/local/lib/python3.9/site-packages/airflow/www/extensions/init_views.py", line 141, in init_plugins
    app.register_blueprint(blue_print["blueprint"])
  File "/usr/local/lib/python3.9/site-packages/flask/scaffold.py", line 56, in wrapper_func
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1028, in register_blueprint
    blueprint.register(self, options)
TypeError: register() missing 1 required positional argument: 'first_registration'
+ set +x
=======================
```

100 lines:
```
=======================
+ tail -n 100
+ kubectl logs --all-containers -n airflow-13218 airflow-13218-run-airflow-migrations-98k5z
Waiting for database: airflow-13218-postgresql.airflow-13218:5432
Successfully connected to the database.
/usr/local/lib/python3.9/site-packages/airflow/configuration.py:533: DeprecationWarning: The auth_backend option in [api] has been renamed to auth_backends - the old setting has been used, but please update your config.
  option = self._get_option_from_config_file(deprecated_key, deprecated_section, key, kwargs, section)
/usr/local/lib/python3.9/site-packages/airflow/configuration.py:437: FutureWarning: The 'auth_backends' setting in [api] has the old default value of 'airflow.api.auth.backend.deny_all'. This value has been changed to 'airflow.api.auth.backend.session' in the running config, but please update your config before Apache Airflow 3.0.
  warnings.warn(
[2022-06-29 07:16:25+0000 364ms] {cli_action_loggers.py:105} WARNING - Failed to log action with (psycopg2.errors.UndefinedColumn) column "map_index" of relation "log" does not exist
LINE 1: INSERT INTO log (dttm, dag_id, task_id, map_index, event, ex...
                                                ^

[SQL: INSERT INTO log (dttm, dag_id, task_id, map_index, event, execution_date, owner, extra) VALUES (%(dttm)s, %(dag_id)s, %(task_id)s, %(map_index)s, %(event)s, %(execution_date)s, %(owner)s, %(extra)s) RETURNING log.id]
[parameters: {'dttm': datetime.datetime(2022, 6, 29, 7, 16, 25, 354710, tzinfo=Timezone('UTC')), 'dag_id': None, 'task_id': None, 'map_index': None, 'event': 'cli_upgradedb', 'execution_date': None, 'owner': 'astro', 'extra': '{"host_name": "airflow-13218-run-airflow-migrations-98k5z", "full_command": "[\'/usr/local/bin/airflow\', \'db\', \'upgrade\']"}'}]
(Background on this error at: http://sqlalche.me/e/14/f405)
DB: postgresql://postgres:***@airflow-13218-postgresql.airflow-13218:5432/postgres?sslmode=disable
Performing upgrade with database postgresql://postgres:***@airflow-13218-postgresql.airflow-13218:5432/postgres?sslmode=disable
[2022-06-29 07:16:25+0000 643ms] {db.py:1482} INFO - Creating tables
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade 849da589634d -> 2c6edca13270, Resource based permissions.
[2022-06-29 07:16:26+0000 204ms] {manager.py:817} WARNING - No user yet created, use flask fab command to do it.
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/airflow/__main__.py", line 38, in main
    args.func(args)
  File "/usr/local/lib/python3.9/site-packages/airflow/cli/cli_parser.py", line 51, in command
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/utils/cli.py", line 94, in wrapper
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/cli/commands/db_command.py", line 82, in upgradedb
    db.upgradedb(to_revision=to_revision, from_revision=from_revision, show_sql_only=args.show_sql_only)
  File "/usr/local/lib/python3.9/site-packages/astronomer/airflow/version_check/plugin.py", line 29, in run_before
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/utils/session.py", line 71, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/airflow/utils/db.py", line 1483, in upgradedb
    command.upgrade(config, revision=to_revision or 'heads')
  File "/usr/local/lib/python3.9/site-packages/alembic/command.py", line 322, in upgrade
    script.run_env()
  File "/usr/local/lib/python3.9/site-packages/alembic/script/base.py", line 569, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/usr/local/lib/python3.9/site-packages/alembic/util/pyfiles.py", line 94, in load_python_file
    module = load_module_py(module_id, path)
  File "/usr/local/lib/python3.9/site-packages/alembic/util/pyfiles.py", line 110, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/env.py", line 108, in <module>
    run_migrations_online()
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/env.py", line 102, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/usr/local/lib/python3.9/site-packages/alembic/runtime/environment.py", line 853, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/usr/local/lib/python3.9/site-packages/alembic/runtime/migration.py", line 623, in run_migrations
    step.migration_fn(**kw)
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/versions/0074_2_0_0_resource_based_permissions.py", line 342, in upgrade
    remap_permissions()
  File "/usr/local/lib/python3.9/site-packages/airflow/migrations/versions/0074_2_0_0_resource_based_permissions.py", line 290, in remap_permissions
    appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
  File "/usr/local/lib/python3.9/site-packages/airflow/www/app.py", line 140, in create_app
    init_plugins(flask_app)
  File "/usr/local/lib/python3.9/site-packages/airflow/www/extensions/init_views.py", line 141, in init_plugins
    app.register_blueprint(blue_print["blueprint"])
  File "/usr/local/lib/python3.9/site-packages/flask/scaffold.py", line 56, in wrapper_func
    return f(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1028, in register_blueprint
    blueprint.register(self, options)
TypeError: register() missing 1 required positional argument: 'first_registration'
+ set +x
=======================
```