### PR TITLE
Remove broken `EXECUTOR` support

### DIFF
--- a/2.3.4/bullseye/include/entrypoint
+++ b/2.3.4/bullseye/include/entrypoint
@@ -11,11 +11,6 @@ else
   __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
 fi
 
-if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
-  # Support for puckle style of defining configs
-  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
-fi
-
 # Handle 2.3.0 DeprecationWarnings - can be removed once platform is setting these themselves
 # Add SQL_ALCHEMY_CONN to new section if it only exists in the old section
 if [[ -n "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" && -z "$AIRFLOW__DATABASE__SQL_ALCHEMY_CONN" ]]; then

--- a/2.4.3/bullseye/include/entrypoint
+++ b/2.4.3/bullseye/include/entrypoint
@@ -11,11 +11,6 @@ else
   __TINIFIED=1 exec gosu "${ASTRONOMER_USER}" tini -- "$0" "$@"
 fi
 
-if [[ -n "$EXECUTOR" && -z "$AIRFLOW__CORE__EXECUTOR" ]]; then
-  # Support for puckel style of defining configs
-  export AIRFLOW__CORE__EXECUTOR "${EXECUTOR}Executor"
-fi
-
 # Handle 2.3.0 DeprecationWarnings - can be removed once platform is setting these themselves
 # Add SQL_ALCHEMY_CONN to new section if it only exists in the old section
 if [[ -n "$AIRFLOW__CORE__SQL_ALCHEMY_CONN" && -z "$AIRFLOW__DATABASE__SQL_ALCHEMY_CONN" ]]; then


### PR DESCRIPTION
We intended to support puckel style config via `EXECUTOR`, but there was a ` ` vs `=` typo meaning it never actually functioned. Let's just remove it as no one is relying on it.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]

- [ ] If a new distribution or new version of Airflow is added, please make sure:
  + [ ] to follow all of the directions in the `README.md`
  + [ ] that there are Dockerfiles in all base image directories
  + [ ] that all of the new or modified Dockerfiles build successfully
- [ ] If changing an existing image, please add an applicable test in `.circleci/bin/test-airflow-image.py`
