### PR TITLE
Simplify CI dependencies

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -128,6 +128,8 @@ workflows:
             {% include "new_build_slack_approval.json.j2" %}
             {%- endfilter %}
           requires:
+            - scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
+            - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
           filters:
             branches:
@@ -160,11 +162,12 @@ workflows:
             - docker.io
             - qa
           requires:
+            {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
+            - Need-Approval-{{ airflow_version }}-{{ distribution }}
+            {%- else %}
             - scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
-            {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
-            - Need-Approval-{{ airflow_version }}-{{ distribution }}
             {%- endif %}
           filters:
             branches:
@@ -187,11 +190,12 @@ workflows:
             - docker.io
             - qa
           requires:
+            {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
+            - Need-Approval-{{ airflow_version }}-{{ distribution }}
+            {%- else %}
             - scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
             - scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
             - test-{{ airflow_version }}-{{ distribution }}-images
-            {%- if ("dev" not in ac_version or airflow_version in dev_allowlist) and not edge_build %}
-            - Need-Approval-{{ airflow_version }}-{{ distribution }}
             {%- endif %}
           filters:
             branches:


### PR DESCRIPTION
We can simplify the dependecy chain by properly setting the required jobs based on whether we are a dev build or not. Dev builds don't need approval (thus push depends on the tests/scans), while releases do (approval depends on tests/scans, push on approval).

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
