### PR TITLE
addAstronomerAnalyticsPluginToImages

### DIFF
--- a/2.1.4/buster/Dockerfile
+++ b/2.1.4/buster/Dockerfile
@@ -15,6 +15,7 @@
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.7"
 ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-buster"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE="0.0.1"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 
@@ -115,6 +116,7 @@ ARG SUBMODULES="async,azure,amazon,celery,elasticsearch,google,password,cncf.kub
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.1.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.2"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -133,6 +135,10 @@ RUN pip install "${AIRFLOW_MODULE}" \
     && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
     && pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+# Install Astronomer airflow plugins
+ADD https://github.com/astronomer/airflow-analytics-plugin/archive/refs/tags/${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}.tar.gz /
+RUN tar -xzf /0.0.1.tar.gz
+RUN rm /0.0.1.tar.gz
 
 ## move this to same layer as airflow because its from tag.
 
@@ -206,6 +212,8 @@ USER ${ASTRONOMER_USER}
 
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
+COPY --from=devel /airflow-analytics-plugin-${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}/plugins /plugins/
 
 ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/2.3.4/bullseye/Dockerfile
+++ b/2.3.4/bullseye/Dockerfile
@@ -15,6 +15,7 @@
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.9"
 ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-bullseye"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE="0.0.1"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 
@@ -115,6 +116,7 @@ ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.3.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.3"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -133,6 +135,10 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower \
     && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
     && pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+# Install Astronomer airflow plugins
+ADD https://github.com/astronomer/airflow-analytics-plugin/archive/refs/tags/${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}.tar.gz /
+RUN tar -xzf /0.0.1.tar.gz
+RUN rm /0.0.1.tar.gz
 
 ## move this to same layer as airflow because its from tag.
 
@@ -206,6 +212,8 @@ USER ${ASTRONOMER_USER}
 
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
+COPY --from=devel /airflow-analytics-plugin-${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}/plugins /plugins/
 
 ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/2.4.1/bullseye/Dockerfile
+++ b/2.4.1/bullseye/Dockerfile
@@ -15,6 +15,7 @@
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.9"
 ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-bullseye"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE="0.0.1"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 
@@ -115,6 +116,7 @@ ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes
 ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.4.1"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.3"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -133,6 +135,10 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower \
     && pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
     && pip install --find-links https://pip.astronomer.io/simple/astronomer-fab-security-manager/ "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+# Install Astronomer airflow plugins
+ADD https://github.com/astronomer/airflow-analytics-plugin/archive/refs/tags/${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}.tar.gz /
+RUN tar -xzf /0.0.1.tar.gz
+RUN rm /0.0.1.tar.gz
 
 ## move this to same layer as airflow because its from tag.
 
@@ -206,6 +212,8 @@ USER ${ASTRONOMER_USER}
 
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
+COPY --from=devel /airflow-analytics-plugin-${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}/plugins /plugins/
 
 ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]

--- a/main/bullseye/Dockerfile
+++ b/main/bullseye/Dockerfile
@@ -15,6 +15,7 @@
 ARG APT_DEPS_IMAGE="airflow-apt-deps"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.9"
 ARG PYTHON_BASE_IMAGE="python:${PYTHON_MAJOR_MINOR_VERSION}-slim-bullseye"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE="0.0.1"
 
 FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
 
@@ -115,6 +116,7 @@ ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes
 ARG AIRFLOW_MODULE="astronomer_certified[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION=${VERSION}
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.1"
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
 
 # Make pip look at our pip repo too, and force it to install these specific
 # versions when ever it installs a module.
@@ -128,6 +130,10 @@ RUN pip install "${AIRFLOW_MODULE}" celery flower "elasticsearch==7.13.4" \
 	&& pip install "https://github.com/astronomer/astronomer-airflow-scripts/releases/download/v0.0.5/astronomer_airflow_scripts-0.0.5-py3-none-any.whl" \
 	&& pip install "astronomer-fab-security-manager==${ASTRONOMER_FAB_SECURITY_MANAGER_VERSION}"
 
+# Install Astronomer airflow plugins
+ADD https://github.com/astronomer/airflow-analytics-plugin/archive/refs/tags/${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}.tar.gz /
+RUN tar -xzf /0.0.1.tar.gz
+RUN rm /0.0.1.tar.gz
 
 ## move this to same layer as airflow because its from tag.
 
@@ -202,6 +208,8 @@ USER ${ASTRONOMER_USER}
 
 # Switch to AIRFLOW_HOME
 WORKDIR ${AIRFLOW_HOME}
+ARG ASTRONOMER_ANALYTICS_PLUGIN_RELEASE
+COPY --from=devel /airflow-analytics-plugin-${ASTRONOMER_ANALYTICS_PLUGIN_RELEASE}/plugins /plugins/
 
 ENTRYPOINT ["/entrypoint"]
 CMD ["airflow", "--help"]


### PR DESCRIPTION
Adds an airflow plugin to our ap-airflow images. The plugin adds an api endpoint that allows us to pull task usage data.

#### Checklist

- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
