### PR TITLE
Bump 2.3.3 dependency numbers to fix trivy issues

### DIFF
--- a/2.3.3/bullseye/Dockerfile
+++ b/2.3.3/bullseye/Dockerfile
@@ -53,7 +53,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="3"
+ARG DEPENDENCIES_EPOCH_NUMBER="4"
 # Increase the value below to force renstalling of all dependencies
 ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
 
@@ -139,7 +139,7 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower \
 FROM ${APT_DEPS_IMAGE} as main
 
 # By increasing this number we force CI to upgrade all system packages
-ARG PACKAGE_UPGRADE_EPOCH_NUMBER="1"
+ARG PACKAGE_UPGRADE_EPOCH_NUMBER="2"
 
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes Trivy complaints.

The CI failure is due to an unrelated constraints issue in `main`.