### PR TITLE
Release 2.4.3-6 and 2.3.4-11

### DIFF
--- a/.circleci/common.py
+++ b/.circleci/common.py
@@ -34,6 +34,6 @@ def get_airflow_version(ac_version):
 
 
 IMAGE_MAP = collections.OrderedDict([
-    ("2.3.4-11-dev", ["bullseye"]),
-    ("2.4.3-6-dev", ["bullseye"]),
+    ("2.3.4-11", ["bullseye"]),
+    ("2.4.3-6", ["bullseye"]),
 ])

--- a/2.3.4/CHANGELOG.md
+++ b/2.3.4/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-Astronomer Certified 2.3.4-10, TBD
-----------------------------------
+Astronomer Certified 2.3.4-11, 2023-03-31
+-----------------------------------------
 
 ### Bugfixes
 

--- a/2.3.4/bullseye/Dockerfile
+++ b/2.3.4/bullseye/Dockerfile
@@ -114,7 +114,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.3.4-11-*"
+ARG VERSION="2.3.4+astro.11"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.3.4"
@@ -154,7 +154,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.3.4-11-*"
+ARG VERSION="2.3.4+astro.11"
 ARG AIRFLOW_VERSION="2.3.4"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"

--- a/2.4.3/CHANGELOG.md
+++ b/2.4.3/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-Astronomer Certified 2.4.3-6, TBD
----------------------------------
+Astronomer Certified 2.4.3-6, 2023-03-31
+----------------------------------------
 
 ### Bugfixes
 

--- a/2.4.3/bullseye/Dockerfile
+++ b/2.4.3/bullseye/Dockerfile
@@ -113,7 +113,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.4.3-6-*"
+ARG VERSION="2.4.3+astro.6"
 ARG SUBMODULES="async,azure,amazon,elasticsearch,google,password,cncf.kubernetes,mysql,postgres,redis,slack,ssh,statsd,virtualenv"
 ARG AIRFLOW_MODULE="apache-airflow[${SUBMODULES}]==$VERSION"
 ARG AIRFLOW_VERSION="2.4.3"
@@ -154,7 +154,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG VERSION="2.4.3-6-*"
+ARG VERSION="2.4.3+astro.6"
 ARG AIRFLOW_VERSION="2.4.3"
 ARG ASTRONOMER_FAB_SECURITY_MANAGER_VERSION="1.9.3"
 LABEL io.astronomer.docker.airflow.version="${AIRFLOW_VERSION}"


### PR DESCRIPTION
I just want to call out explicitly that these images have major version bumps in the amazon and google providers to fix CVEs.