### PR TITLE
Stop building from main

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -37,7 +37,6 @@ IMAGE_MAP = collections.OrderedDict([
     ("1.10.15-9", ["buster"]),
     ("2.1.4-9", ["buster"]),
     ("2.3.3-2-dev", ["bullseye"]),
-    ("main-dev", ["bullseye"]),
 ])
 
 # Airflow Versions for which we don't publish Python Wheels


### PR DESCRIPTION
**What this PR does / why we need it**:

We can stop building from `main` now. 🎉

In an attempt to minimize churn, I didn't change any of the template branching logic, since I don't know that that buys us a whole lot anymore.