### PR TITLE
Fix nightly scans

### DIFF
--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -905,7 +905,7 @@ commands:
               --label io.astronomer.repo.commit_sha="${CIRCLE_SHA1}" \
               --label io.astronomer.repo.url="${CIRCLE_REPOSITORY_URL}" \
               --label io.astronomer.ci.build_url="${CIRCLE_BUILD_URL}" \
-              --file '<< parameters.path>>/<< parameters.dockerfile >>' \
+              --file '<< parameters.path >>/<< parameters.dockerfile >>' \
               << parameters.extra_args >> '<< parameters.path >>'
             docker save -o saved-images/<< parameters.image_name >>.tar '<< parameters.image_name >>'
             docker inspect << parameters.image_name >>
@@ -947,7 +947,7 @@ commands:
           command: |
             docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
       - snyk/scan:
-          docker-image-name: ap-airflow:<<parameters.tag>>-onbuild
+          docker-image-name: ap-airflow:<< parameters.tag >>-onbuild
           monitor-on-build: false
           project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}-app
           severity-threshold: high

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -631,10 +631,8 @@ jobs:
       - attach_workspace:
           at: {{ workspace_prefix }}
       - run:
-          name: Load archived Docker image or pull it from the registry
-          command: |
-            docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar || \
-            docker pull quay.io/astronomer/<< parameters.image_name >>-onbuild
+          name: Load archived Docker image
+          command: docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar
       - run:
           name: Install trivy
           command: |
@@ -945,10 +943,9 @@ commands:
       - attach_workspace:
           at: {{ workspace_prefix }}
       - run:
-          name: Load archived Docker image or pull it from the registry
+          name: Load archived Docker image
           command: |
-            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar || \
-            docker pull quay.io/astronomer/ap-airflow:<< parameters.tag >>-onbuild
+            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
       - snyk/scan:
           docker-image-name: ap-airflow:<< parameters.tag >>-onbuild
           monitor-on-build: false

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -85,11 +85,29 @@ workflows:
             {%- if edge_build %}
             - download-latest-{{ airflow_version_wout_dev }}-build-metadata-file
             {%- endif %}
+      - load-image:
+          name: load-image-{{ airflow_version }}-{{ distribution }}-onbuild
+          {%- if distribution in ["buster"] %}
+          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}-onbuild"
+          {%- else %}
+          image_name: "ap-airflow:{{ airflow_version }}-onbuild"
+          {%- endif %}
+          requires:
+            - build-{{ airflow_version }}-{{ distribution }}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
+          {%- if distribution in ["buster"] %}
+          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          image_name: "ap-airflow:{{ airflow_version }}"
+          {%- endif %}
+          requires:
+            - load-image-{{ airflow_version }}-{{ distribution }}-onbuild
+      - load-image:
+          name: load-image-{{ airflow_version }}-{{ distribution }}
           {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
@@ -105,7 +123,7 @@ workflows:
           tag: "{{ airflow_version }}"
           {%- endif %}
           requires:
-            - build-{{ airflow_version }}-{{ distribution }}
+            - load-image-{{ airflow_version }}-{{ distribution }}
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-images
           {%- if distribution in ["buster"] %}
@@ -378,11 +396,29 @@ workflows:
           requires:
             - download-latest-{{ airflow_version_wout_dev }}-build-info
           {%- endif %}
+      - load-image:
+          name: load-image-{{ airflow_version }}-{{ distribution }}-onbuild
+          {%- if distribution in ["buster"] %}
+          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}-onbuild"
+          {%- else %}
+          image_name: "ap-airflow:{{ airflow_version }}-onbuild"
+          {%- endif %}
+          requires:
+            - build-{{ airflow_version }}-{{ distribution }}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
+          {%- if distribution in ["buster"] %}
+          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          image_name: "ap-airflow:{{ airflow_version }}"
+          {%- endif %}
+          requires:
+            - load-image-{{ airflow_version }}-{{ distribution }}-onbuild
+      - load-image:
+          name: load-image-{{ airflow_version }}-{{ distribution }}
           {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
@@ -398,7 +434,7 @@ workflows:
           tag: "{{ airflow_version }}"
           {%- endif %}
           requires:
-            - build-{{ airflow_version }}-{{ distribution }}
+            - load-image-{{ airflow_version }}-{{ distribution }}
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-images
           {%- if distribution in ["buster"] %}
@@ -464,23 +500,41 @@ workflows:
       # {{ airflow_version }}
       {%- for distribution in distributions %}
       # {{ airflow_version }} - {{ distribution }}
+      - pull-image:
+          name: pull-image-{{ airflow_version }}-{{ distribution }}-onbuild
+          {%- if distribution in ["buster"] %}
+          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-{{ distribution }}-onbuild"
+          {%- else %}
+          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-onbuild"
+          {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
           {%- if distribution in ["buster"] %}
-          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
+          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
-          image_name: "ap-airflow:{{ airflow_version }}"
+          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}"
+          {%- endif %}
+          requires:
+            - pull-image-{{ airflow_version }}-{{ distribution }}-onbuild
+      - pull-image:
+          name: pull-image-{{ airflow_version }}-{{ distribution }}
+          {%- if distribution in ["buster"] %}
+          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-{{ distribution }}"
+          {%- else %}
+          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}"
           {%- endif %}
       - scan-snyk:
-          name: scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
+          name: scan-snyk-{{ airflow_version }}-{{ distribution }}
           {%- if distribution in ["buster"] %}
-          tag: "{{ airflow_version }}-{{ distribution }}"
+          tag: "quay.io/astronomer/{{ airflow_version }}-{{ distribution }}"
           {%- else %}
-          tag: "{{ airflow_version }}"
+          tag: "quay.io/astronomer/{{ airflow_version }}"
           {%- endif %}
+          requires:
+            - pull-image-{{ airflow_version }}-{{ distribution }}
       {%- endfor %}{# distribution in distributions #}
       {%- endif -%}{# dev_release #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
@@ -608,6 +662,38 @@ jobs:
     steps:
       - airflow-image-test:
           tag: "<< parameters.tag >>"
+  load-image:
+    description: Load an image from a local file
+    docker:
+      - image: docker:18.09-git
+    parameters:
+      image_name:
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: {{ workspace_prefix }}
+      - run:
+          name: Load archived Docker image or pull it from the registry
+          command: |
+            docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>.tar
+  pull-image:
+    description: Pull an image from a remote registry
+    docker:
+      - image: docker:18.09-git
+    parameters:
+      image_name:
+        type: string
+    steps:
+      - checkout
+      - setup_remote_docker
+      - attach_workspace:
+          at: {{ workspace_prefix }}
+      - run:
+          name: Load archived Docker image or pull it from the registry
+          command: |
+            docker pull << parameters.image_name >>
   scan-trivy:
     docker:
       - image: docker:18.09-git
@@ -630,11 +716,6 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: {{ workspace_prefix }}
-      - run:
-          name: Load archived Docker image or pull it from the registry
-          command: |
-            docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar || \
-            docker pull quay.io/astronomer/<< parameters.image_name >>-onbuild
       - run:
           name: Install trivy
           command: |
@@ -944,11 +1025,6 @@ commands:
       - setup_remote_docker
       - attach_workspace:
           at: {{ workspace_prefix }}
-      - run:
-          name: Load archived Docker image or pull it from the registry
-          command: |
-            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar || \
-            docker pull quay.io/astronomer/ap-airflow:<< parameters.tag >>-onbuild
       - snyk/scan:
           docker-image-name: ap-airflow:<< parameters.tag >>-onbuild
           monitor-on-build: false

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -47,7 +47,7 @@ workflows:
       # {{ airflow_version }} - {{ distribution }}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
-          airflow_version: {{ airflow_version }}
+          airflow_version: "{{ airflow_version }}"
           distribution_name: {{ distribution }}
           dev_build: {{ dev_build }}
           edge_build: {{ edge_build }}
@@ -87,7 +87,7 @@ workflows:
             {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-          airflow_version: {{ airflow_version }}
+          airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
           {%- if distribution in ["buster"] %}
@@ -343,7 +343,7 @@ workflows:
       {%- for distribution in distributions %}
       - build:
           name: build-{{ airflow_version }}-{{ distribution }}
-          airflow_version: {{ airflow_version }}
+          airflow_version: "{{ airflow_version }}"
           distribution_name: {{ distribution }}
           dev_build: true
           edge_build: {{ edge_build }}
@@ -380,7 +380,7 @@ workflows:
           {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-          airflow_version: {{ airflow_version }}
+          airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
           {%- if distribution in ["buster"] %}
@@ -466,7 +466,7 @@ workflows:
       # {{ airflow_version }} - {{ distribution }}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
-          airflow_version: {{ airflow_version }}
+          airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
           {%- if distribution in ["buster"] %}

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -632,7 +632,10 @@ jobs:
           at: {{ workspace_prefix }}
       - run:
           name: Load archived Docker image
-          command: docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar
+          command: |
+            if [[ -e "{{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar" ]]; then
+              docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar
+            fi
       - run:
           name: Install trivy
           command: |
@@ -945,7 +948,9 @@ commands:
       - run:
           name: Load archived Docker image
           command: |
-            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
+            if [[ -e "{{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar" ]]; then
+              docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
+            fi
       - snyk/scan:
           docker-image-name: ap-airflow:<< parameters.tag >>-onbuild
           monitor-on-build: false

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -631,8 +631,10 @@ jobs:
       - attach_workspace:
           at: {{ workspace_prefix }}
       - run:
-          name: Load archived Docker image
-          command: docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar
+          name: Load archived Docker image or pull it from the registry
+          command: |
+            docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar || \
+            docker pull quay.io/astronomer/<< parameters.image_name >>-onbuild
       - run:
           name: Install trivy
           command: |
@@ -943,9 +945,10 @@ commands:
       - attach_workspace:
           at: {{ workspace_prefix }}
       - run:
-          name: Load archived Docker image
+          name: Load archived Docker image or pull it from the registry
           command: |
-            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar
+            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar || \
+            docker pull quay.io/astronomer/ap-airflow:<< parameters.tag >>-onbuild
       - snyk/scan:
           docker-image-name: ap-airflow:<< parameters.tag >>-onbuild
           monitor-on-build: false

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -85,29 +85,11 @@ workflows:
             {%- if edge_build %}
             - download-latest-{{ airflow_version_wout_dev }}-build-metadata-file
             {%- endif %}
-      - load-image:
-          name: load-image-{{ airflow_version }}-{{ distribution }}-onbuild
-          {%- if distribution in ["buster"] %}
-          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}-onbuild"
-          {%- else %}
-          image_name: "ap-airflow:{{ airflow_version }}-onbuild"
-          {%- endif %}
-          requires:
-            - build-{{ airflow_version }}-{{ distribution }}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
-          {%- if distribution in ["buster"] %}
-          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
-          {%- else %}
-          image_name: "ap-airflow:{{ airflow_version }}"
-          {%- endif %}
-          requires:
-            - load-image-{{ airflow_version }}-{{ distribution }}-onbuild
-      - load-image:
-          name: load-image-{{ airflow_version }}-{{ distribution }}
           {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
@@ -123,7 +105,7 @@ workflows:
           tag: "{{ airflow_version }}"
           {%- endif %}
           requires:
-            - load-image-{{ airflow_version }}-{{ distribution }}
+            - build-{{ airflow_version }}-{{ distribution }}
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-images
           {%- if distribution in ["buster"] %}
@@ -396,29 +378,11 @@ workflows:
           requires:
             - download-latest-{{ airflow_version_wout_dev }}-build-info
           {%- endif %}
-      - load-image:
-          name: load-image-{{ airflow_version }}-{{ distribution }}-onbuild
-          {%- if distribution in ["buster"] %}
-          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}-onbuild"
-          {%- else %}
-          image_name: "ap-airflow:{{ airflow_version }}-onbuild"
-          {%- endif %}
-          requires:
-            - build-{{ airflow_version }}-{{ distribution }}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
-          {%- if distribution in ["buster"] %}
-          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
-          {%- else %}
-          image_name: "ap-airflow:{{ airflow_version }}"
-          {%- endif %}
-          requires:
-            - load-image-{{ airflow_version }}-{{ distribution }}-onbuild
-      - load-image:
-          name: load-image-{{ airflow_version }}-{{ distribution }}
           {%- if distribution in ["buster"] %}
           image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
@@ -434,7 +398,7 @@ workflows:
           tag: "{{ airflow_version }}"
           {%- endif %}
           requires:
-            - load-image-{{ airflow_version }}-{{ distribution }}
+            - build-{{ airflow_version }}-{{ distribution }}
       - test:
           name: test-{{ airflow_version }}-{{ distribution }}-images
           {%- if distribution in ["buster"] %}
@@ -500,41 +464,23 @@ workflows:
       # {{ airflow_version }}
       {%- for distribution in distributions %}
       # {{ airflow_version }} - {{ distribution }}
-      - pull-image:
-          name: pull-image-{{ airflow_version }}-{{ distribution }}-onbuild
-          {%- if distribution in ["buster"] %}
-          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-{{ distribution }}-onbuild"
-          {%- else %}
-          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-onbuild"
-          {%- endif %}
       - scan-trivy:
           name: scan-trivy-{{ airflow_version }}-{{ distribution }}-onbuild
           airflow_version: "{{ airflow_version }}"
           distribution: {{ distribution }}
           distribution_name: {{ distribution }}-onbuild
           {%- if distribution in ["buster"] %}
-          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-{{ distribution }}"
+          image_name: "ap-airflow:{{ airflow_version }}-{{ distribution }}"
           {%- else %}
-          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}"
-          {%- endif %}
-          requires:
-            - pull-image-{{ airflow_version }}-{{ distribution }}-onbuild
-      - pull-image:
-          name: pull-image-{{ airflow_version }}-{{ distribution }}
-          {%- if distribution in ["buster"] %}
-          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}-{{ distribution }}"
-          {%- else %}
-          image_name: "quay.io/astronomer/ap-airflow:{{ airflow_version }}"
+          image_name: "ap-airflow:{{ airflow_version }}"
           {%- endif %}
       - scan-snyk:
-          name: scan-snyk-{{ airflow_version }}-{{ distribution }}
+          name: scan-snyk-{{ airflow_version }}-{{ distribution }}-onbuild
           {%- if distribution in ["buster"] %}
-          tag: "quay.io/astronomer/{{ airflow_version }}-{{ distribution }}"
+          tag: "{{ airflow_version }}-{{ distribution }}"
           {%- else %}
-          tag: "quay.io/astronomer/{{ airflow_version }}"
+          tag: "{{ airflow_version }}"
           {%- endif %}
-          requires:
-            - pull-image-{{ airflow_version }}-{{ distribution }}
       {%- endfor %}{# distribution in distributions #}
       {%- endif -%}{# dev_release #}
       {%- endfor %}{# ac_version, distributions in image_map.items() #}
@@ -662,38 +608,6 @@ jobs:
     steps:
       - airflow-image-test:
           tag: "<< parameters.tag >>"
-  load-image:
-    description: Load an image from a local file
-    docker:
-      - image: docker:18.09-git
-    parameters:
-      image_name:
-        type: string
-    steps:
-      - checkout
-      - setup_remote_docker
-      - attach_workspace:
-          at: {{ workspace_prefix }}
-      - run:
-          name: Load archived Docker image or pull it from the registry
-          command: |
-            docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>.tar
-  pull-image:
-    description: Pull an image from a remote registry
-    docker:
-      - image: docker:18.09-git
-    parameters:
-      image_name:
-        type: string
-    steps:
-      - checkout
-      - setup_remote_docker
-      - attach_workspace:
-          at: {{ workspace_prefix }}
-      - run:
-          name: Load archived Docker image or pull it from the registry
-          command: |
-            docker pull << parameters.image_name >>
   scan-trivy:
     docker:
       - image: docker:18.09-git
@@ -716,6 +630,11 @@ jobs:
       - setup_remote_docker
       - attach_workspace:
           at: {{ workspace_prefix }}
+      - run:
+          name: Load archived Docker image or pull it from the registry
+          command: |
+            docker load -i {{ workspace_prefix }}/saved-images/<< parameters.image_name >>-onbuild.tar || \
+            docker pull quay.io/astronomer/<< parameters.image_name >>-onbuild
       - run:
           name: Install trivy
           command: |
@@ -1025,6 +944,11 @@ commands:
       - setup_remote_docker
       - attach_workspace:
           at: {{ workspace_prefix }}
+      - run:
+          name: Load archived Docker image or pull it from the registry
+          command: |
+            docker load -i {{ workspace_prefix }}/saved-images/ap-airflow:<< parameters.tag >>-onbuild.tar || \
+            docker pull quay.io/astronomer/ap-airflow:<< parameters.tag >>-onbuild
       - snyk/scan:
           docker-image-name: ap-airflow:<< parameters.tag >>-onbuild
           monitor-on-build: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix the nightlies. If we can't load images before scans, pull them from the registry. This allows us to scan images that we haven't just built, which is what happens for builds we've already released.