### PR TITLE
Switch to using `pip.astronomer.io` as primary index

### DIFF
--- a/1.10.15/buster/include/pip.conf
+++ b/1.10.15/buster/include/pip.conf
@@ -1,3 +1,4 @@
 [global]
-extra-index-url = https://pip.astronomer.io/simple/
+index-url = https://pip.astronomer.io/simple/
+extra-index-url = https://pypi.org/simple/
 constraint = /usr/local/share/astronomer-pip-constraints.txt

--- a/2.1.4/buster/include/pip.conf
+++ b/2.1.4/buster/include/pip.conf
@@ -1,3 +1,4 @@
 [global]
-extra-index-url = https://pip.astronomer.io/simple/
+index-url = https://pip.astronomer.io/simple/
+extra-index-url = https://pypi.org/simple/
 constraint = /usr/local/share/astronomer-pip-constraints.txt

--- a/2.3.4/bullseye/include/pip.conf
+++ b/2.3.4/bullseye/include/pip.conf
@@ -1,3 +1,4 @@
 [global]
-extra-index-url = https://pip.astronomer.io/simple/
+index-url = https://pip.astronomer.io/simple/
+extra-index-url = https://pypi.org/simple/
 constraint = /usr/local/share/astronomer-pip-constraints.txt

--- a/main/bullseye/include/pip.conf
+++ b/main/bullseye/include/pip.conf
@@ -1,3 +1,4 @@
 [global]
-extra-index-url = https://pip.astronomer.io/simple/
+index-url = https://pip.astronomer.io/simple/
+extra-index-url = https://pypi.org/simple/
 constraint = /usr/local/share/astronomer-pip-constraints.txt


### PR DESCRIPTION
And make the default public pip repo the extra/secondary index.

This has the effect that for packages we (re)publish in `pip.a.io` _only_ those versions will be available, but that was the intent all along

Closes #522 