### PR TITLE
Fix bug where packages.txt in Windows line-endings didn't work on bullseye

### DIFF
--- a/common/Dockerfile.onbuild-bullseye
+++ b/common/Dockerfile.onbuild-bullseye
@@ -25,7 +25,7 @@ LABEL io.astronomer.docker.airflow.onbuild=true
 ONBUILD COPY packages.txt .
 ONBUILD USER root
 ONBUILD RUN if [[ -s packages.txt ]]; then \
-    apt-get update && cat packages.txt | xargs apt-get install -y --no-install-recommends \
+    apt-get update && cat packages.txt | tr '\r\n' '\n' | xargs apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*; \
   fi


### PR DESCRIPTION
This was fixed a while back for our buster images (#482), but was missed for bullseye.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
