### PR TITLE
Scan released versions nightly

### DIFF
--- a/.circleci/bin/test-airflow
+++ b/.circleci/bin/test-airflow
@@ -63,16 +63,11 @@ echo "Airflow Version (SemVer): $AIRFLOW_VERSION_SEMVER"
 EDGE_BUILD=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.build.edge" }}' "$REPOSITORY:$TEST_TAG")
 export EDGE_BUILD
 
-# Find alpine or debian
+# Find debian
 DISTRO=$(docker inspect --format '{{ index .Config.Labels "io.astronomer.docker.distro" }}' "$REPOSITORY:$TEST_TAG")
 # This is handled by Houston for the platform: https://github.com/astronomer/houston-api/pull/581
-if [[ "$DISTRO" == "alpine" ]]; then
-  export IMAGE_UID="100"
-  export IMAGE_GID="101"
-else
-  export IMAGE_UID="50000"
-  export IMAGE_GID="50000"
-fi
+export IMAGE_UID="50000"
+export IMAGE_GID="50000"
 echo "Distro: $DISTRO - Setting UID to $IMAGE_UID and GID to $IMAGE_GID"
 
 CHART_VERSION=$(helm search repo --regexp 'astronomer/airflow[^-]' | grep astronomer/airflow | awk '{print $2}')

--- a/.circleci/bin/test-airflow-image.py
+++ b/.circleci/bin/test-airflow-image.py
@@ -274,8 +274,6 @@ def test_airflow_configs(scheduler, docker_client):
 
     if distro == "debian":
         expected_run_as_user = "50000"
-    elif distro == "alpine":
-        expected_run_as_user = "100"
     elif distro == "rhel":
         expected_run_as_user = "100"
     else:

--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -14,7 +14,7 @@ def dev_releases(all_releases):
     """Find dev releases from a list of releases"""
     return [
         release for release in all_releases
-        if is_dev_release(release) and get_airflow_version(release) not in DEV_ALLOWLIST
+        if is_dev_release(release)
     ]
 
 
@@ -38,6 +38,3 @@ IMAGE_MAP = collections.OrderedDict([
     ("2.1.4-9", ["buster"]),
     ("2.3.4-2-dev", ["bullseye"]),
 ])
-
-# Airflow Versions for which we don't publish Python Wheels
-DEV_ALLOWLIST = []

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -51,7 +51,7 @@ workflows:
           distribution_name: {{ distribution }}
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
-          {%- if "dev" in ac_version and airflow_version not in dev_allowlist %}
+          {%- if "dev" in ac_version %}
           extra_args: |-
             {#- If you modify this, make sure you also modify it in the 'nightly' workflow -#}
             {%- if not edge_build %}
@@ -116,7 +116,7 @@ workflows:
           requires:
             - build-{{ airflow_version }}-{{ distribution }}
       {#- Only dev and edge builds are allowed to skip approval before pushing and notifying #}
-      {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
+      {%- if "dev" not in ac_version and not edge_build %}
       - slack/on-hold:
           name: Slack-Approval-Notification-{{ airflow_version }}-{{ distribution }}
           context: slack_ap-airflow
@@ -162,7 +162,7 @@ workflows:
             - docker.io
             - qa
           requires:
-            {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
+            {%- if "dev" not in ac_version and not edge_build %}
             - Need-Approval-{{ airflow_version }}-{{ distribution }}
             {%- else %}
             - scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -190,7 +190,7 @@ workflows:
             - docker.io
             - qa
           requires:
-            {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
+            {%- if "dev" not in ac_version and not edge_build %}
             - Need-Approval-{{ airflow_version }}-{{ distribution }}
             {%- else %}
             - scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
@@ -224,7 +224,7 @@ workflows:
                 - master
 
       {#- Only dev and edge builds kick off smoke and regression tests (for now) #}
-      {%- if ("dev" in ac_version and airflow_version not in dev_allowlist) or edge_build %}
+      {%- if "dev" in ac_version or edge_build %}
       - kick-off-smoke-tests:
           name: Kick-off-smoke-tests-{{ airflow_version }}-{{ distribution }}
           {%- if distribution in ["alpine3.10", "buster"] %}
@@ -330,7 +330,6 @@ workflows:
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- set ext_build_filename_workspace = workspace_prefix + '/latest-' + airflow_version_wout_dev + '.build.json' %}
-      {%- if airflow_version not in dev_allowlist  %}
 
       {%- if edge_build %}
       - download-file:
@@ -460,7 +459,6 @@ workflows:
               only:
                 - master
       {%- endfor %}{# distribution in distributions #}
-      {%- endif %}{# if airflow_version not in dev_allowlist #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
   {%- endif %}{# image_map.keys() | dev_releases | length > 0 #}
 

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -75,7 +75,7 @@ workflows:
             --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
             {%- endif %}{# edge_build #}
           {%- endif %}
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
@@ -90,7 +90,7 @@ workflows:
           airflow_version: {{ airflow_version }}
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
@@ -99,7 +99,7 @@ workflows:
             - build-{{ airflow_version }}-{{ distribution }}
       - scan-snyk:
           name: scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
@@ -108,7 +108,7 @@ workflows:
             - build-{{ airflow_version }}-{{ distribution }}
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-images
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
@@ -150,7 +150,7 @@ workflows:
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
           nightly_build: false
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
           {%- else %}
@@ -178,7 +178,7 @@ workflows:
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
           nightly_build: false
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
           {%- else %}
@@ -206,7 +206,7 @@ workflows:
           name: new-build-slack-notification-{{ airflow_version }}-{{ distribution }}-onbuild
           dev_build: {{ dev_build }}
           airflow_version: "{{ airflow_version }}"
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ ac_version }}-{{ distribution }}-onbuild"
           {%- else %}
@@ -227,7 +227,7 @@ workflows:
       {%- if "dev" in ac_version or edge_build %}
       - kick-off-smoke-tests:
           name: Kick-off-smoke-tests-{{ airflow_version }}-{{ distribution }}
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_tag: "{{ airflow_version }}"
@@ -244,7 +244,7 @@ workflows:
       - smoke-test-slack-notification:
           name: smoke-test-slack-notification-{{ airflow_version }}-{{ distribution }}
           airflow_version: "{{ airflow_version }}"
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_tag: "{{ airflow_version }}"
@@ -285,7 +285,7 @@ workflows:
                 - master
       - kick-off-regression-tests:
           name: Kick-off-regression-tests-{{ airflow_version }}-{{ distribution }}
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_tag: "{{ airflow_version }}"
@@ -300,7 +300,7 @@ workflows:
       - regression-test-slack-notification:
           name: regression-test-slack-notification-{{ airflow_version }}-{{ distribution }}
           airflow_version: "{{ airflow_version }}"
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_tag: "{{ airflow_version }}"
@@ -369,7 +369,7 @@ workflows:
             {#- This redirects to the canonical workflow URL #}
             --label com.circleci.workflow.url="https://app.circleci.com/pipelines/workflows/${CIRCLE_WORKFLOW_ID}"
             {%- endif %}{# edge_build #}
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
@@ -383,7 +383,7 @@ workflows:
           airflow_version: {{ airflow_version }}
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
@@ -392,7 +392,7 @@ workflows:
             - build-{{ airflow_version }}-{{ distribution }}
       - scan-snyk:
           name: scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
@@ -401,7 +401,7 @@ workflows:
             - build-{{ airflow_version }}-{{ distribution }}
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-images
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
@@ -413,13 +413,13 @@ workflows:
           dev_build: true
           edge_build: {{ edge_build }}
           nightly_build: true
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
           extra_tags: "{{ airflow_version }}-${CIRCLE_BUILD_NUM},{{ ac_version }}"
-          {%- endif %}{# distribution in ["alpine3.10", "buster"] #}
+          {%- endif %}{# distribution in ["buster"] #}
           {%- if edge_build %}
           extra_tags_file: {{ workspace_prefix }}/extra-tags-{{ airflow_version_wout_dev }}.txt
           {%- endif %}{# edge_build #}
@@ -440,7 +440,7 @@ workflows:
           dev_build: true
           edge_build: {{ edge_build }}
           nightly_build: true
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}-onbuild"
           extra_tags: "{{ airflow_version }}-{{ distribution }}-onbuild-${CIRCLE_BUILD_NUM},{{ ac_version }}-{{ distribution }}-onbuild"
           {%- else %}
@@ -469,14 +469,14 @@ workflows:
           airflow_version: {{ airflow_version }}
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           image_name: "ap-airflow:{{ airflow_version }}"
           {%- endif %}
       - scan-snyk:
           name: scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
-          {%- if distribution in ["alpine3.10", "buster"] %}
+          {%- if distribution in ["buster"] %}
           tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
           tag: "{{ airflow_version }}"
@@ -843,7 +843,7 @@ commands:
         default: "1.10.5"
       distribution_name:
         type: string
-        default: alpine
+        default: bullseye
       extra_args:
         description: "Extra args to pass to pass to Docker build command"
         default: ""

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -317,7 +317,6 @@ workflows:
       {%- endfor %}{# distribution in distributions #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
 
-  {%- if image_map.keys() | dev_releases | length > 0 %}
   nightly:
     when:
       and:
@@ -327,10 +326,12 @@ workflows:
       {%- for ac_version, distributions in image_map.items() %}
       {%- set airflow_version = ac_version | get_airflow_version %}
       {%- set airflow_version_wout_dev = airflow_version | replace('.dev', '') | replace('-dev', '') -%}
+      {%- set dev_release = ac_version | is_dev_release -%}
       {%- set edge_build = ac_version | is_edge_build -%}
       {%- set ext_build_filename = 'latest-' + airflow_version_wout_dev + '.build.json' %}
       {%- set ext_build_filename_workspace = workspace_prefix + '/latest-' + airflow_version_wout_dev + '.build.json' %}
 
+      {%- if dev_release -%}
       {%- if edge_build %}
       - download-file:
           name: download-latest-{{ airflow_version_wout_dev }}-build-info
@@ -459,8 +460,32 @@ workflows:
               only:
                 - master
       {%- endfor %}{# distribution in distributions #}
+      {%- else  -%}{# if dev_release #}
+      # {{ airflow_version }}
+      {%- for distribution in distributions %}
+      # {{ airflow_version }} - {{ distribution }}
+      - scan-trivy:
+          name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
+          airflow_version: {{ airflow_version }}
+          distribution: {{ distribution }}
+          distribution_name: {{ distribution }}-onbuild
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          image_name: "ap-airflow:{{ airflow_version }}"
+          {%- endif %}
+      - scan-snyk:
+          name: scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
+          {%- if distribution in ["alpine3.10", "buster"] %}
+          tag: "{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          tag: "{{ airflow_version }}"
+          {%- endif %}
+          requires:
+            - build-{{ airflow_version }}-{{ distribution }}
+      {%- endfor %}{# distribution in distributions #}
+      {%- endif -%}{# dev_release #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
-  {%- endif %}{# image_map.keys() | dev_releases | length > 0 #}
 
 jobs:
   rebase-astro-main:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -8,7 +8,6 @@ from jinja2 import Environment, FileSystemLoader
 
 from common import (
     circle_directory,
-    DEV_ALLOWLIST,
     dev_releases,
     get_airflow_version,
     IMAGE_MAP,
@@ -29,7 +28,6 @@ def generate_circleci_config():
 
     config = template.render(
         image_map=IMAGE_MAP,
-        dev_allowlist=DEV_ALLOWLIST,
     )
     print(config)
 

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,6 +11,7 @@ from common import (
     dev_releases,
     get_airflow_version,
     IMAGE_MAP,
+    is_dev_release,
     is_edge_build,
 )
 
@@ -23,6 +24,7 @@ def generate_circleci_config():
     template_env = Environment(loader=FileSystemLoader(searchpath=circle_directory), autoescape=True)
     template_env.filters['dev_releases'] = dev_releases
     template_env.filters['get_airflow_version'] = get_airflow_version
+    template_env.filters['is_dev_release'] = is_dev_release
     template_env.filters['is_edge_build'] = is_edge_build
     template = template_env.get_template("config.yml.j2")
 

--- a/.circleci/update_dockerfiles.py
+++ b/.circleci/update_dockerfiles.py
@@ -6,7 +6,7 @@ This script is used to update the VERSION in all Dockerfiles with the correspond
 import os
 import re
 
-from common import DEV_ALLOWLIST, get_airflow_version, IMAGE_MAP, project_directory, is_edge_build
+from common import get_airflow_version, IMAGE_MAP, project_directory, is_edge_build
 from datetime import datetime
 
 
@@ -23,8 +23,7 @@ def update_dockerfiles():
         arg_ac_version = ac_version
         if "dev" in ac_version:
             dev_version = True
-            if airflow_version not in DEV_ALLOWLIST:
-                arg_ac_version = ac_version.replace("dev", "*")
+            arg_ac_version = ac_version.replace("dev", "*")
 
         for distro in distros:
             file_name = os.path.join(project_directory, airflow_version, distro, "Dockerfile")

--- a/.circleci/update_dockerfiles.py
+++ b/.circleci/update_dockerfiles.py
@@ -61,13 +61,12 @@ def update_dockerfiles():
                     'https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/'
                     'constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt'
                 )
-            if "alpine3.10" not in distros:
-                new_text = re.sub(
-                    r'https://raw.githubusercontent.com/apache/airflow/constraints-(.*)/constraints-(.*).txt',
-                    constraints_url,
-                    new_text,
-                    flags=re.MULTILINE
-                )
+            new_text = re.sub(
+                r'https://raw.githubusercontent.com/apache/airflow/constraints-(.*)/constraints-(.*).txt',
+                constraints_url,
+                new_text,
+                flags=re.MULTILINE
+            )
 
             with open(file_name, "w") as f:
                 f.write(new_text)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds scans for released builds to the nightly "builds"/pipelines.

I think that Trivy and Snyk will automatically pull images that are not in the local cache, but I'm not 100% sure about this, so I'll monitor the nightly jobs and fix things as needed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
