### PR TITLE
Experiment better bash formatting

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -48,7 +48,7 @@ workflows:
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
           {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
-          extra_args: |
+          extra_args: |-
             {#- If you modify this, make sure you also modify it in the 'nightly' workflow -#}
             {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)
@@ -320,7 +320,7 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: true
           edge_build: {{ edge_build }}
-          extra_args: |
+          extra_args: |-
             {#- If you modify this, make sure you also modify it in the 'certified-airflow' workflow -#}
             {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -53,20 +53,20 @@ workflows:
             {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)
             {%- else %}
-            --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' <{{ ext_build_filename_workspace }})"
-            --label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
-            --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}"
+            --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' <{{ ext_build_filename_workspace }})" \
+            --label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }}) \
+            --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}" \
             {#- This redirects to the canonical workflow URL #}
             --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
             {%- endif %}{# edge_build #}
@@ -325,20 +325,20 @@ workflows:
             {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)
             {%- else %}
-            --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <{{ ext_build_filename_workspace }})
-            --label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' <{{ ext_build_filename_workspace }})"
-            --label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }})
-            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }})
-            --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}"
+            --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.build.date=$(jq -r '.date' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' <{{ ext_build_filename_workspace }}) \
+            --label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' <{{ ext_build_filename_workspace }})" \
+            --label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' <{{ ext_build_filename_workspace }})=$(jq -r '.git.built_by.ref.name' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' <{{ ext_build_filename_workspace }}) \
+            --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' <{{ ext_build_filename_workspace }}) \
+            --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}" \
             {#- This redirects to the canonical workflow URL #}
             --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
             {%- endif %}{# edge_build #}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -48,7 +48,7 @@ workflows:
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
           {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
-          extra_args:
+          extra_args: |
             {#- If you modify this, make sure you also modify it in the 'nightly' workflow -#}
             {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)
@@ -320,7 +320,7 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: true
           edge_build: {{ edge_build }}
-          extra_args:
+          extra_args: |
             {#- If you modify this, make sure you also modify it in the 'certified-airflow' workflow -#}
             {%- if not edge_build %}
             --build-arg VERSION=$(curl https://pip.astronomer.io/simple/astronomer-certified/latest-{{ airflow_version_wout_dev }}.build)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the generated Bash a bit easier to read when it's finally rendered before running in CircleCI.

Before:

```
#!/bin/bash -eo pipefail
set -xe
mkdir -p saved-images/"$(dirname 'ap-airflow:main')"
docker build $([[ "true" == "true" ]] && printf -- "--no-cache") \
  --tag 'ap-airflow:main' \
  --label io.astronomer.docker.build_time="$(date +%s)" \
  --label io.astronomer.repo.commit_sha="${CIRCLE_SHA1}" \
  --label io.astronomer.repo.url="${CIRCLE_REPOSITORY_URL}" \
  --label io.astronomer.ci.build_url="${CIRCLE_BUILD_URL}" \
  --file 'main/bullseye/Dockerfile' \
  --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.build.date=$(jq -r '.date' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' </tmp/workspace/latest-main.build.json) --label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' </tmp/workspace/latest-main.build.json)" --label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' </tmp/workspace/latest-main.build.json) --label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' </tmp/workspace/latest-main.build.json) --label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' </tmp/workspace/latest-main.build.json)=$(jq -r '.git.built_by.ref.name' </tmp/workspace/latest-main.build.json) --label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' </tmp/workspace/latest-main.build.json) --label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' </tmp/workspace/latest-main.build.json) --label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}" --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}" 'main/bullseye'
docker save -o saved-images/ap-airflow:main.tar 'ap-airflow:main'
docker inspect ap-airflow:main
```

After:

```
#!/bin/bash -eo pipefail
set -xe
mkdir -p saved-images/"$(dirname 'ap-airflow:main')"
docker build $([[ "true" == "true" ]] && printf -- "--no-cache") \
  --tag 'ap-airflow:main' \
  --label io.astronomer.docker.build_time="$(date +%s)" \
  --label io.astronomer.repo.commit_sha="${CIRCLE_SHA1}" \
  --label io.astronomer.repo.url="${CIRCLE_REPOSITORY_URL}" \
  --label io.astronomer.ci.build_url="${CIRCLE_BUILD_URL}" \
  --file 'main/bullseye/Dockerfile' \
  --build-arg VERSION=$(jq -r '.output.astronomer_certified.package.version' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.build.date=$(jq -r '.date' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.build.url=$(jq -r '.github.run.url' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.build.version=$(jq -r '.output.airflow.package.version' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.js.node.version_string=$(jq -r '.js.node.version' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.js.npm.version_string=$(jq -r '.js.npm.version' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.js.yarn.version_string=$(jq -r '.js.yarn.version' </tmp/workspace/latest-main.build.json) \
--label org.apache.airflow.ci.python.version_string="$(jq -r '.python.version' </tmp/workspace/latest-main.build.json)" \
--label io.astronomer.airflow.built_from.git.branch=$(jq -r '.git.built_from.branch' </tmp/workspace/latest-main.build.json) \
--label io.astronomer.airflow.built_from.git.commit_sha=$(jq -r '.git.built_from.commit' </tmp/workspace/latest-main.build.json) \
--label io.astronomer.airflow.built_by.git.$(jq -r '.git.built_by.ref.type' </tmp/workspace/latest-main.build.json)=$(jq -r '.git.built_by.ref.name' </tmp/workspace/latest-main.build.json) \
--label io.astronomer.airflow.built_by.git.commit_sha=$(jq -r '.git.built_by.commit' </tmp/workspace/latest-main.build.json) \
--label io.astronomer.astronomer_certified.build.version=$(jq -r '.output.astronomer_certified.package.version' </tmp/workspace/latest-main.build.json) \
--label com.circleci.workflow.id="${CIRCLE_WORKFLOW_ID}" \
--label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}" 'main/bullseye'
docker save -o saved-images/ap-airflow:main.tar 'ap-airflow:main'
docker inspect ap-airflow:main
```

**Special notes for your reviewer**:

And this might be burying the lede here, but it might also [fix](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/3410/workflows/528df324-00d8-4996-a78e-bc884b4954f5/jobs/75575) the [broken build](https://app.circleci.com/pipelines/github/astronomer/ap-airflow/3406/workflows/848521e6-9c73-4560-9726-bc5e8f6b1de5/jobs/75522)...somehow. Still not sure why but if it's resolved, I'm leaving it alone.