### PR TITLE
Better links and Slack messages

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -4,6 +4,10 @@
 {%- else -%}
 {%- set approvers_slack_syntax = ("<@" + (approvers|join("")) + ">" ) | safe -%}
 {%- endif -%}
+{%- set qa_reponame = "qa-airflow-run-on-software" -%}
+{%- set qa_repo = "https://github.com/astronomer/" + qa_reponame -%}
+{%- set qa_repo_default_branch = "master" -%}
+{%- set qa_circleci_project ="https://app.circleci.com/pipelines/github/astronomer/qa-airflow-run-on-software?branch=" + qa_repo_default_branch -%}
 {%- set workspace_prefix = '/tmp/workspace' -%}
 version: 2.1
 
@@ -237,6 +241,11 @@ workflows:
       - smoke-test-slack-notification:
           name: smoke-test-slack-notification-{{ airflow_version }}-{{ distribution }}
           airflow_version: "{{ airflow_version }}"
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          image_tag: "{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          image_tag: "{{ airflow_version }}"
+          {%- endif %}
           context:
             - slack_ap-airflow
           requires:
@@ -288,6 +297,11 @@ workflows:
       - regression-test-slack-notification:
           name: regression-test-slack-notification-{{ airflow_version }}-{{ distribution }}
           airflow_version: "{{ airflow_version }}"
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          image_tag: "{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          image_tag: "{{ airflow_version }}"
+          {%- endif %}
           context:
             - slack_ap-airflow
           requires:
@@ -721,6 +735,14 @@ jobs:
     parameters:
       airflow_version:
         type: string
+      image_tag:
+        type: string
+      qa_repo_default_branch:
+        type: string
+        default: {{ qa_repo_default_branch }}
+      qa_circleci_project:
+        type: string
+        default: {{ qa_circleci_project }}
     steps:
       - slack/notify:
           branch_pattern: master,push_tags_db
@@ -756,6 +778,14 @@ jobs:
     parameters:
       airflow_version:
         type: string
+      image_tag:
+        type: string
+      qa_repo_default_branch:
+        type: string
+        default: {{ qa_repo_default_branch }}
+      qa_circleci_project:
+        type: string
+        default: {{ qa_circleci_project }}
     steps:
       - slack/notify:
           branch_pattern: master,push_tags_db

--- a/.circleci/new_build_slack_approval.json.j2
+++ b/.circleci/new_build_slack_approval.json.j2
@@ -1,84 +1,85 @@
 {
-  "blocks": [
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": ":tada:    *New Astronomer Certified Build*    :tada:"
-      }
-    },
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "Version {{ ac_version }} Release Awaiting Approval"
-      },
-      "accessory": {
-        "type": "image",
-        "image_url": "https://i.imgur.com/NMUmkxH.png",
-        "alt_text": "Astronomer.io logo, white background, dark blue letter A, multicolored stars, and a rocket with red to yellow exhaust orbiting the letter A"
-      }
-    },
-    {
-      "type": "divider"
-    },
-    {
-      "type": "section",
-      "fields": [
+    "blocks": [
         {
-          "type": "mrkdwn",
-          "text": "*Project*:\n    <https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH&filter=all|$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME :circleci:>"
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":tada:    *New Astronomer Certified Build*    :tada:",
+                "emoji": true
+            }
         },
         {
-          "type": "mrkdwn",
-          "text": "*Branch*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH|`$CIRCLE_BRANCH`>"
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "Version {{ ac_version }} Release Awaiting Approval"
+            },
+            "accessory": {
+                "type": "image",
+                "image_url": "https://i.imgur.com/NMUmkxH.png",
+                "alt_text": "Astronomer.io logo, white background, dark blue letter A, multicolored stars, and a rocket with red to yellow exhaust orbiting the letter A"
+            }
         },
         {
-          "type": "mrkdwn",
-          "text": "*Author*:\n    $CIRCLE_USERNAME"
+            "type": "divider"
         },
         {
-          "type": "mrkdwn",
-          "text": "*Git SHA*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|`${CIRCLE_SHA1:0:7}`>"
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "*Project*:\n    <https://app.circleci.com/pipelines/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?branch=$CIRCLE_BRANCH&filter=all|$CIRCLE_PROJECT_REPONAME :circleci:>"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Branch*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH|`$CIRCLE_BRANCH`>"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Author*:\n    $CIRCLE_USERNAME"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Git SHA*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|`${CIRCLE_SHA1:0:7}`>"
+                }
+            ]
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "image",
+                    "image_url": "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png",
+                    "alt_text": "notifications warning icon"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Edge (main) builds and dev builds bypass approval*"
+                }
+            ]
+        },
+        {
+            "type": "divider"
+        },
+        {
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "Allowed Approvers:\n{{ approvers_slack_syntax }}"
+                }
+            ],
+            "accessory": {
+                "type": "button",
+                "style": "primary",
+                "text": {
+                    "emoji": true,
+                    "type": "plain_text",
+                    "text": "Approve on CircleCI :arrow_upper_right:"
+                },
+                "url": "https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}",
+                "action_id": "button-action"
+            }
         }
-      ]
-    },
-    {
-      "type": "context",
-      "elements": [
-        {
-          "type": "image",
-          "image_url": "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png",
-          "alt_text": "notifications warning icon"
-        },
-        {
-          "type": "mrkdwn",
-          "text": "*Edge (main) builds and dev builds bypass approval*"
-        }
-      ]
-    },
-    {
-      "type": "divider"
-    },
-    {
-      "type": "section",
-      "fields": [
-        {
-          "type": "mrkdwn",
-          "text": "Allowed Approvers:\n{{ approvers_slack_syntax }}"
-        }
-      ],
-      "accessory": {
-        "type": "button",
-        "style": "primary",
-        "text": {
-          "emoji": true,
-          "type": "plain_text",
-          "text": "Approve on CircleCI :arrow_upper_right:"
-        },
-        "url": "https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}",
-        "action_id": "button-action"
-      }
-    }
-  ]
+    ]
 }

--- a/.circleci/new_dev_build_slack_notification.json.j2
+++ b/.circleci/new_dev_build_slack_notification.json.j2
@@ -1,59 +1,48 @@
 {
-  "blocks": [
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": ":tada:    *New Astronomer Certified DEV Build*    :tada:"
-      }
-    },
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": "<< parameters.airflow_version >> Development Image(s) Released"
-      },
-      "accessory": {
-        "type": "image",
-        "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
-        "alt_text": "Cute cartoon Docker whale with containers on its back and a notification bell in the upper left showing one notification"
-      }
-    },
-    {
-      "type": "divider"
-    },
-    {
-      "type": "section",
-      "fields": [
+    "blocks": [
         {
-          "type": "mrkdwn",
-          "text": "*Image Registry*:\n    <https://quay.io/repository/astronomer/ap-airflow-dev?tag=latest&tab=tags|ap-airflow-dev>"
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": ":tada:    *New Astronomer Certified DEV Build*    :tada:",
+                "emoji": true
+            }
         },
         {
-          "type": "mrkdwn",
-          "text": "*Tags*:\n    << parameters.extra_tags >>"
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<< parameters.airflow_version >> Development Image(s) Released"
+            },
+            "accessory": {
+                "type": "image",
+                "image_url": "https://res.cloudinary.com/practicaldev/image/fetch/s--dPhPEZO8--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png",
+                "alt_text": "Cute cartoon Docker whale with containers on its back and a notification bell in the upper left showing one notification"
+            }
         },
         {
-          "type": "mrkdwn",
-          "text": "*Author*:\n    $CIRCLE_USERNAME"
+            "type": "section",
+            "fields": [
+                {
+                    "type": "mrkdwn",
+                    "text": "*Image Registry*:\n    <https://quay.io/repository/astronomer/ap-airflow-dev?tag=latest&tab=tags|ap-airflow-dev>"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Tags*:\n    `<< parameters.extra_tags >>`"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Author*:\n    $CIRCLE_USERNAME"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Git SHA*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|`${CIRCLE_SHA1:0:7}`>"
+                }
+            ]
         },
         {
-          "type": "mrkdwn",
-          "text": "*Git SHA*:\n    <https://github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/commit/$CIRCLE_SHA1|`${CIRCLE_SHA1:0:7}`>"
+            "type": "divider"
         }
-      ]
-    },
-    {
-      "type": "divider"
-    },
-    {
-      "type": "section",
-      "fields": [
-        {
-          "type": "mrkdwn",
-          "text": "Release Owners: Airflow Team\n{{ approvers_slack_syntax }}"
-        }
-      ]
-    }
-  ]
+    ]
 }

--- a/.circleci/regression_test_slack_approval.json.j2
+++ b/.circleci/regression_test_slack_approval.json.j2
@@ -1,10 +1,11 @@
 {
     "blocks": [
         {
-            "type": "section",
+            "type": "header",
             "text": {
-                "type": "mrkdwn",
-                "text": ":question:    *Start QA Tests?*    :question:"
+                "type": "plain_text",
+                "text": ":question::clipboard::question:    *Start QA Tests?*    :question::clipboard::question:",
+                "emoji": true
             }
         },
         {
@@ -35,7 +36,7 @@
                 },
                 {
                     "type": "mrkdwn",
-                    "text": "*Branch*:\n    $CIRCLE_BRANCH"
+                    "text": "*Branch*:\n    `$CIRCLE_BRANCH`"
                 },
                 {
                     "type": "mrkdwn",

--- a/.circleci/regression_test_slack_notification.json.j2
+++ b/.circleci/regression_test_slack_notification.json.j2
@@ -1,50 +1,33 @@
 {
     "blocks": [
         {
-            "type": "section",
+            "type": "header",
             "text": {
-                "type": "mrkdwn",
-                "text": ":drum_with_drumsticks:    *Regression Tests Started*    :drum_with_drumsticks:"
+                "type": "plain_text",
+                "text": ":drum_with_drumsticks::clipboard::drum_with_drumsticks:    Regression Tests Started    :drum_with_drumsticks::clipboard::drum_with_drumsticks:",
+                "emoji": true
             }
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "\n"
-            },
-            "accessory": {
-                "type": "image",
-                "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/Circleci-icon-logo.svg/104px-Circleci-icon-logo.svg.png",
-                "alt_text": "CircleCI icon, a backwards letter C with a dot in the center"
-            }
-        },
-        {
-            "type": "divider"
         },
         {
             "type": "section",
             "fields": [
                 {
                     "type": "mrkdwn",
-                    "text": "*Airflow Version*:\n    {{ airflow_version }}"
+                    "text": "*Airflow Version*:\n    << parameters.airflow_version >>"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Image Tag*:\n    `<< parameters.image_tag >>`"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Branch*:\n    <https://github.com/astronomer/qa-airflow-run-on-software|<< parameters.qa_repo_default_branch >> >"
                 },
                 {
                     "type": "mrkdwn",
                     "text": "*Image Registry*:\n    <https://quay.io/repository/astronomer/ap-airflow-dev?tag=latest&tab=tags|ap-airflow-dev>"
-                },
-                {
-                    "type": "mrkdwn",
-                    "text": "*Branch*:\n    $CIRCLE_BRANCH"
-                },
-                {
-                    "type": "mrkdwn",
-                    "text": "*Author*:\n    $CIRCLE_USERNAME"
                 }
             ]
-        },
-        {
-            "type": "divider"
         },
         {
             "type": "section",
@@ -62,7 +45,7 @@
                     "type": "plain_text",
                     "text": "Follow on CircleCI :arrow_upper_right:"
                 },
-                "url": "https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}",
+                "url": "<< parameters.qa_circleci_project >>",
                 "action_id": "button-action"
             }
         }

--- a/.circleci/regression_test_slack_notification.json.j2
+++ b/.circleci/regression_test_slack_notification.json.j2
@@ -9,6 +9,9 @@
             }
         },
         {
+            "type": "divider"
+        },
+        {
             "type": "section",
             "fields": [
                 {
@@ -21,7 +24,7 @@
                 },
                 {
                     "type": "mrkdwn",
-                    "text": "*Branch*:\n    <https://github.com/astronomer/qa-airflow-run-on-software|<< parameters.qa_repo_default_branch >> >"
+                    "text": "*Branch*:\n    <https://github.com/astronomer/qa-airflow-run-on-software|`<< parameters.qa_repo_default_branch >>`>"
                 },
                 {
                     "type": "mrkdwn",
@@ -39,7 +42,6 @@
             ],
             "accessory": {
                 "type": "button",
-                "style": "primary",
                 "text": {
                     "emoji": true,
                     "type": "plain_text",
@@ -48,6 +50,9 @@
                 "url": "<< parameters.qa_circleci_project >>",
                 "action_id": "button-action"
             }
+        },
+        {
+            "type": "divider"
         }
     ]
 }

--- a/.circleci/smoke_test_slack_notification.json.j2
+++ b/.circleci/smoke_test_slack_notification.json.j2
@@ -1,26 +1,12 @@
 {
     "blocks": [
         {
-            "type": "section",
+            "type": "header",
             "text": {
-                "type": "mrkdwn",
-                "text": ":drum_with_drumsticks:    *Smoke Tests Started*    :drum_with_drumsticks:"
+                "type": "plain_text",
+                "text": ":drum_with_drumsticks::cloud::drum_with_drumsticks:    Smoke Tests Started    :drum_with_drumsticks::cloud::drum_with_drumsticks:",
+                "emoji": true
             }
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "\n"
-            },
-            "accessory": {
-                "type": "image",
-                "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/82/Circleci-icon-logo.svg/104px-Circleci-icon-logo.svg.png",
-                "alt_text": "CircleCI icon, a backwards letter C with a dot in the center"
-            }
-        },
-        {
-            "type": "divider"
         },
         {
             "type": "section",
@@ -31,20 +17,17 @@
                 },
                 {
                     "type": "mrkdwn",
+                    "text": "*Image Tag*:\n    `<< parameters.image_tag >>`"
+                },
+                {
+                    "type": "mrkdwn",
+                    "text": "*Branch*:\n    <https://github.com/astronomer/qa-airflow-run-on-software|<< parameters.qa_repo_default_branch >> >"
+                },
+                {
+                    "type": "mrkdwn",
                     "text": "*Image Registry*:\n    <https://quay.io/repository/astronomer/ap-airflow-dev?tag=latest&tab=tags|ap-airflow-dev>"
-                },
-                {
-                    "type": "mrkdwn",
-                    "text": "*Branch*:\n    $CIRCLE_BRANCH"
-                },
-                {
-                    "type": "mrkdwn",
-                    "text": "*Author*:\n    $CIRCLE_USERNAME"
                 }
             ]
-        },
-        {
-            "type": "divider"
         },
         {
             "type": "section",
@@ -62,7 +45,7 @@
                     "type": "plain_text",
                     "text": "Follow on CircleCI :arrow_upper_right:"
                 },
-                "url": "https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}",
+                "url": "<< parameters.qa_circleci_project >>",
                 "action_id": "button-action"
             }
         }

--- a/.circleci/smoke_test_slack_notification.json.j2
+++ b/.circleci/smoke_test_slack_notification.json.j2
@@ -9,6 +9,9 @@
             }
         },
         {
+            "type": "divider"
+        },
+        {
             "type": "section",
             "fields": [
                 {
@@ -21,7 +24,7 @@
                 },
                 {
                     "type": "mrkdwn",
-                    "text": "*Branch*:\n    <https://github.com/astronomer/qa-airflow-run-on-software|<< parameters.qa_repo_default_branch >> >"
+                    "text": "*Branch*:\n    <https://github.com/astronomer/qa-airflow-run-on-software|`<< parameters.qa_repo_default_branch >>`>"
                 },
                 {
                     "type": "mrkdwn",
@@ -39,7 +42,6 @@
             ],
             "accessory": {
                 "type": "button",
-                "style": "primary",
                 "text": {
                     "emoji": true,
                     "type": "plain_text",
@@ -48,6 +50,9 @@
                 "url": "<< parameters.qa_circleci_project >>",
                 "action_id": "button-action"
             }
+        },
+        {
+            "type": "divider"
         }
     ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds better links to QA test workflows, and also improves (IMO) all of our Slack messages a bit.

![Screen Shot 2022-08-05 at 6 45 17 PM](https://user-images.githubusercontent.com/597113/183229121-fac7ee04-6f9c-4ebe-bc77-0c6374797af3.png)
![Screen Shot 2022-08-05 at 6 46 13 PM](https://user-images.githubusercontent.com/597113/183229123-b9a3af64-fbe3-4143-b58d-c1c45361a094.png)
![Screen Shot 2022-08-05 at 6 54 45 PM](https://user-images.githubusercontent.com/597113/183229106-72267fc1-c961-45ca-ac60-95a5075e13ff.png)
![Screen Shot 2022-08-05 at 6 54 56 PM](https://user-images.githubusercontent.com/597113/183229107-d4daca50-d8b7-403c-9977-d295229ffb70.png)
![Screen Shot 2022-08-05 at 6 50 04 PM](https://user-images.githubusercontent.com/597113/183229114-a7447c1f-cc59-4300-9470-373747997c10.png)

I removed some section dividers, and added some at the end of the messages - this should hopefully help visually separate notifications about different versions, since we one message for each AC version in a run. I also utilized the (new?) `header` block that renders text larger than the rest of the message, which should further help out.