### PR TITLE
Fix and improve triggering QA tests

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -216,17 +216,19 @@ workflows:
                 - master
 
       {#- Only dev and edge builds kick off smoke and regression tests (for now) #}
-      {%- if (dev_build and airflow_version in dev_allowlist) or edge_build %}
+      {%- if ("dev" in ac_version and airflow_version not in dev_allowlist) or edge_build %}
       - kick-off-smoke-tests:
           name: Kick-off-smoke-tests-{{ airflow_version }}-{{ distribution }}
           airflow_version: "{{ airflow_version }}"
           requires:
             - push-{{ airflow_version }}-{{ distribution }}
             - push-{{ airflow_version }}-{{ distribution }}-onbuild
+            - test-{{ airflow_version }}-{{ distribution }}-images
           filters:
             branches:
               only:
                 - master
+                - test
       - smoke-test-slack-notification:
           name: smoke-test-slack-notification-{{ airflow_version }}-{{ distribution }}
           airflow_version: "{{ airflow_version }}"
@@ -694,10 +696,12 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "21:8b:f6:e6:a1:4a:59:06:d4:1a:c3:28:a4:67:f9:24"
+      - checkout
+      - install-yq
       - run:
           name: Kick off new smoke tests
           command: |
-            .circleci/kickoff_qa_tests.sh smoke ac << parameters.airflow_version >>
+            .circleci/kickoff_qa_tests.sh << parameters.airflow_version >> smoke
 
   smoke-test-slack-notification:
     executor: docker-executor
@@ -725,10 +729,12 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "21:8b:f6:e6:a1:4a:59:06:d4:1a:c3:28:a4:67:f9:24"
+      - checkout
+      - install-yq
       - run:
           name: Kick off new regression tests
           command: |
-            .circleci/kickoff_qa_tests.sh regression ac << parameters.airflow_version >>
+            .circleci/kickoff_qa_tests.sh << parameters.airflow_version >> regression
 
   regression-test-slack-notification:
     executor: docker-executor
@@ -931,4 +937,18 @@ commands:
           command: |
             {% filter indent(width=12) -%}
             {% include "push.bash.j2" -%}
-            {% endfilter -%}
+            {% endfilter %}
+  install-yq:
+    description: Install yq in a Docker container
+    parameters:
+      version:
+        type: string
+        default: v4.26.1  # update at any time
+      binary:
+        type: string
+        default: yq_linux_amd64
+    steps:
+      - run:
+          name: Install yq
+          command: |
+            wget https://github.com/mikefarah/yq/releases/download/v4.26.1/yq_linux_amd64.tar.gz -O - |  tar xz && sudo mv yq_linux_amd64 /usr/bin/yq

--- a/.circleci/kickoff_qa_tests.sh
+++ b/.circleci/kickoff_qa_tests.sh
@@ -4,29 +4,25 @@
 GIT_REPOSITORY="https://github.com/astronomer/${TEST_REPO_NAME}.git"
 
 if [[ -z "${TEST_REPO_NAME}" ]]; then
-    echo "The TEST_REPO_NAME environment variable must be defined" >&2
+    echo "The TEST_REPO_NAME environment variable must be defined (currently: '${TEST_REPO_NAME}')" >&2
     exit 1
 fi
 
-read -r -d '' USAGE <<EOF
-kickoff_qa_tests.sh <test_type> <airflow_version>
-
-Arguments:
-  airflow_version (required) - the version of Airflow to test
-  test_type (required)       - the type of tests to kick off, can be either 'smoke' or 'regression'
-EOF
-
 if [[ $# -lt 2 ]]; then
-    echo "$USAGE" >&2
-    echo
-    echo "You must specify both arguments" >&2
+    echo >&2 "kickoff_qa_tests.sh <test_type> <airflow_version>"
+    echo >&2 ""
+    echo >&2 "Arguments:"
+    echo >&2 "  airflow_version (required) - the version of Airflow to test"
+    echo >&2 "  test_type (required)       - the type of tests to kick off, can be either 'smoke' or 'regression'"
+    echo >&2 ""
+    echo >&2 "You must specify both arguments"
     exit 1
 fi
 
 AIRFLOW_VERSION=$1
 
 TEST_TYPE=$(echo "$2" | tr '[[:upper:]]' '[[:lower:]]')  # smoke or regression
-if [[ "$TEST_TYPE" = "smoke" && "$TEST_TYPE" = "regression" ]]; then
+if [[ "$TEST_TYPE" != "smoke" && "$TEST_TYPE" != "regression" ]]; then
     echo "The specified test type must be either 'smoke' or 'regression'" >&2
     exit 1
 fi
@@ -35,11 +31,13 @@ fi
 
 
 
+set -ex -o pipefail
+
 # Update the repo with the latest
 if [[ -d "${TEST_REPO_NAME}" ]]; then
     cd "${TEST_REPO_NAME}"
     git fetch
-    git reset --hard origin/$(git branch --show-current)
+    git pull || ( git rebase --abort; git reset --hard origin/$(git branch --show-current) )
 else
     git clone ${GIT_REPOSITORY}
     cd ${TEST_REPO_NAME}
@@ -47,14 +45,29 @@ fi
 
 git branch --show-current
 
-CONFIG_FILE=platform_configs_default.yaml
+CONFIG_FILE=platforms_config.yaml
 
 # Update $CONFIG_FILE:
 # - platform:
 #     ...
-#     airflow: ${AIRFLOW_VERSION}
+#     airflow:
+#       - "${AIRFLOW_VERSION}"
 #     ...
-sed -i.bak "s/^\([[:space:]]*airflow:[[:space:]]*\)\".*\"/\1\"${AIRFLOW_VERSION}\"/" $CONFIG_FILE
+#     tests:
+#       - "smoke"
+#     ...
+# Replace each .platform.airflow value with a list of airflow versions and
+# replace each .platform.tests value with the test type
+# https://stackoverflow.com/a/72627603
+# https://stackoverflow.com/a/72795815
+# We double quote the array values to ensure YAML interprets them as strings
+# and not floats (for the version strings)
+AIRFLOW_VERSION=$AIRFLOW_VERSION \
+TEST_TYPE=$TEST_TYPE \
+yq eval --inplace \
+    '(.[].platform.airflow) |= [strenv(AIRFLOW_VERSION)] | ..style="double"
+    |(.[].platform.tests) |= [strenv(TEST_TYPE)] | ..style="double"' \
+    ${CONFIG_FILE}
 
 # For runtime, need to update version and image_tag properties in $CONFIG_FILE
 
@@ -64,10 +77,15 @@ sed -i.bak "s/^\([[:space:]]*airflow:[[:space:]]*\)\".*\"/\1\"${AIRFLOW_VERSION}
 # and version/s on another
 
 git add $CONFIG_FILE
-git commit -m "Run ${TEST_TYPE} tests for Airflow $AIRFLOW_VERSION"
+git config user.name "ap-airflow"
+git config user.email "astronomer@users.noreply.github.com"
+git commit --allow-empty --message="Run ${TEST_TYPE} tests for Airflow $AIRFLOW_VERSION"
+
+if [[ -n "$DRY_RUN" ]]; then
+    exit 0
+fi
 
 # Try to minimize the amount of time we are vulnerable to a race condition with other jobs
-
 FAILURE_COUNT=0
 until [[ $FAILURE_COUNT -ge 5 ]] || git push; do
     git fetch && git merge --no-edit --strategy=ours origin/$(git branch --show-current)

--- a/.circleci/kickoff_qa_tests.sh
+++ b/.circleci/kickoff_qa_tests.sh
@@ -36,7 +36,6 @@ set -ex -o pipefail
 # Update the repo with the latest
 if [[ -d "${TEST_REPO_NAME}" ]]; then
     cd "${TEST_REPO_NAME}"
-    git fetch
     git pull || ( git rebase --abort; git reset --hard origin/$(git branch --show-current) )
 else
     git clone ${GIT_REPOSITORY}


### PR DESCRIPTION
**What this PR does / why we need it**:

* Kick off QA smoke tests from the `test` branch (so I don't have to commit and push to `master` to test fixes)
* Fix logic that gates kicking off tests for dev builds
* Explicitly check out the code before using it
* Fix the order of arguments to `kickoff_qa_tests.sh`
* Fix checking arguments in `kickoff_qa_tests.sh`
* Improve the logic to update the code from `origin` - fast forward rebases/merges are now supported
* Update the correct file
* Install and use `yq` to update the YAML config files instead of blindly using `sed` - this should be much more robust!
* Configure a git user and email address
* Allow empty QA repo commits - this allows us to force test runs by adding and pushing empty commits
* Add a `DRY_RUN` variable to prevent pushing code, but don't document it
* Better debugging and error messages

This should be the last major code churn to enable QA tests (famous last words...) - the rest of the bugs will need to be worked out in the QA repo.